### PR TITLE
Issues/111 validation dependencies bpe

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
@@ -42,6 +42,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>dev.dsf</groupId>
+			<artifactId>dsf-fhir-validation</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>
 			<artifactId>crypto-utils</artifactId>
 		</dependency>

--- a/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-server-jetty/pom.xml
+++ b/dsf-bpe/dsf-bpe-server-jetty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -51,6 +51,12 @@
 			<artifactId>crypto-utils</artifactId>
 		</dependency>
 
+		<!-- dependencies for process plugins -->
+		<dependency>
+			<groupId>dev.dsf</groupId>
+			<artifactId>dsf-fhir-validation</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/pom.xml
+++ b/dsf-bpe/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-common/dsf-common-auth/pom.xml
+++ b/dsf-common/dsf-common-auth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-common/dsf-common-config/pom.xml
+++ b/dsf-common/dsf-common-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-common/dsf-common-documentation/pom.xml
+++ b/dsf-common/dsf-common-documentation/pom.xml
@@ -6,6 +6,6 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/dsf-common/dsf-common-jetty/pom.xml
+++ b/dsf-common/dsf-common-jetty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-common/dsf-common-status/pom.xml
+++ b/dsf-common/dsf-common-status/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-common/pom.xml
+++ b/dsf-common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	
 	<modules>

--- a/dsf-fhir/dsf-fhir-auth/pom.xml
+++ b/dsf-fhir/dsf-fhir-auth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
+++ b/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
+++ b/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
@@ -11,11 +11,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>dev.dsf</groupId>
-			<artifactId>dsf-common-auth</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 		</dependency>

--- a/dsf-fhir/dsf-fhir-server-jetty/pom.xml
+++ b/dsf-fhir/dsf-fhir-server-jetty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
@@ -98,7 +98,7 @@
 				</configuration>
 				<!-- Workaround for exec maven plugin version 3.1.0 issue -->
 				<!-- https://github.com/mojohaus/exec-maven-plugin/issues/247 -->
-				<!-- <dependencies> <dependency> <groupId>dev.dsf</groupId> <artifactId>dsf-tools-bundle-generator</artifactId> <version>1.2.1-SNAPSHOT</version> </dependency>
+				<!-- <dependencies> <dependency> <groupId>dev.dsf</groupId> <artifactId>dsf-tools-bundle-generator</artifactId> <version>1.3.0-SNAPSHOT</version> </dependency>
 					</dependencies> -->
 			</plugin>
 		</plugins>

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -50,6 +50,7 @@
 			<!-- https://github.com/mojohaus/exec-maven-plugin/issues/247 -->
 			<!-- <scope>test</scope> -->
 			<scope>runtime</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -58,6 +59,7 @@
 			<!-- https://github.com/mojohaus/exec-maven-plugin/issues/247 -->
 			<!-- <scope>test</scope> -->
 			<scope>runtime</scope>
+			<optional>true</optional>
 		</dependency>
 		<!-- Workaround for exec maven plugin version 3.1.0 issue -->
 		<!-- https://github.com/mojohaus/exec-maven-plugin/issues/247 -->
@@ -65,6 +67,7 @@
 			<groupId>dev.dsf</groupId>
 			<artifactId>dsf-tools-bundle-generator</artifactId>
 			<scope>runtime</scope>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/dsf-fhir/dsf-fhir-webservice-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-webservice-client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-websocket-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-websocket-client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/pom.xml
+++ b/dsf-fhir/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-tools/dsf-tools-build-info-reader/pom.xml
+++ b/dsf-tools/dsf-tools-build-info-reader/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-bundle-generator/pom.xml
+++ b/dsf-tools/dsf-tools-bundle-generator/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-db-migration/pom.xml
+++ b/dsf-tools/dsf-tools-db-migration/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-docker-secrets-reader/pom.xml
+++ b/dsf-tools/dsf-tools-docker-secrets-reader/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-documentation-generator/pom.xml
+++ b/dsf-tools/dsf-tools-documentation-generator/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-proxy-test/pom.xml
+++ b/dsf-tools/dsf-tools-proxy-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-test-data-generator/pom.xml
+++ b/dsf-tools/dsf-tools-test-data-generator/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/pom.xml
+++ b/dsf-tools/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>dev.dsf</groupId>
 	<artifactId>dsf-pom</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
* Removes not needed dependencies and adds validation support for process plugins.
* Version to 1.3.0-SNAPSHOT

closes #111 

_Rename of 1.2.1 milestone to 1.3.0 tbd._