### PR TITLE
Issues/124 125 OIDC support

### DIFF
--- a/dsf-docker-test-setup-3dic-ttp/docker-compose.yml
+++ b/dsf-docker-test-setup-3dic-ttp/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       --spi-truststore-file-hostname-verification-policy=STRICT
 
   dic1-fhir:
+    build: ../dsf-fhir/dsf-fhir-server-jetty/docker
     image: datasharingframework/fhir
     restart: "no"
     ports:
@@ -175,6 +176,7 @@ services:
       - keycloak
 
   dic2-fhir:
+    build: ../dsf-fhir/dsf-fhir-server-jetty/docker
     image: datasharingframework/fhir
     restart: "no"
     ports:
@@ -243,6 +245,7 @@ services:
       - keycloak
 
   dic3-fhir:
+    build: ../dsf-fhir/dsf-fhir-server-jetty/docker
     image: datasharingframework/fhir
     restart: "no"
     ports:
@@ -311,6 +314,7 @@ services:
       - keycloak
 
   ttp-fhir:
+    build: ../dsf-fhir/dsf-fhir-server-jetty/docker
     image: datasharingframework/fhir
     restart: "no"
     ports:
@@ -386,6 +390,7 @@ services:
       - keycloak
 
   dic1-bpe:
+    build: ../dsf-bpe/dsf-bpe-server-jetty/docker
     image: datasharingframework/bpe
     restart: "no"
     ports:
@@ -452,6 +457,7 @@ services:
       - keycloak
 
   dic2-bpe:
+    build: ../dsf-bpe/dsf-bpe-server-jetty/docker
     image: datasharingframework/bpe
     restart: "no"
     ports:
@@ -518,6 +524,7 @@ services:
       - keycloak
 
   dic3-bpe:
+    build: ../dsf-bpe/dsf-bpe-server-jetty/docker
     image: datasharingframework/bpe
     restart: "no"
     ports:
@@ -585,6 +592,7 @@ services:
       - keycloak
 
   ttp-bpe:
+    build: ../dsf-bpe/dsf-bpe-server-jetty/docker
     image: datasharingframework/bpe
     restart: "no"
     ports:

--- a/dsf-docker-test-setup/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup/bpe/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   app:
+    build: ../../dsf-bpe/dsf-bpe-server-jetty/docker
     image: datasharingframework/bpe
     restart: "no"
     ports:

--- a/dsf-docker-test-setup/fhir/docker-compose.yml
+++ b/dsf-docker-test-setup/fhir/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   proxy:
+    build: ../../dsf-docker/fhir_proxy
     image: datasharingframework/fhir_proxy
     restart: "no"
     ports:
@@ -28,6 +29,7 @@ services:
       - app
 
   app:
+    build: ../../dsf-fhir/dsf-fhir-server-jetty/docker
     image: datasharingframework/fhir
     restart: "no"
     ports:

--- a/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
+++ b/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
@@ -36,21 +36,21 @@ RequestHeader set X-ClientCert ""
 Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
 
 <Location "${SERVER_CONTEXT_PATH}">
-	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s "expr=-n %{SSL_CLIENT_CERT}"
 	RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
 
 	ProxyPass http://${APP_SERVER_IP}:8080/fhir/ timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
 	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir/
 </Location>
 <Location "${SERVER_CONTEXT_PATH}/">
-	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s "expr=-n %{SSL_CLIENT_CERT}"
 	RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
 
 	ProxyPass http://${APP_SERVER_IP}:8080/fhir/ timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
 	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir/
 </Location>
 <Location "${SERVER_CONTEXT_PATH}/ws">
-	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s "expr=-n %{SSL_CLIENT_CERT}"
 	RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
 
 	ProxyWebsocketFallbackToProxyHttp off

--- a/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
+++ b/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
@@ -37,18 +37,21 @@ Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains
 
 <Location "${SERVER_CONTEXT_PATH}">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+	RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
 
 	ProxyPass http://${APP_SERVER_IP}:8080/fhir/ timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
 	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir/
 </Location>
 <Location "${SERVER_CONTEXT_PATH}/">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+	RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
 
 	ProxyPass http://${APP_SERVER_IP}:8080/fhir/ timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
 	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir/
 </Location>
 <Location "${SERVER_CONTEXT_PATH}/ws">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
+	RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
 
 	ProxyWebsocketFallbackToProxyHttp off
 	ProxyPass ws://${APP_SERVER_IP}:8080/fhir/ws timeout=${PROXY_PASS_TIMEOUT_WS} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_WS}


### PR DESCRIPTION
* Adds the `X-Forwarded-Proto` header for proxy request to the fhir app server.
* Only sends the `X-ClientCert` header if the variable SSL_CLIENT_CERT is not empty. The value is empty if a users is not authenticated with a client certificate and client certificate authentication is optional.
* Adds mail address based on the `iss` (issuer) and `sub` (subject) values from the access token to the currently logged in Practitioner object.

fixes #124 
closes #125 