### PR TITLE
Issues/85 fhir reverse proxy server context path

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PropertiesConfig.java
@@ -48,7 +48,7 @@ public class PropertiesConfig implements InitializingBean
 	@Value("${dev.dsf.bpe.db.user.camunda.password}")
 	private char[] dbCamundaPassword;
 
-	@Documentation(required = true, description = "PEM encoded file with one or more trusted root certificates to validate server certificates for https connections to local and remote DSF FHIR servers", recommendation = "Use docker secret file to configure", example = "/run/secrets/app_server_trust_certificates.pem")
+	@Documentation(required = true, description = "PEM encoded file with one or more trusted root certificates to validate server certificates for https connections to local and remote DSF FHIR servers", recommendation = "Use docker secret file to configure", example = "/run/secrets/app_client_trust_certificates.pem")
 	@Value("${dev.dsf.bpe.fhir.client.trust.server.certificate.cas}")
 	private String clientCertificateTrustStoreFile;
 

--- a/dsf-docker/fhir_proxy/README.md
+++ b/dsf-docker/fhir_proxy/README.md
@@ -9,39 +9,39 @@ Description: Reverse proxy target.
 Example: 172.28.1.3
 
 **SSL_CERTIFICATE_FILE**  
-Description: To set apache config param `SSLCertificateFile`, with the server certificate private key.  
+Description: To set apache config param `SSLCertificateFile`, with the server certificate private key.
 
 **SSL_CERTIFICATE_KEY_FILE**  
-Description: To set apache config param `SSLCertificateKeyFile`, with the server certificate (and ca chain except root).  
+Description: To set apache config param `SSLCertificateKeyFile`, with the server certificate (and ca chain except root).
 
 **SSL_CERTIFICATE_CHAIN_FILE**  
-Description: To set apache config param `SSLCertificateChainFile`, with the server certificate ca chain for (excluding the root CA), can be used if CA chain is not included in **SSL_CERTIFICATE_FILE**.  
+Description: To set apache config param `SSLCertificateChainFile`, with the server certificate ca chain for (excluding the root CA), can be used if CA chain is not included in **SSL_CERTIFICATE_FILE**.
 
 **SSL_CA_CERTIFICATE_FILE**  
-Description: To set apache config param `SSLCACertificateFile`, with the trusted full CA chains for validating client certificates.  
+Description: To set apache config param `SSLCACertificateFile`, with the trusted full CA chains for validating client certificates.
 
 **SSL_CA_DN_REQUEST_FILE**  
 Description: To set apache config param `SSLCADNRequestFile` with client certificate signing CAs to modify the "Acceptable client certificate CA names" send to the client.  
 Default: If not set, all CAs from **SSL_CA_CERTIFICATE_FILE** are used for the "Acceptable client certificate CA names".
 
 **SSL_VERIFY_CLIENT**  
-Description: To set apache config param `SSLVerifyClient`, default value `require`, set to `optional` when using OIDC authentication.  
+Description: To set apache config param `SSLVerifyClient`, default value `require`, set to `optional` when using OIDC authentication.
 
 **PROXY_PASS_TIMEOUT_HTTP**  
 Description: timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a reply.  
-Default: `60` seconds  
+Default: `60` seconds
 
 **PROXY_PASS_TIMEOUT_WS**  
 Description: Timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a reply.  
-Default: `60` seconds  
+Default: `60` seconds
 
 **PROXY_PASS_CONNECTION_TIMEOUT_HTTP**  
 Description: Connection timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a connection to be established.  
-Default: `30` seconds  
+Default: `30` seconds
 
 **PROXY_PASS_CONNECTION_TIMEOUT_WS**  
 Description: Connection timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a connection to be established.  
-Default: `30` seconds  
+Default: `30` seconds
 
 **SERVER_CONTEXT_PATH**  
 Description: Reverse proxy context path that delegates to the app server, `/` character at start, no `/` character at end, use `''` (empty string) to configure root as context path.  

--- a/dsf-docker/fhir_proxy/README.md
+++ b/dsf-docker/fhir_proxy/README.md
@@ -1,15 +1,48 @@
-Variables:
+# Environment Variables
 
