### PR TITLE
Custom User-Agent Header for Webservice/Websocket Clients / Modified Rev-Proxy Log Pattern

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v1/src/test/java/dev/dsf/bpe/start/ExampleStarter.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/test/java/dev/dsf/bpe/start/ExampleStarter.java
@@ -129,7 +129,7 @@ public class ExampleStarter
 		FhirContext context = FhirContext.forR4();
 		ReferenceCleaner referenceCleaner = new ReferenceCleanerImpl(new ReferenceExtractorImpl());
 
-		return new FhirWebserviceClientJersey(baseUrl, trustStore, keyStore, certificatePassword, null, null, null, 0,
-				0, false, null, context, referenceCleaner);
+		return new FhirWebserviceClientJersey(baseUrl, trustStore, keyStore, certificatePassword, null, null, null,
+				null, 0, 0, false, "DSF Example Starter", context, referenceCleaner);
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/FhirClientConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/FhirClientConfig.java
@@ -44,6 +44,9 @@ public class FhirClientConfig implements InitializingBean
 	@Autowired
 	private FhirConfig fhirConfig;
 
+	@Autowired
+	private BuildInfoReaderConfig buildInfoReaderConfig;
+
 	@Override
 	public void afterPropertiesSet() throws Exception
 	{
@@ -105,7 +108,8 @@ public class FhirClientConfig implements InitializingBean
 					keyStorePassword, propertiesConfig.getWebserviceClientRemoteReadTimeout(),
 					propertiesConfig.getWebserviceClientRemoteConnectTimeout(),
 					propertiesConfig.getWebserviceClientRemoteVerbose(), getWebsocketUrl(), webserviceTrustStore,
-					webserviceKeyStore, keyStorePassword, propertiesConfig.proxyConfig());
+					webserviceKeyStore, keyStorePassword, propertiesConfig.proxyConfig(),
+					buildInfoReaderConfig.buildInfoReader());
 		}
 		catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException | PKCSException e)
 		{

--- a/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
+++ b/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
@@ -49,6 +49,6 @@ Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains
 	ProxyPassReverse ws://${APP_SERVER_IP}:8080/fhir/ws
 </Location>
 
-CustomLog /proc/self/fd/1 "%h %t \"%r\" %>s %b %{SSL_PROTOCOL}x %{SSL_CIPHER}x"
+CustomLog /proc/self/fd/1 "%h %t \"%r\" %>s %b %{SSL_PROTOCOL}x %{SSL_CIPHER}x %{user-agent}i %{SSL_CLIENT_S_DN}x"
 
 </VirtualHost>

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/client/ClientProviderImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/client/ClientProviderImpl.java
@@ -13,10 +13,12 @@ import dev.dsf.common.config.ProxyConfig;
 import dev.dsf.fhir.dao.EndpointDao;
 import dev.dsf.fhir.help.ExceptionHandler;
 import dev.dsf.fhir.service.ReferenceCleaner;
+import dev.dsf.tools.build.BuildInfoReader;
 
 public class ClientProviderImpl implements ClientProvider, InitializingBean
 {
 	private static final Logger logger = LoggerFactory.getLogger(ClientProviderImpl.class);
+	private static final String USER_AGENT_VALUE = "DSF/";
 
 	private final KeyStore webserviceTrustStore;
 	private final KeyStore webserviceKeyStore;
@@ -30,11 +32,12 @@ public class ClientProviderImpl implements ClientProvider, InitializingBean
 	private final ReferenceCleaner referenceCleaner;
 	private final EndpointDao endpointDao;
 	private final ExceptionHandler exceptionHandler;
+	private final BuildInfoReader buildInfoReader;
 
 	public ClientProviderImpl(KeyStore webserviceTrustStore, KeyStore webserviceKeyStore,
 			char[] webserviceKeyStorePassword, int remoteReadTimeout, int remoteConnectTimeout, ProxyConfig proxyConfig,
 			boolean logRequests, FhirContext fhirContext, ReferenceCleaner referenceCleaner, EndpointDao endpointDao,
-			ExceptionHandler exceptionHandler)
+			ExceptionHandler exceptionHandler, BuildInfoReader buildInfoReader)
 	{
 		this.webserviceTrustStore = webserviceTrustStore;
 		this.webserviceKeyStore = webserviceKeyStore;
@@ -47,6 +50,7 @@ public class ClientProviderImpl implements ClientProvider, InitializingBean
 		this.referenceCleaner = referenceCleaner;
 		this.endpointDao = endpointDao;
 		this.exceptionHandler = exceptionHandler;
+		this.buildInfoReader = buildInfoReader;
 	}
 
 	@Override
@@ -55,13 +59,12 @@ public class ClientProviderImpl implements ClientProvider, InitializingBean
 		Objects.requireNonNull(webserviceTrustStore, "webserviceTrustStore");
 		Objects.requireNonNull(webserviceKeyStore, "webserviceKeyStore");
 		Objects.requireNonNull(webserviceKeyStorePassword, "webserviceKeyStorePassword");
-
 		Objects.requireNonNull(proxyConfig, "proxyConfig");
-
 		Objects.requireNonNull(fhirContext, "fhirContext");
 		Objects.requireNonNull(referenceCleaner, "referenceCleaner");
 		Objects.requireNonNull(endpointDao, "endpointDao");
 		Objects.requireNonNull(exceptionHandler, "exceptionHandler");
+		Objects.requireNonNull(buildInfoReader, "buildInfoReader");
 	}
 
 	@Override
