### PR TITLE
Allow larger binary resources with mime type "application/json"

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -16,4 +16,4 @@ jobs:
         java-version: 17
         cache: 'maven'
     - name: Build with Maven
-      run: mvn --batch-mode --fail-at-end --threads 1C -DforkCount=2 -Dgpg.skip clean verify
+      run: mvn --batch-mode --fail-at-end --threads 1C -DforkCount=2 -DreuseForks=false -Dgpg.skip clean verify

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -16,4 +16,4 @@ jobs:
         java-version: 17
         cache: 'maven'
     - name: Build with Maven
-      run: mvn --batch-mode --fail-at-end --threads 1C -DforkCount=2 -DreuseForks=false -Dgpg.skip clean verify
+      run: mvn --batch-mode --fail-at-end --threads 1C -DforkCount=2 -Dgpg.skip clean verify

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/FhirConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/FhirConfig.java
@@ -5,6 +5,8 @@ import java.util.Locale;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.HapiLocalizer;
 
@@ -14,6 +16,10 @@ public class FhirConfig
 	@Bean
 	public FhirContext fhirContext()
 	{
+		// TODO remove workaround after upgrading to HAPI 6.8+, see https://github.com/hapifhir/hapi-fhir/issues/5205
+		StreamReadConstraints.overrideDefaultStreamReadConstraints(
+				StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+
 		FhirContext context = FhirContext.forR4();
 		HapiLocalizer localizer = new HapiLocalizer()
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/FhirConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/FhirConfig.java
@@ -13,11 +13,16 @@ import ca.uhn.fhir.i18n.HapiLocalizer;
 @Configuration
 public class FhirConfig
 {
-	@Bean
-	public FhirContext fhirContext()
+
+	static
 	{
 		StreamReadConstraints.overrideDefaultStreamReadConstraints(
 				StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+	}
+
+	@Bean
+	public FhirContext fhirContext()
+	{
 		FhirContext context = FhirContext.forR4();
 		HapiLocalizer localizer = new HapiLocalizer()
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/FhirConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/FhirConfig.java
@@ -5,6 +5,8 @@ import java.util.Locale;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.HapiLocalizer;
 
@@ -14,6 +16,8 @@ public class FhirConfig
 	@Bean
 	public FhirContext fhirContext()
 	{
+		StreamReadConstraints.overrideDefaultStreamReadConstraints(
+				StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
 		FhirContext context = FhirContext.forR4();
 		HapiLocalizer localizer = new HapiLocalizer()
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/FhirConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/FhirConfig.java
@@ -13,16 +13,13 @@ import ca.uhn.fhir.i18n.HapiLocalizer;
 @Configuration
 public class FhirConfig
 {
-
-	static
-	{
-		StreamReadConstraints.overrideDefaultStreamReadConstraints(
-				StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
-	}
-
 	@Bean
 	public FhirContext fhirContext()
 	{
+		// TODO remove workaround after upgrading to HAPI 6.8+, see https://github.com/hapifhir/hapi-fhir/issues/5205
+		StreamReadConstraints.overrideDefaultStreamReadConstraints(
+				StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+
 		FhirContext context = FhirContext.forR4();
 		HapiLocalizer localizer = new HapiLocalizer()
 		{

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractDbTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractDbTest.java
@@ -6,12 +6,18 @@ import org.apache.commons.dbcp2.BasicDataSource;
 import org.postgresql.Driver;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+
 public abstract class AbstractDbTest
 {
 	static
 	{
 		SLF4JBridgeHandler.removeHandlersForRootLogger();
 		SLF4JBridgeHandler.install();
+
+		// TODO remove workaround after upgrading to HAPI 6.8+, see https://github.com/hapifhir/hapi-fhir/issues/5205
+		StreamReadConstraints.overrideDefaultStreamReadConstraints(
+				StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
 	}
 
 	protected static final String CHANGE_LOG_FILE = "db/db.changelog.xml";

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -37,7 +37,6 @@ import org.hl7.fhir.r4.model.ResearchStudy;
 import org.hl7.fhir.r4.model.ResearchStudy.ResearchStudyStatus;
 import org.junit.Test;
 
-import ca.uhn.fhir.context.FhirContext;
 import dev.dsf.fhir.dao.BinaryDao;
 import dev.dsf.fhir.dao.DocumentReferenceDao;
 import dev.dsf.fhir.dao.OrganizationDao;
@@ -2859,15 +2858,11 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 	@Test
 	public void testCreateLargeBinaryFhirJsonResource1() throws Exception
 	{
-
 		Binary binary = new Binary();
 		binary.setContentType(MediaType.APPLICATION_JSON);
 		// set to be smaller than 20000000 characters
 		binary.setData(("{\"data\": \"" + "a".repeat(14999826) + "\"}").getBytes());
 		getReadAccessHelper().addAll(binary);
-
-		String s = FhirContext.forR4().newJsonParser().encodeResourceToString(binary);
-
 
 		getWebserviceClient().create(binary);
 	}
@@ -2875,15 +2870,11 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 	@Test
 	public void testCreateLargeBinaryFhirJsonResource2() throws Exception
 	{
-
 		Binary binary = new Binary();
 		binary.setContentType(MediaType.APPLICATION_JSON);
 		// set to be larger than 20000000 characters
 		binary.setData(("{\"data\": \"" + "a".repeat(14999999) + "\"}").getBytes());
 		getReadAccessHelper().addAll(binary);
-
-		String s = FhirContext.forR4().newJsonParser().encodeResourceToString(binary);
-
 
 		getWebserviceClient().create(binary);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -38,6 +38,7 @@ import org.hl7.fhir.r4.model.ResearchStudy;
 import org.hl7.fhir.r4.model.ResearchStudy.ResearchStudyStatus;
 import org.junit.Test;
 
+import ca.uhn.fhir.context.FhirContext;
 import dev.dsf.fhir.dao.BinaryDao;
 import dev.dsf.fhir.dao.DocumentReferenceDao;
 import dev.dsf.fhir.dao.OrganizationDao;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -2856,16 +2857,33 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateLargeBinaryFhirJsonResource() throws Exception
+	public void testCreateLargeBinaryFhirJsonResource1() throws Exception
 	{
-		// set to be larger than 20000000 characters
-		//
-		byte[] data = new byte[1204 * 1024 * 32]; // 32 MiB
 
 		Binary binary = new Binary();
 		binary.setContentType(MediaType.APPLICATION_JSON);
-		binary.setData(data);
+		// set to be smaller than 20000000 characters
+		binary.setData(("{\"data\": \"" + "a".repeat(14999826) + "\"}").getBytes());
 		getReadAccessHelper().addAll(binary);
+
+		String s = FhirContext.forR4().newJsonParser().encodeResourceToString(binary);
+
+
+		getWebserviceClient().create(binary);
+	}
+
+	@Test
+	public void testCreateLargeBinaryFhirJsonResource2() throws Exception
+	{
+
+		Binary binary = new Binary();
+		binary.setContentType(MediaType.APPLICATION_JSON);
+		// set to be larger than 20000000 characters
+		binary.setData(("{\"data\": \"" + "a".repeat(14999999) + "\"}").getBytes());
+		getReadAccessHelper().addAll(binary);
+
+		String s = FhirContext.forR4().newJsonParser().encodeResourceToString(binary);
+
 
 		getWebserviceClient().create(binary);
 	}
@@ -2878,7 +2896,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		getReadAccessHelper().addAll(p);
 		Patient created = dao.create(p);
 
-		byte[] data = new byte[1204 * 1024 * 8]; // 8 MiB
+		byte[] data = new byte[1024 * 1024 * 8]; // 8 MiB
 		String securityContext = "Patient/" + created.getIdElement().getIdPart();
 
 		getWebserviceClient().createBinary(new ByteArrayInputStream(data), MediaType.APPLICATION_OCTET_STREAM_TYPE,

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -2856,6 +2856,21 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
+	public void testCreateLargeBinaryFhirJsonResource() throws Exception
+	{
+		// set to be larger than 20000000 characters
+		//
+		byte[] data = new byte[1204 * 1024 * 32]; // 32 MiB
+
+		Binary binary = new Binary();
+		binary.setContentType(MediaType.APPLICATION_JSON);
+		binary.setData(data);
+		getReadAccessHelper().addAll(binary);
+
+		getWebserviceClient().create(binary);
+	}
+
+	@Test
 	public void testCreateLargeBinaryDirect() throws Exception
 	{
 		PatientDao dao = getSpringWebApplicationContext().getBean(PatientDao.class);


### PR DESCRIPTION
This pull request is intended to fix #138.

It uses the [relativly new feature to set a default maximum string size ](https://github.com/FasterXML/jackson-core/pull/1019/files#diff-41ffdb6337d4e68c7ae85301ca9f13fb7fcfe00a3244e3b70a604bf49fa12efeR80) in Jackson.