-${HTTPS\_SERVER\_NAME\_PORT} - example: localhost:8443  
-${APP\_SERVER\_IP} - example: 172.28.1.3  
-${SSL\_CERTIFICATE\_FILE} - to set apache config param `SSLCertificateFile`  
-${SSL\_CERTIFICATE\_KEY\_FILE} - to set apache config param `SSLCertificateKeyFile`  
-${SSL\_CERTIFICATE\_CHAIN\_FILE} - to set apache config param `SSLCertificateChainFile` (optional environment variable)  
-${SSL\_CA\_CERTIFICATE\_FILE} - to set apache config param `SSLCACertificateFile`  
-${SSL\_CA\_DN\_REQUEST\_FILE} - to set apache config param `SSLCADNRequestFile` (optional environment variable)  
-${SSL\_VERIFY\_CLIENT} - to set apache config param `SSLVerifyClient `, default value `require`, set to `optional` when using OIDC authentication  
-${PROXY\_PASS\_TIMEOUT\_HTTP} - timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a reply, default: `60` seconds  
-${PROXY\_PASS\_TIMEOUT\_WS} - timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a reply, default: `60` seconds  
-${PROXY\_PASS\_CONNECTION\_TIMEOUT\_HTTP} - connection timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a connection to be established, default: `30` seconds  
-${PROXY\_PASS\_CONNECTION\_TIMEOUT\_WS} - connection timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a connection to be established, default: `30` seconds  
-${SERVER\_CONTEXT\_PATH} - reverse proxy context path that delegates to the app server, `/` character at start, no `/` character at end, default: `/fhir`
+**HTTPS_SERVER_NAME_PORT**  
+Description: Server hostname and port.  
+Example: localhost:8443
+
+**APP_SERVER_IP**  
+Description: Reverse proxy target.  
+Example: 172.28.1.3
+
+**SSL_CERTIFICATE_FILE**  
+Description: To set apache config param `SSLCertificateFile`, with the server certificate private key.  
+
+**SSL_CERTIFICATE_KEY_FILE**  
+Description: To set apache config param `SSLCertificateKeyFile`, with the server certificate (and ca chain except root).  
+
+**SSL_CERTIFICATE_CHAIN_FILE**  
+Description: To set apache config param `SSLCertificateChainFile`, with the server certificate ca chain for (excluding the root CA), can be used if CA chain is not included in **SSL_CERTIFICATE_FILE**.  
+
+**SSL_CA_CERTIFICATE_FILE**  
+Description: To set apache config param `SSLCACertificateFile`, with the trusted full CA chains for validating client certificates.  
+
+**SSL_CA_DN_REQUEST_FILE**  
+Description: To set apache config param `SSLCADNRequestFile` with client certificate signing CAs to modify the "Acceptable client certificate CA names" send to the client.  
+Default: All CAs from **SSL_CA_DN_REQUEST_FILE** if not set.  
+
+**SSL_VERIFY_CLIENT**  
+Description: To set apache config param `SSLVerifyClient `, default value `require`, set to `optional` when using OIDC authentication.  
+
+**PROXY_PASS_TIMEOUT_HTTP**  
+Description: timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a reply.  
+Default: `60` seconds  
+
+**PROXY_PASS_TIMEOUT_WS**  
+Description: Timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a reply.  
+Default: `60` seconds  
+
+**PROXY_PASS_CONNECTION_TIMEOUT_HTTP**  
+Description: Connection timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a connection to be established.  
+Default: `30` seconds  
+
+**PROXY_PASS_CONNECTION_TIMEOUT_WS**  
+Description: Connection timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a connection to be established.  
+Default: `30` seconds  
+
+**SERVER_CONTEXT_PATH**  
+Description: Reverse proxy context path that delegates to the app server, `/` character at start, no `/` character at end, use `''` (empty string) to configure root as context path.  
+Default: `/fhir`

--- a/dsf-docker/fhir_proxy/README.md
+++ b/dsf-docker/fhir_proxy/README.md
@@ -22,10 +22,10 @@ Description: To set apache config param `SSLCACertificateFile`, with the trusted
 
 **SSL_CA_DN_REQUEST_FILE**  
 Description: To set apache config param `SSLCADNRequestFile` with client certificate signing CAs to modify the "Acceptable client certificate CA names" send to the client.  
-Default: All CAs from **SSL_CA_DN_REQUEST_FILE** if not set.  
+Default: If not set, all CAs from **SSL_CA_CERTIFICATE_FILE** are used for the "Acceptable client certificate CA names".
 
 **SSL_VERIFY_CLIENT**  
-Description: To set apache config param `SSLVerifyClient `, default value `require`, set to `optional` when using OIDC authentication.  
+Description: To set apache config param `SSLVerifyClient`, default value `require`, set to `optional` when using OIDC authentication.  
 
 **PROXY_PASS_TIMEOUT_HTTP**  
 Description: timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a reply.  

--- a/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
+++ b/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
@@ -38,8 +38,14 @@ Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains
 <Location "${SERVER_CONTEXT_PATH}">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
 
-	ProxyPass http://${APP_SERVER_IP}:8080/fhir timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
-	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir
+	ProxyPass http://${APP_SERVER_IP}:8080/fhir/ timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
+	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir/
+</Location>
+<Location "${SERVER_CONTEXT_PATH}/">
+	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+
+	ProxyPass http://${APP_SERVER_IP}:8080/fhir/ timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
+	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir/
 </Location>
 <Location "${SERVER_CONTEXT_PATH}/ws">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
@@ -328,7 +328,7 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 
 	private URI getResourceUri(Resource resource) throws MalformedURLException
 	{
-		return getResourceUrlString(resource).map(this::toURI).orElse(uriInfo.getRequestUri());
+		return getResourceUrlString(resource).map(this::toURI).orElse(toURI(serverBaseUrl + "/" + uriInfo.getPath()));
 	}
 
 	private URI toURI(String str)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/PropertiesConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/PropertiesConfig.java
@@ -68,7 +68,7 @@ public class PropertiesConfig implements InitializingBean
 	@Value("${dev.dsf.fhir.server.init.bundle:conf/bundle.xml}")
 	private String initBundleFile;
 
-	@Documentation(required = true, description = "PEM encoded file with one or more trusted root certificates to validate server certificates for https connections to remote DSF FHIR servers", recommendation = "Use docker secret file to configure", example = "/run/secrets/app_server_trust_certificates.pem")
+	@Documentation(required = true, description = "PEM encoded file with one or more trusted root certificates to validate server certificates for https connections to remote DSF FHIR servers", recommendation = "Use docker secret file to configure", example = "/run/secrets/app_client _trust_certificates.pem")
 	@Value("${dev.dsf.fhir.client.trust.server.certificate.cas}")
 	private String webserviceClientCertificateTrustCertificatesFile;
 


### PR DESCRIPTION
* Adds reverse proxy config for requests to the context-url without trailing slash.
* Fixes url title in the UI for the "/" (root) and "/metadata" urls for context-paths other then `/fhir`.
* Improves some documentation.

closes #85 