### PR TITLE
Issues/135 enable parallel maven builds

### DIFF
--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -221,49 +221,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>io.fabric8</groupId>
-				<artifactId>docker-maven-plugin</artifactId>
-				<extensions>true</extensions>
-				<executions>
-					<execution>
-						<id>start-postgres</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>start</goal>
-						</goals>
-						<configuration>
-							<images>
-								<image>
-									<name>postgres:15</name>
-									<run>
-										<ports>
-											<port>127.0.0.1:54321:5432</port>
-										</ports>
-										<env>
-											<TZ>Europe/Berlin</TZ>
-											<POSTGRES_USER>postgres</POSTGRES_USER>
-											<POSTGRES_PASSWORD>password</POSTGRES_PASSWORD>
-											<POSTGRES_DB>db</POSTGRES_DB>
-										</env>
-										<wait>
-											<!-- <log>(?s)database system is ready to accept connections.*database system is ready to accept connections</log> -->
-											<time>2500</time>
-										</wait>
-									</run>
-								</image>
-							</images>
-						</configuration>
-					</execution>
-					<execution>
-						<id>stop-postgres</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/dao/AbstractDbTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/dao/AbstractDbTest.java
@@ -24,18 +24,18 @@ public abstract class AbstractDbTest
 	protected static final String DATABASE_CAMUNDA_USER = "camunda_user";
 	protected static final String DATABASE_CAMUNDA_USER_PASSWORD = "camunda_user_password";
 
-	protected static final String DATABASE_URL = "jdbc:postgresql://localhost:54321/db";
+	protected static final String ROOT_USER = "postgres";
 
