### PR TITLE
Issues/65 different endpoint for different roles in parent org

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
@@ -135,8 +135,8 @@ public class OrganizationAuthorizationRule extends AbstractMetaTagAuthorizationR
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while searching for Organization with thumbprint", e);
-			return false;
+			logger.warn("Unable to search for Organization", e);
+			throw new RuntimeException("Unable to search for OrganizationAffiliation", e);
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/OrganizationAffiliationDao.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/OrganizationAffiliationDao.java
@@ -3,6 +3,7 @@ package dev.dsf.fhir.dao;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.UUID;
 
 import org.hl7.fhir.r4.model.OrganizationAffiliation;
 
@@ -10,4 +11,8 @@ public interface OrganizationAffiliationDao extends ResourceDao<OrganizationAffi
 {
 	List<OrganizationAffiliation> readActiveNotDeletedByMemberOrganizationIdentifierIncludingOrganizationIdentifiersWithTransaction(
 			Connection connection, String identifierValue) throws SQLException;
+
+	boolean existsNotDeletedByParentOrganizationMemberOrganizationRoleAndNotEndpointWithTransaction(
+			Connection connection, UUID parentOrganization, UUID memberOrganization, String roleSystem, String roleCode,
+			UUID endpoint) throws SQLException;
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/OrganizationAffiliationDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/OrganizationAffiliationDaoJdbc.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import javax.sql.DataSource;
 
@@ -103,6 +104,38 @@ public class OrganizationAffiliationDaoJdbc extends AbstractResourceDaoJdbc<Orga
 				}
 
 				return affiliations;
+			}
+		}
+	}
+
+	@Override
+	public boolean existsNotDeletedByParentOrganizationMemberOrganizationRoleAndNotEndpointWithTransaction(
+			Connection connection, UUID parentOrganization, UUID memberOrganization, String roleSystem, String roleCode,
+			UUID endpoint) throws SQLException
+	{
+		Objects.requireNonNull(connection, "connection");
+		Objects.requireNonNull(parentOrganization, "parentOrganization");
+		Objects.requireNonNull(memberOrganization, "memberOrganization");
+		Objects.requireNonNull(roleSystem, "roleSystem");
+		Objects.requireNonNull(roleCode, "roleCode");
+		Objects.requireNonNull(endpoint, "endpoint");
+
+		try (PreparedStatement statement = connection
+				.prepareStatement("SELECT count(*) FROM current_organization_affiliations "
+						+ "WHERE organization_affiliation->'organization'->>'reference' = ? "
+						+ "AND organization_affiliation->'participatingOrganization'->>'reference' = ? "
+						+ "AND (SELECT jsonb_agg(coding) FROM jsonb_array_elements(organization_affiliation->'code') AS code, jsonb_array_elements(code->'coding') AS coding) @> ?::jsonb "
+						+ "AND ? NOT IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization_affiliation->'endpoint') AS reference)"))
+		{
+			statement.setString(1, "Organization/" + parentOrganization.toString());
+			statement.setString(2, "Organization/" + memberOrganization.toString());
+			statement.setString(3, "[{\"code\": \"" + roleCode + "\", \"system\": \"" + roleSystem + "\"}]");
+			statement.setString(4, "Endpoint/" + endpoint.toString());
+
+			logger.trace("Executing query '{}'", statement);
+			try (ResultSet result = statement.executeQuery())
+			{
+				return result.next() && result.getInt(1) > 0;
 			}
 		}
 	}


### PR DESCRIPTION
* `OrganizationAffiliation` resources are now unique based on `parent organization + member organization + endpoint`. A role can no longer be defined for different `OrganizationAffiliation` resources for the same `parent organization + member organization` combination.
* New rule implementation allows multiple `OrganizationAffiliation` resources for an organization within a parent organization if a) a different enpoint is used an b) roles are only defined in one `OrganizationAffiliation` resource.