@@ -74,8 +77,9 @@ public class ClientProviderImpl implements ClientProvider, InitializingBean
 			char[] proxyPassword = proxyConfig.isEnabled(serverBase) ? proxyConfig.getPassword() : null;
 
 			FhirWebserviceClient client = new FhirWebserviceClientJersey(serverBase, webserviceTrustStore,
-					webserviceKeyStore, webserviceKeyStorePassword, proxyUrl, proxyUsername, proxyPassword,
-					remoteConnectTimeout, remoteReadTimeout, logRequests, null, fhirContext, referenceCleaner);
+					webserviceKeyStore, webserviceKeyStorePassword, null, proxyUrl, proxyUsername, proxyPassword,
+					remoteConnectTimeout, remoteReadTimeout, logRequests,
+					USER_AGENT_VALUE + buildInfoReader.getProjectVersion(), fhirContext, referenceCleaner);
 
 			return Optional.of(client);
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/ClientConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/ClientConfig.java
@@ -50,6 +50,9 @@ public class ClientConfig implements InitializingBean
 	@Autowired
 	private ReferenceConfig referenceConfig;
 
+	@Autowired
+	private BuildInfoReaderConfig buildInfoReaderConfig;
+
 	@Bean
 	public ClientProvider clientProvider()
 	{
@@ -67,7 +70,8 @@ public class ClientConfig implements InitializingBean
 					propertiesConfig.getWebserviceClientReadTimeout(),
 					propertiesConfig.getWebserviceClientConnectTimeout(), propertiesConfig.proxyConfig(),
 					propertiesConfig.getWebserviceClientVerbose(), fhirConfig.fhirContext(),
-					referenceConfig.referenceCleaner(), daoConfig.endpointDao(), helperConfig.exceptionHandler());
+					referenceConfig.referenceCleaner(), daoConfig.endpointDao(), helperConfig.exceptionHandler(),
+					buildInfoReaderConfig.buildInfoReader());
 		}
 		catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException | PKCSException e)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/client/ClientProviderTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/client/ClientProviderTest.java
@@ -21,6 +21,7 @@ import dev.dsf.fhir.dao.EndpointDao;
 import dev.dsf.fhir.function.SupplierWithSqlException;
 import dev.dsf.fhir.help.ExceptionHandler;
 import dev.dsf.fhir.service.ReferenceCleaner;