-	protected static final Map<String, String> CHANGE_LOG_PARAMETERS = Map.of("db.liquibase_user", "postgres",
+	protected static final Map<String, String> CHANGE_LOG_PARAMETERS = Map.of("db.liquibase_user", ROOT_USER,
 			"db.server_users_group", DATABASE_USERS_GROUP, "db.server_user", DATABASE_USER, "db.server_user_password",
 			DATABASE_USER_PASSWORD, "db.camunda_users_group", DATABASE_CAMUNDA_USERS_GROUP, "db.camunda_user",
 			DATABASE_CAMUNDA_USER, "db.camunda_user_password", DATABASE_CAMUNDA_USER_PASSWORD);
 
-	public static BasicDataSource createDefaultDataSource()
+	public static BasicDataSource createDefaultDataSource(String host, int port, String databaseName)
 	{
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl(DATABASE_URL);
+		dataSource.setUrl("jdbc:postgresql://" + host + ":" + port + "/" + databaseName);
 		dataSource.setUsername(DATABASE_USER);
 		dataSource.setPassword(DATABASE_USER_PASSWORD);
 		dataSource.setDefaultReadOnly(true);
@@ -46,40 +46,11 @@ public abstract class AbstractDbTest
 		return dataSource;
 	}
 
-	public static BasicDataSource createLiquibaseDataSource()
+	public static BasicDataSource createCamundaDataSource(String host, int port, String databaseName)
 	{
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl(DATABASE_URL);
-		dataSource.setUsername("postgres");
-		dataSource.setPassword("password");
-		dataSource.setDefaultReadOnly(true);
-
-		dataSource.setTestOnBorrow(true);
-		dataSource.setValidationQuery("SELECT 1");
-
-		return dataSource;
-	}
-
-	public static BasicDataSource createAdminBasicDataSource()
-	{
-		BasicDataSource dataSource = new BasicDataSource();
-		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl("jdbc:postgresql://localhost:54321/postgres");
-		dataSource.setUsername("postgres");
-		dataSource.setPassword("password");
-
-		dataSource.setTestOnBorrow(true);
-		dataSource.setValidationQuery("SELECT 1");
-
-		return dataSource;
-	}
-
-	public static BasicDataSource createCamundaDataSource()
-	{
-		BasicDataSource dataSource = new BasicDataSource();
-		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl(DATABASE_URL);
+		dataSource.setUrl("jdbc:postgresql://" + host + ":" + port + "/" + databaseName);
 		dataSource.setUsername(DATABASE_CAMUNDA_USER);
 		dataSource.setPassword(DATABASE_CAMUNDA_USER_PASSWORD);
 		dataSource.setDefaultReadOnly(true);

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/StatusPortAuthenticator.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/StatusPortAuthenticator.java
@@ -1,5 +1,8 @@
 package dev.dsf.common.auth;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.ServerAuthException;
@@ -15,11 +18,13 @@ public class StatusPortAuthenticator implements Authenticator
 {
 	private static final String STATUS_PATH = "/status";
 
-	private final int statusPort;
+	private final Supplier<Integer> statusPortSupplier;
 
-	public StatusPortAuthenticator(int statusPort)
+	public StatusPortAuthenticator(Supplier<Integer> statusPortSupplier)
 	{
-		this.statusPort = statusPort;
+		Objects.requireNonNull(statusPortSupplier, "statusPortSupplier");
+
+		this.statusPortSupplier = statusPortSupplier;
 	}
 
 	@Override
@@ -37,7 +42,7 @@ public class StatusPortAuthenticator implements Authenticator
 	{
 		HttpServletRequest request = (HttpServletRequest) req;
 		return HttpMethod.GET.is(request.getMethod()) && STATUS_PATH.equals(request.getPathInfo())
-				&& statusPort == request.getLocalPort();
+				&& statusPortSupplier.get() != null && statusPortSupplier.get() == request.getLocalPort();
 	}
 
 	@Override

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractHttpJettyConfig.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractHttpJettyConfig.java
@@ -2,13 +2,13 @@ package dev.dsf.common.config;
 
 import java.util.function.Function;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 
 public abstract class AbstractHttpJettyConfig extends AbstractJettyConfig
 {
 	@Override
-	protected Function<Server, Connector> apiConnector()
+	protected Function<Server, ServerConnector> apiConnector()
 	{
 		return httpApiConnector();
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractHttpsJettyConfig.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractHttpsJettyConfig.java
@@ -2,13 +2,13 @@ package dev.dsf.common.config;
 
 import java.util.function.Function;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 
 public abstract class AbstractHttpsJettyConfig extends AbstractJettyConfig
 {
 	@Override
-	protected Function<Server, Connector> apiConnector()
+	protected Function<Server, ServerConnector> apiConnector()
 	{
 		return httpsApiConnector();
 	}

--- a/dsf-docker-for-junit-testing/start-postgres15.bat
+++ b/dsf-docker-for-junit-testing/start-postgres15.bat
@@ -1,4 +1,0 @@
-@echo off
-
-echo starting postgres docker container at 127.0.0.1:54321 ...
-docker run -it --rm -e POSTGRES_PASSWORD=password -e TZ=Europe/Berlin -e POSTGRES_DB=db -p 127.0.0.1:54321:5432 postgres:15 postgres -c log_statement=all -c log_min_messages=NOTICE

--- a/dsf-docker-for-junit-testing/start-postgres15.sh
+++ b/dsf-docker-for-junit-testing/start-postgres15.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo starting postgres docker container at 127.0.0.1:54321 ...
-docker run -it --rm -e POSTGRES_PASSWORD=password -e TZ=Europe/Berlin -e POSTGRES_DB=db -p 127.0.0.1:54321:5432 postgres:15 postgres -c log_statement=all -c log_min_messages=NOTICE

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -249,56 +249,12 @@
 						<include>**/*DaoTest</include>
 						<include>**/*IntegrationTest</include>
 					</includes>
-					<reuseForks>false</reuseForks>
 				</configuration>
 				<executions>
 					<execution>
 						<goals>
 							<goal>integration-test</goal>
 							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>io.fabric8</groupId>
-				<artifactId>docker-maven-plugin</artifactId>
-				<extensions>true</extensions>
-				<executions>
-					<execution>
-						<id>start-postgres</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>start</goal>
-						</goals>
-						<configuration>
-							<images>
-								<image>
-									<name>postgres:15</name>
-									<run>
-										<ports>
-											<port>127.0.0.1:54321:5432</port>
-										</ports>
-										<env>
-											<TZ>Europe/Berlin</TZ>
-											<POSTGRES_USER>postgres</POSTGRES_USER>
-											<POSTGRES_PASSWORD>password</POSTGRES_PASSWORD>
-											<POSTGRES_DB>db</POSTGRES_DB>
-										</env>
-										<wait>
-											<!-- <log>(?s)database system is ready to accept connections.*database system is ready to accept connections</log> -->
-											<time>2500</time>
-										</wait>
-									</run>
-								</image>
-							</images>
-						</configuration>
-					</execution>
-					<execution>
-						<id>stop-postgres</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>stop</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractDbTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractDbTest.java
@@ -24,19 +24,19 @@ public abstract class AbstractDbTest
 	protected static final String DATABASE_DELETE_USER = "server_permanent_delete_user";
 	protected static final String DATABASE_DELETE_USER_PASSWORD = "server_permanent_delete_user_password";
 
-	protected static final String DATABASE_URL = "jdbc:postgresql://localhost:54321/db";
+	protected static final String ROOT_USER = "postgres";
 
-	protected static final Map<String, String> CHANGE_LOG_PARAMETERS = Map.of("db.liquibase_user", "postgres",
+	protected static final Map<String, String> CHANGE_LOG_PARAMETERS = Map.of("db.liquibase_user", ROOT_USER,
 			"db.server_users_group", DATABASE_USERS_GROUP, "db.server_user", DATABASE_USER, "db.server_user_password",
 			DATABASE_USER_PASSWORD, "db.server_permanent_delete_users_group", DATABASE_DELETE_USERS_GROUP,
 			"db.server_permanent_delete_user", DATABASE_DELETE_USER, "db.server_permanent_delete_user_password",
 			DATABASE_DELETE_USER_PASSWORD);
 
-	public static BasicDataSource createDefaultDataSource()
+	public static BasicDataSource createDefaultDataSource(String host, int port, String databaseName)
 	{
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl(DATABASE_URL);
+		dataSource.setUrl("jdbc:postgresql://" + host + ":" + port + "/" + databaseName);
 		dataSource.setUsername(DATABASE_USER);
 		dataSource.setPassword(DATABASE_USER_PASSWORD);
 		dataSource.setDefaultReadOnly(true);
@@ -47,40 +47,11 @@ public abstract class AbstractDbTest
 		return dataSource;
 	}
 
-	public static BasicDataSource createLiquibaseDataSource()
+	public static BasicDataSource createPermanentDeleteDataSource(String host, int port, String databaseName)
 	{
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl(DATABASE_URL);
-		dataSource.setUsername("postgres");
-		dataSource.setPassword("password");
-		dataSource.setDefaultReadOnly(true);
-
-		dataSource.setTestOnBorrow(true);
-		dataSource.setValidationQuery("SELECT 1");
-
-		return dataSource;
-	}
-
-	public static BasicDataSource createAdminBasicDataSource()
-	{
-		BasicDataSource dataSource = new BasicDataSource();
-		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl("jdbc:postgresql://localhost:54321/postgres");
-		dataSource.setUsername("postgres");
-		dataSource.setPassword("password");
-
-		dataSource.setTestOnBorrow(true);
-		dataSource.setValidationQuery("SELECT 1");
-
-		return dataSource;
-	}
-
-	public static BasicDataSource createPermanentDeleteDataSource()
-	{
-		BasicDataSource dataSource = new BasicDataSource();
-		dataSource.setDriverClassName(Driver.class.getName());
-		dataSource.setUrl(DATABASE_URL);
+		dataSource.setUrl("jdbc:postgresql://" + host + ":" + port + "/" + databaseName);
 		dataSource.setUsername(DATABASE_DELETE_USER);
 		dataSource.setPassword(DATABASE_DELETE_USER_PASSWORD);
 		dataSource.setDefaultReadOnly(true);

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/HistoryDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/HistoryDaoTest.java
@@ -9,13 +9,15 @@ import java.util.UUID;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.hl7.fhir.r4.model.Organization;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.utility.DockerImageName;
 
 import ca.uhn.fhir.context.FhirContext;
-import de.rwh.utils.test.LiquibaseTemplateTestClassRule;
-import de.rwh.utils.test.LiquibaseTemplateTestRule;
+import de.hsheilbronn.mi.utils.test.PostgreSqlContainerLiquibaseTemplateClassRule;
+import de.hsheilbronn.mi.utils.test.PostgresTemplateRule;
 import dev.dsf.fhir.dao.jdbc.BinaryDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.HistroyDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.OrganizationDaoJdbc;
@@ -28,29 +30,35 @@ import dev.dsf.fhir.search.PageAndCount;
 
 public class HistoryDaoTest extends AbstractDbTest
 {
-	private static final BasicDataSource adminDataSource = createAdminBasicDataSource();
-	private static final BasicDataSource liquibaseDataSource = createLiquibaseDataSource();
-	private static final BasicDataSource defaultDataSource = createDefaultDataSource();
-	private static final BasicDataSource permanentDeleteDataSource = createPermanentDeleteDataSource();
+	private static BasicDataSource defaultDataSource;
+	private static BasicDataSource permanentDeleteDataSource;
 
 	@ClassRule
-	public static final LiquibaseTemplateTestClassRule liquibaseRule = new LiquibaseTemplateTestClassRule(
-			adminDataSource, LiquibaseTemplateTestClassRule.DEFAULT_TEST_DB_NAME,
-			AbstractResourceDaoTest.DAO_DB_TEMPLATE_NAME, liquibaseDataSource, CHANGE_LOG_FILE, CHANGE_LOG_PARAMETERS,
-			true);
+	public static final PostgreSqlContainerLiquibaseTemplateClassRule liquibaseRule = new PostgreSqlContainerLiquibaseTemplateClassRule(
+			DockerImageName.parse("postgres:15"), ROOT_USER, "fhir", "fhir_template", CHANGE_LOG_FILE,
+			CHANGE_LOG_PARAMETERS, true);
+
+	@Rule
+	public final PostgresTemplateRule templateRule = new PostgresTemplateRule(liquibaseRule);
+
+	@BeforeClass
+	public static void beforeClass() throws Exception
+	{
+		defaultDataSource = createDefaultDataSource(liquibaseRule.getHost(), liquibaseRule.getMappedPort(5432),
+				liquibaseRule.getDatabaseName());
+		defaultDataSource.start();
+
+		permanentDeleteDataSource = createPermanentDeleteDataSource(liquibaseRule.getHost(),
+				liquibaseRule.getMappedPort(5432), liquibaseRule.getDatabaseName());
+		permanentDeleteDataSource.start();
+	}
 
 	@AfterClass
 	public static void afterClass() throws Exception
 	{
 		defaultDataSource.close();
-		liquibaseDataSource.close();
-		adminDataSource.close();
 		permanentDeleteDataSource.close();
 	}
-
-	@Rule
-	public final LiquibaseTemplateTestRule templateRule = new LiquibaseTemplateTestRule(adminDataSource,
-			LiquibaseTemplateTestClassRule.DEFAULT_TEST_DB_NAME, AbstractResourceDaoTest.DAO_DB_TEMPLATE_NAME);
 
 	private final FhirContext fhirContext = FhirContext.forR4();
 	private final OrganizationDao orgDao = new OrganizationDaoJdbc(defaultDataSource, permanentDeleteDataSource,

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -1270,7 +1270,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		assertNotNull(created.getIdPart());
 		assertNotNull(created.getVersionIdPart());
 
-		assertEquals(BASE_URL, created.getBaseUrl());
+		assertEquals(getBaseUrl(), created.getBaseUrl());
 		assertEquals("Binary", created.getResourceType());
 		assertEquals("1", created.getVersionIdPart());
 	}
@@ -1369,7 +1369,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		assertNotNull(created.getIdPart());
 		assertNotNull(created.getVersionIdPart());
 
-		assertEquals(BASE_URL, created.getBaseUrl());
+		assertEquals(getBaseUrl(), created.getBaseUrl());
 		assertEquals("Binary", created.getResourceType());
 		assertEquals("1", created.getVersionIdPart());
 	}
@@ -1933,7 +1933,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		assertNotNull(updated.getIdPart());
 		assertNotNull(updated.getVersionIdPart());
 
-		assertEquals(BASE_URL, updated.getBaseUrl());
+		assertEquals(getBaseUrl(), updated.getBaseUrl());
 		assertEquals("Binary", updated.getResourceType());
 		assertEquals("2", updated.getVersionIdPart());
 	}
@@ -2038,8 +2038,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.TRANSACTION);
-		bundle.addEntry().setFullUrl(BASE_URL + "/Binary/" + created.getIdElement().getIdPart()).setResource(created)
-				.getRequest().setMethod(HTTPVerb.PUT).setUrl("Binary/" + created.getIdElement().getIdPart());
+		bundle.addEntry().setFullUrl(getBaseUrl() + "/Binary/" + created.getIdElement().getIdPart())
+				.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
+				.setUrl("Binary/" + created.getIdElement().getIdPart());
 
 		Bundle responseBundle = getWebserviceClient().postBundle(bundle);
 
@@ -2096,8 +2097,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.TRANSACTION);
-		bundle.addEntry().setFullUrl(BASE_URL + "/Binary/" + created.getIdElement().getIdPart()).setResource(created)
-				.getRequest().setMethod(HTTPVerb.PUT).setUrl("Binary/" + created.getIdElement().getIdPart());
+		bundle.addEntry().setFullUrl(getBaseUrl() + "/Binary/" + created.getIdElement().getIdPart())
+				.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
+				.setUrl("Binary/" + created.getIdElement().getIdPart());
 
 		expectForbidden(() -> getExternalWebserviceClient().postBundle(bundle));
 	}
@@ -2142,8 +2144,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.TRANSACTION);
-		bundle.addEntry().setFullUrl(BASE_URL + "/Binary/" + created.getIdElement().getIdPart()).setResource(created)
-				.getRequest().setMethod(HTTPVerb.PUT).setUrl("Binary/" + created.getIdElement().getIdPart());
+		bundle.addEntry().setFullUrl(getBaseUrl() + "/Binary/" + created.getIdElement().getIdPart())
+				.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
+				.setUrl("Binary/" + created.getIdElement().getIdPart());
 
 		expectForbidden(() -> getWebserviceClient().postBundle(bundle));
 	}
@@ -2176,8 +2179,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.BATCH);
-		bundle.addEntry().setFullUrl(BASE_URL + "/Binary/" + created.getIdElement().getIdPart()).setResource(created)
-				.getRequest().setMethod(HTTPVerb.PUT).setUrl("Binary/" + created.getIdElement().getIdPart());
+		bundle.addEntry().setFullUrl(getBaseUrl() + "/Binary/" + created.getIdElement().getIdPart())
+				.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
+				.setUrl("Binary/" + created.getIdElement().getIdPart());
 
 		Bundle responseBundle = getWebserviceClient().postBundle(bundle);
 
@@ -2233,8 +2237,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.BATCH);
-		bundle.addEntry().setFullUrl(BASE_URL + "/Binary/" + created.getIdElement().getIdPart()).setResource(created)
-				.getRequest().setMethod(HTTPVerb.PUT).setUrl("Binary/" + created.getIdElement().getIdPart());
+		bundle.addEntry().setFullUrl(getBaseUrl() + "/Binary/" + created.getIdElement().getIdPart())
+				.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
+				.setUrl("Binary/" + created.getIdElement().getIdPart());
 
 		Bundle responseBundle = getExternalWebserviceClient().postBundle(bundle);
 		assertNotNull(responseBundle);
