### PR TITLE
Use StrongUuidGenerator for process id generation

### DIFF
--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -133,6 +133,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.uuid</groupId>
+			<artifactId>java-uuid-generator</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>jakarta.mail</artifactId>
 		</dependency>
@@ -185,7 +190,7 @@
 				</includes>
 			</testResource>
 		</testResources>
-		
+
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/CamundaConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/CamundaConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.jobexecutor.DefaultJobExecutor;
+import org.camunda.bpm.engine.impl.persistence.StrongUuidGenerator;
 import org.camunda.bpm.engine.spring.ProcessEngineFactoryBean;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.postgresql.Driver;
@@ -132,6 +133,8 @@ public class CamundaConfig
 		jobExecutor.setQueueSize(propertiesConfig.getProcessEngineJobExecutorQueueSize());
 		jobExecutor.setMaxPoolSize(propertiesConfig.getProcessEngineJobExecutorMaxPoolSize());
 		c.setJobExecutor(jobExecutor);
+
+		c.setIdGenerator(new StrongUuidGenerator());
 
 		return c;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 				<artifactId>db-test-utils</artifactId>
 				<version>1.0.0</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.auth0</groupId>
 				<artifactId>java-jwt</artifactId>
@@ -381,7 +381,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-  				<version>1.24.0</version>
+				<version>1.24.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
@@ -435,6 +435,12 @@
 				<groupId>org.yaml</groupId>
 				<artifactId>snakeyaml</artifactId>
 				<version>2.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.fasterxml.uuid</groupId>
+				<artifactId>java-uuid-generator</artifactId>
+				<version>3.1.2</version>
 			</dependency>
 
 			<!-- maven plugin -->


### PR DESCRIPTION
The Camunda documentation suggests to use the UUID  generator in production instead of the default database generated id's.

see [Id Generators](https://docs.camunda.org/manual/latest/user-guide/process-engine/id-generator/)