+import dev.dsf.tools.build.BuildInfoReader;
 
 public class ClientProviderTest
 {
@@ -28,6 +29,7 @@ public class ClientProviderTest
 	private EndpointDao endpointDao;
 	private ExceptionHandler exceptionHandler;
 	private ClientProvider provider;
+	private BuildInfoReader buildInfoReader;
 
 	@Before
 	public void before() throws Exception
@@ -49,11 +51,12 @@ public class ClientProviderTest
 		referenceCleaner = mock(ReferenceCleaner.class);
 		endpointDao = mock(EndpointDao.class);
 		exceptionHandler = mock(ExceptionHandler.class);
+		buildInfoReader = mock(BuildInfoReader.class);
 
 		provider = new ClientProviderImpl(webserviceTrustStore, webserviceKeyStore, webserviceKeyStorePassword,
 				remoteReadTimeout, remoteConnectTimeout,
 				new ProxyConfigImpl(remoteProxySchemeHostPort, remoteProxyUsername, remoteProxyPassword, null),
-				logRequests, fhirContext, referenceCleaner, endpointDao, exceptionHandler);
+				logRequests, fhirContext, referenceCleaner, endpointDao, exceptionHandler, buildInfoReader);
 	}
 
 	@Test
@@ -62,6 +65,7 @@ public class ClientProviderTest
 	{
 		final String serverBase = "http://foo/fhir/";
 
+		when(buildInfoReader.getProjectVersion()).thenReturn("1.2.3-TEST");
 		when(exceptionHandler.handleSqlException(any(SupplierWithSqlException.class))).thenReturn(true);
 
 		Optional<FhirWebserviceClient> client = provider.getClient(serverBase);
@@ -69,8 +73,9 @@ public class ClientProviderTest
 		assertTrue(client.isPresent());
 		assertEquals(serverBase, client.get().getBaseUrl());
 
+		verify(buildInfoReader).getProjectVersion();
 		verify(exceptionHandler).handleSqlException(any(SupplierWithSqlException.class));
-		verifyNoMoreInteractions(referenceCleaner, endpointDao, exceptionHandler);
+		verifyNoMoreInteractions(referenceCleaner, endpointDao, exceptionHandler, buildInfoReader);
 	}
 
 	@Test
@@ -84,6 +89,6 @@ public class ClientProviderTest
 		assertTrue(client.isEmpty());
 
 		verify(exceptionHandler).handleSqlException(any(SupplierWithSqlException.class));