@@ -2287,8 +2292,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.BATCH);
-		bundle.addEntry().setFullUrl(BASE_URL + "/Binary/" + created.getIdElement().getIdPart()).setResource(created)
-				.getRequest().setMethod(HTTPVerb.PUT).setUrl("Binary/" + created.getIdElement().getIdPart());
+		bundle.addEntry().setFullUrl(getBaseUrl() + "/Binary/" + created.getIdElement().getIdPart())
+				.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
+				.setUrl("Binary/" + created.getIdElement().getIdPart());
 
 		Bundle responseBundle = getWebserviceClient().postBundle(bundle);
 		assertNotNull(responseBundle);

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/TaskIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/TaskIntegrationTest.java
@@ -1421,7 +1421,7 @@ public class TaskIntegrationTest extends AbstractIntegrationTest
 		BasicDataSource dataSource = getSpringWebApplicationContext().getBean("dataSource", BasicDataSource.class);
 
 		ReferencesHelperImpl<Task> referencesHelper = new ReferencesHelperImpl<>(0,
-				TestOrganizationIdentity.local(organizationProvider.getLocalOrganization().get()), task, BASE_URL,
+				TestOrganizationIdentity.local(organizationProvider.getLocalOrganization().get()), task, getBaseUrl(),
 				referenceExtractor, referenceResolver, responseGenerator);
 		try (Connection connection = dataSource.getConnection())
 		{
@@ -1440,7 +1440,7 @@ public class TaskIntegrationTest extends AbstractIntegrationTest
 		Bundle bundle = new Bundle();
 		bundle.setType(BundleType.TRANSACTION);
 		BundleEntryComponent entry = bundle.addEntry()
-				.setFullUrl(created.getIdElement().withServerBase(BASE_URL, "Task").toVersionless().getValue());
+				.setFullUrl(created.getIdElement().withServerBase(getBaseUrl(), "Task").toVersionless().getValue());
 		entry.setResource(created).getRequest().setMethod(HTTPVerb.PUT)
 				.setUrl("Task/" + created.getIdElement().getIdPart());
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/TestNameLoggerRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/TestNameLoggerRule.java
@@ -1,0 +1,29 @@
+package dev.dsf.fhir.integration;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestNameLoggerRule extends TestWatcher
+{
+	private static final Logger logger = LoggerFactory.getLogger(TestNameLoggerRule.class);
+
+	@Override
+	protected void starting(Description description)
+	{
+		logger.info("Starting {}.{} ...", description.getClassName(), description.getMethodName());
+	}
+
+	@Override
+	protected void succeeded(Description description)
+	{
+		logger.info("{}.{} [succeeded]", description.getClassName(), description.getMethodName());
+	}
+
+	@Override
+	protected void failed(Throwable e, Description description)
+	{
+		logger.info("{}.{} [failed]", description.getClassName(), description.getMethodName());
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/BasicFhirWebserviceClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/BasicFhirWebserviceClient.java
@@ -45,6 +45,13 @@ public interface BasicFhirWebserviceClient extends PreferReturnResource
 
 	<R extends Resource> boolean exists(Class<R> resourceType, String id);
 
+	/**
+	 * @param id
+	 *            not <code>null</code>
+	 * @param mediaType
+	 *            not <code>null</code>
+	 * @return {@link InputStream} needs to be closed
+	 */
 	InputStream readBinary(String id, MediaType mediaType);
 
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -162,12 +162,13 @@
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>crypto-utils</artifactId>
+				<!-- Can't update to 4.0.0 as renamed packages in crypto-utils would break existing process plugins -->
 				<version>3.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>db-test-utils</artifactId>
-				<version>0.22.0</version>
+				<version>1.0.0</version>
 			</dependency>
 			
 			<dependency>


### PR DESCRIPTION
Enables parallel maven builds with parallel test execution.

The PostgreSQL container for JUnit database and integration tests is now started via the testcontainers library. PostgreSQL containers and FHIR jetty servers now use random tcp ports.

With `mvn install -DforkCount=4 -T2C` maven modules can be build in parallel and multiple test classes executed concurrently. The parameter `-T2C` results in two threads per CPU core used to build maven modules. With `-DforkCount=4` parallel execution of 4 JUnit test classes can be enabled. Note, this means that for database tests, multiple PostgreSQL containers and for integration tests multiple database containers and jetty servers will be running.

Removes not needed batch/bash scripts to start PostgreSQL DB for running JUnit tests via IDE.

Adds javadoc to BasicFhirWebserviceClient.

closes #135 