### PR TITLE
Issues/85 fhir reverse proxy server context path

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
@@ -391,7 +391,7 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 				+ "\">" + result.group() + "</a>");
 
 		Matcher referenceUuidMatcher = XML_REFERENCE_UUID_PATTERN.matcher(content);
-		content = referenceUuidMatcher.replaceAll(result -> "&lt;reference value=\"<a href=\"/fhir/" + result.group(1)
+		content = referenceUuidMatcher.replaceAll(result -> "&lt;reference value=\"<a href=\"" + result.group(1)
 				+ "\">" + result.group(1) + "</a>\"&gt");
 
 		out.write(content);


### PR DESCRIPTION
* fixes xml UUID links, by removing `/fhir/` prefix.