-		verifyNoMoreInteractions(referenceCleaner, endpointDao, exceptionHandler);
+		verifyNoMoreInteractions(referenceCleaner, endpointDao, exceptionHandler, buildInfoReader);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/AbstractIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/AbstractIntegrationTest.java
@@ -157,15 +157,16 @@ public abstract class AbstractIntegrationTest extends AbstractDbTest
 	private static FhirWebserviceClient createWebserviceClient(KeyStore trustStore, KeyStore keyStore,
 			char[] keyStorePassword, FhirContext fhirContext, ReferenceCleaner referenceCleaner)
 	{
-		return new FhirWebserviceClientJersey(BASE_URL, trustStore, keyStore, keyStorePassword, null, null, null, 0, 0,
-				false, null, fhirContext, referenceCleaner);
+		return new FhirWebserviceClientJersey(BASE_URL, trustStore, keyStore, keyStorePassword, null, null, null, null,
+				0, 0, false, "DSF Integration Test Client", fhirContext, referenceCleaner);
 	}
 
 	private static WebsocketClient createWebsocketClient(KeyStore trustStore, KeyStore keyStore,
 			char[] keyStorePassword, String subscriptionIdPart)
 	{
 		return new WebsocketClientTyrus(() ->
-		{}, URI.create(WEBSOCKET_URL), trustStore, keyStore, keyStorePassword, null, null, null, subscriptionIdPart);
+		{}, URI.create(WEBSOCKET_URL), trustStore, keyStore, keyStorePassword, null, null, null,
+				"Integration Test Client", subscriptionIdPart);
 	}
 
 	private static JettyServer startFhirServer() throws Exception

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractJerseyClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractJerseyClient.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
 
 public class AbstractJerseyClient
 {
@@ -37,13 +39,14 @@ public class AbstractJerseyClient
 	public AbstractJerseyClient(String baseUrl, KeyStore trustStore, KeyStore keyStore, char[] keyStorePassword,
 			ObjectMapper objectMapper, Collection<?> componentsToRegister)
 	{
-		this(baseUrl, trustStore, keyStore, keyStorePassword, null, null, null, 0, 0, objectMapper,
-				componentsToRegister, false);
+		this(baseUrl, trustStore, keyStore, keyStorePassword, objectMapper, componentsToRegister, null, null, null, 0,
+				0, false, null);
 	}
 
 	public AbstractJerseyClient(String baseUrl, KeyStore trustStore, KeyStore keyStore, char[] keyStorePassword,
-			String proxySchemeHostPort, String proxyUserName, char[] proxyPassword, int connectTimeout, int readTimeout,
-			ObjectMapper objectMapper, Collection<?> componentsToRegister, boolean logRequests)
+			ObjectMapper objectMapper, Collection<?> componentsToRegister, String proxySchemeHostPort,
+			String proxyUserName, char[] proxyPassword, int connectTimeout, int readTimeout, boolean logRequests,
+			String userAgentValue)
 	{
 		SSLContext sslContext = null;
 		if (trustStore != null && keyStore == null && keyStorePassword == null)
@@ -63,6 +66,10 @@ public class AbstractJerseyClient
 		config.property(ClientProperties.PROXY_USERNAME, proxyUserName);
 		config.property(ClientProperties.PROXY_PASSWORD, proxyPassword == null ? null : String.valueOf(proxyPassword));
 		builder = builder.withConfig(config);
+
+		if (userAgentValue != null && !userAgentValue.isBlank())
+			builder = builder.register((ClientRequestFilter) requestContext -> requestContext.getHeaders()
+					.add(HttpHeaders.USER_AGENT, userAgentValue));
 
 		builder = builder.readTimeout(readTimeout, TimeUnit.MILLISECONDS).connectTimeout(connectTimeout,
 				TimeUnit.MILLISECONDS);

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
@@ -77,12 +77,13 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 	private final PreferReturnOutcomeWithRetry preferReturnOutcome;
 
 	public FhirWebserviceClientJersey(String baseUrl, KeyStore trustStore, KeyStore keyStore, char[] keyStorePassword,
-			String proxySchemeHostPort, String proxyUserName, char[] proxyPassword, int connectTimeout, int readTimeout,
-			boolean logRequests, ObjectMapper objectMapper, FhirContext fhirContext, ReferenceCleaner referenceCleaner)
+			ObjectMapper objectMapper, String proxySchemeHostPort, String proxyUserName, char[] proxyPassword,
+			int connectTimeout, int readTimeout, boolean logRequests, String userAgentValue, FhirContext fhirContext,
+			ReferenceCleaner referenceCleaner)
 	{
-		super(baseUrl, trustStore, keyStore, keyStorePassword, proxySchemeHostPort, proxyUserName, proxyPassword,
-				connectTimeout, readTimeout, objectMapper, Collections.singleton(new FhirAdapter(fhirContext)),
-				logRequests);
+		super(baseUrl, trustStore, keyStore, keyStorePassword, objectMapper,
+				Collections.singleton(new FhirAdapter(fhirContext)), proxySchemeHostPort, proxyUserName, proxyPassword,
+				connectTimeout, readTimeout, logRequests, userAgentValue);
 
 		this.referenceCleaner = referenceCleaner;
 

--- a/dsf-tools/dsf-tools-proxy-test/src/main/java/dev/dsf/tools/proxy/TestClient.java
+++ b/dsf-tools/dsf-tools-proxy-test/src/main/java/dev/dsf/tools/proxy/TestClient.java
@@ -15,8 +15,8 @@ public class TestClient extends AbstractJerseyClient
 
 	public TestClient(String baseUrl, String proxySchemeHostPort, String proxyUserName, char[] proxyPassword)
 	{
-		super(baseUrl, null, null, null, proxySchemeHostPort, proxyUserName, proxyPassword, 5_000, 5_000, null, null,
-				true);
+		super(baseUrl, null, null, null, null, null, proxySchemeHostPort, proxyUserName, proxyPassword, 5_000, 5_000,
+				true, "DSF Proxy Test Client");
 
 		logger.info("baseUrl: {}", baseUrl);
 		logger.info("proxySchemeHostPort: {}", proxySchemeHostPort);


### PR DESCRIPTION
* Webservice and websocket clients now send a custom user-agent header `DSF/${version}`.
* The rev-proxy log pattern now includes the user-agent header and client certificate subject DN string.

closes #68