### PR TITLE
update hapi fhir version to 6.10.0

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BundleDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BundleDaoJdbc.java
@@ -1,14 +1,11 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 
 import javax.sql.DataSource;
 
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.IdType;
 
 import ca.uhn.fhir.context.FhirContext;
 import dev.dsf.fhir.dao.BundleDao;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BundleDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BundleDaoJdbc.java
@@ -31,14 +31,4 @@ public class BundleDaoJdbc extends AbstractResourceDaoJdbc<Bundle> implements Bu
 		return resource.copy();
 	}
 
-	@Override
-	protected Bundle getResource(ResultSet result, int index) throws SQLException
-	{
-		// TODO Bugfix HAPI is removing version information from bundle.id
-		Bundle bundle = super.getResource(result, index);
-		IdType fixedId = new IdType(bundle.getResourceType().name(), bundle.getIdElement().getIdPart(),
-				bundle.getMeta().getVersionId());
-		bundle.setIdElement(fixedId);
-		return bundle;
-	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
@@ -767,12 +767,13 @@ public abstract class AbstractResourceServiceImpl<D extends ResourceDao<R>, R ex
 		if (resource.isEmpty())
 			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome, hint post with id url?
 
-		Type mode = parameters.getParameter("mode");
-		if (!(mode instanceof CodeType))
+		ParametersParameterComponent mode = parameters.getParameter("mode");
+
+		if (!(mode.getValue() instanceof CodeType))
 			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
 
-		Type profile = parameters.getParameter("profile");
-		if (!(profile instanceof UriType))
+		ParametersParameterComponent profile = parameters.getParameter("profile");
+		if (!(profile.getValue() instanceof UriType))
 			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
 
 		// TODO handle mode and profile parameters
@@ -805,17 +806,18 @@ public abstract class AbstractResourceServiceImpl<D extends ResourceDao<R>, R ex
 		if (getResource(parameters, "resource").isPresent())
 			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
 
-		Type mode = parameters.getParameter("mode");
-		if (!(mode instanceof CodeType) || !(mode instanceof StringType))
+		ParametersParameterComponent mode = parameters.getParameter("mode");
+		if (!(mode.getValue() instanceof CodeType) || !(mode.getValue() instanceof StringType))
 			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-		if (!"profile".equals(((StringType) mode).getValue()))
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-
-		Type profile = parameters.getParameter("profile");
-		if (!(profile instanceof UriType) || !(mode instanceof UrlType) || !(mode instanceof CanonicalType))
+		if (!"profile".equals(((StringType) mode.getValue()).getValue()))
 			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
 
-		UriType profileUri = (UriType) profile;
+		ParametersParameterComponent profile = parameters.getParameter("profile");
+		if (!(profile.getValue() instanceof UriType) || !(mode.getValue() instanceof UrlType)
+				|| !(mode.getValue() instanceof CanonicalType))
+			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
+
+		UriType profileUri = (UriType) profile.getValue();
 
 		Optional<R> read = exceptionHandler.handleSqlAndResourceDeletedException(serverBase, resourceTypeName,
 				() -> dao.read(parameterConverter.toUuid(resourceTypeName, id)));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
@@ -36,7 +36,6 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.Type;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.UrlType;
 import org.slf4j.Logger;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
@@ -18,7 +18,6 @@ import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.StructureDefinition;
-import org.hl7.fhir.r4.model.Type;
 import org.hl7.fhir.r4.model.UriType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
@@ -176,17 +176,17 @@ public class StructureDefinitionServiceImpl extends
 	@Override
 	public Response postSnapshotNew(String snapshotPath, Parameters parameters, UriInfo uri, HttpHeaders headers)
 	{
-		Type urlType = parameters.getParameter("url");
+		ParametersParameterComponent urlType = parameters.getParameter("url");
 		Optional<ParametersParameterComponent> resource = parameters.getParameter().stream()
 				.filter(p -> "resource".equals(p.getName())).findFirst();
 
 		if (urlType != null && resource.isEmpty())
 		{
-			if (!(urlType instanceof StringType || urlType instanceof UriType))
+			if (!(urlType.getValue() instanceof StringType || urlType.getValue() instanceof UriType))
 				return Response.status(Status.BAD_REQUEST).build(); // TODO OperationOutcome
 
 			@SuppressWarnings("unchecked")
-			PrimitiveType<String> url = (PrimitiveType<String>) urlType;
+			PrimitiveType<String> url = (PrimitiveType<String>) urlType.getValue();
 
 			logger.trace("Parameters with url {}", url.getValue());
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/BundleTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/BundleTest.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.hapi;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/BundleTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/BundleTest.java
@@ -123,10 +123,6 @@ public class BundleTest
 
 		Bundle bRead = newXmlParser().parseResource(Bundle.class, bundleTxt);
 		assertEquals("123", bRead.getMeta().getVersionId());
-		assertNull(bRead.getIdElement().getVersionIdPart());
-
-		// FIXME workaround hapi parser bug
-		bRead.setIdElement(bRead.getIdElement().withVersion(bRead.getMeta().getVersionId()));
 		assertEquals("123", bRead.getIdElement().getVersionIdPart());
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/ParametersTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/ParametersTest.java
@@ -36,8 +36,8 @@ public class ParametersTest
 		FhirContext context = FhirContext.forR4();
 		logger.info("Parameters: {}", context.newXmlParser().encodeResourceToString(parameters));
 
-		assertEquals(mode, parameters.getParameter("mode"));
-		assertEquals(uri, parameters.getParameter("uri"));
+		assertEquals(mode, parameters.getParameter("mode").getValue());
+		assertEquals(uri, parameters.getParameter("uri").getValue());
 	}
 
 	@Test
@@ -56,8 +56,8 @@ public class ParametersTest
 		FhirContext context = FhirContext.forR4();
 		logger.info("Parameters: {}", context.newXmlParser().encodeResourceToString(parameters));
 
-		assertEquals(mode, parameters.getParameter("mode"));
-		assertEquals(uri, parameters.getParameter("uri"));
+		assertEquals(mode, parameters.getParameter("mode").getValue());
+		assertEquals(uri, parameters.getParameter("uri").getValue());
 
 		Optional<ParametersParameterComponent> resource = parameters.getParameter().stream()
 				.filter(p -> "resource".equals(p.getName())).findFirst();
@@ -95,6 +95,6 @@ public class ParametersTest
 		FhirContext context = FhirContext.forR4();
 		logger.info("Parameters: {}", context.newXmlParser().encodeResourceToString(parameters));
 
-		assertEquals(uri, parameters.getParameter("url"));
+		assertEquals(uri, parameters.getParameter("url").getValue());
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/ParserTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/ParserTest.java
@@ -43,16 +43,10 @@ public class ParserTest
 		Bundle bundle = fhirContext.newJsonParser().parseResource(Bundle.class, bundleJson);
 		assertNotNull(bundle);
 		assertEquals("1", bundle.getMeta().getVersionId());
-		// TODO HAPI bug -> null
-		// assertEquals("Bundle.id.version", "1", bundle.getIdElement().getVersionIdPart());
-		assertNull("Bug in HAPI fixed, if method returns 1", bundle.getIdElement().getVersionIdPart());
-		// TODO remove workaround in BundleDaoJdbc#getResource if bug is fixed in HAPI
+		assertEquals("Bundle.id.version", "1", bundle.getIdElement().getVersionIdPart());
 	}
 
-	// TODO HAPI bug -> StackOverflowError
-	// TODO remove workaround in WebserviceClientJersey#read(Class, String)
-	// and WebserviceClientJersey#read(Class, String, String)
-	@Test(expected = StackOverflowError.class)
+	@Test
 	public void testParseBundleWithEntriesWithCircularReferences() throws Exception
 	{
 		Organization org = new Organization();
@@ -74,10 +68,7 @@ public class ParserTest
 		configureParser(fhirContext.newXmlParser()).encodeResourceToString(read);
 	}
 
-	// TODO HAPI bug -> StackOverflowError
-	// TODO remove workaround in WebserviceClientJersey#read(Class, String)
-	// and WebserviceClientJersey#read(Class, String, String)
-	@Test(expected = StackOverflowError.class)
+	@Test
 	public void testParseBundleWithEntriesWithCircularReferencesFile() throws Exception
 	{
 		try (InputStream in = Files.newInputStream(Paths.get("src/test/resources/bundle.xml")))

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -2856,6 +2856,32 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
+	public void testCreateLargeBinaryFhirJsonResource1() throws Exception
+	{
+
+		Binary binary = new Binary();
+		binary.setContentType(MediaType.APPLICATION_JSON);
+		// set to be smaller than 20000000 characters
+		binary.setData(("{\"data\": \"" + "a".repeat(14999826) + "\"}").getBytes());
+		getReadAccessHelper().addAll(binary);
+
+		getWebserviceClient().create(binary);
+	}
+
+	@Test
+	public void testCreateLargeBinaryFhirJsonResource2() throws Exception
+	{
+
+		Binary binary = new Binary();
+		binary.setContentType(MediaType.APPLICATION_JSON);
+		// set to be larger than 20000000 characters
+		binary.setData(("{\"data\": \"" + "a".repeat(14999999) + "\"}").getBytes());
+		getReadAccessHelper().addAll(binary);
+
+		getWebserviceClient().create(binary);
+	}
+
+	@Test
 	public void testCreateLargeBinaryDirect() throws Exception
 	{
 		PatientDao dao = getSpringWebApplicationContext().getBean(PatientDao.class);

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireProfileTest.java
@@ -157,8 +157,7 @@ public class QuestionnaireProfileTest
 				result.getMessages().stream()
 						.filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
 								|| ResultSeverityEnum.FATAL.equals(m.getSeverity()))
-						.filter(m -> m.getMessage() != null).filter(m -> m.getMessage().startsWith("type-code"))
-						.count());
+						.filter(m -> m.getMessage() != null).filter(m -> m.getMessage().contains("type-code")).count());
 	}
 
 	private Questionnaire createQuestionnaire(Questionnaire.QuestionnaireItemType type)

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireResponseProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireResponseProfileTest.java
@@ -173,8 +173,8 @@ public class QuestionnaireResponseProfileTest
 						.filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
 								|| ResultSeverityEnum.FATAL.equals(m.getSeverity()))
 						.filter(m -> m.getMessage() != null)
-						.filter(m -> m.getMessage().startsWith("authored-if-completed")
-								|| m.getMessage().startsWith("author-if-completed"))
+						.filter(m -> m.getMessage().contains("authored-if-completed")
+								|| m.getMessage().contains("author-if-completed"))
 						.count());
 	}
 
@@ -194,8 +194,8 @@ public class QuestionnaireResponseProfileTest
 				result.getMessages().stream()
 						.filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
 								|| ResultSeverityEnum.FATAL.equals(m.getSeverity()))
-						.filter(m -> m.getMessage() != null)
-						.filter(m -> m.getMessage().startsWith("author-if-completed")).count());
+						.filter(m -> m.getMessage() != null).filter(m -> m.getMessage().contains("author-if-completed"))
+						.count());
 	}
 
 	private QuestionnaireResponse createQuestionnaireResponseWithBusinessKey(Type type)

--- a/dsf-fhir/dsf-fhir-validation/src/test/resources/fhir/CodeSystem/dsf-test.xml
+++ b/dsf-fhir/dsf-fhir-validation/src/test/resources/fhir/CodeSystem/dsf-test.xml
@@ -1,0 +1,26 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<url value="http://dsf.dev/fhir/CodeSystem/test" />
+	<version value="1.4" />
+	<name value="DSF_Test" />
+	<title value="DSF Test" />
+	<status value="active" />
+	<experimental value="false" />
+	<date value="2023-12-03" />
+	<publisher value="DSF" />
+	<description value="CodeSystem with standard values for a test process" />
+	<caseSensitive value="true" />
+	<hierarchyMeaning value="grouped-by" />
+	<versionNeeded value="false" />
+	<content value="complete" />
+	<concept>
+		<code value="string-example" />
+		<display value="String Example" />
+		<definition value="Example string input value" />
+	</concept>
+</CodeSystem> 

--- a/dsf-fhir/dsf-fhir-validation/src/test/resources/fhir/StructureDefinition/dsf-task-test.xml
+++ b/dsf-fhir/dsf-fhir-validation/src/test/resources/fhir/StructureDefinition/dsf-task-test.xml
@@ -1,0 +1,86 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <meta>
+    <tag>
+      <system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+      <code value="ALL" />
+    </tag>
+  </meta>
+  <url value="http://dsf.dev/fhir/StructureDefinition/task-test" />
+  <version value="1.4" />
+  <name value="testProcess" />
+  <status value="active" />
+  <experimental value="false" />
+  <date value="2023-12-03" />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Task" />
+  <baseDefinition value="http://dsf.dev/fhir/StructureDefinition/task-base" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Task.instantiatesUri">
+      <path value="Task.instantiatesUri" />
+      <fixedUri value="http://dsf.dev/bpe/Process/test/1.4" />
+    </element>
+    <element id="Task.input">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+        <valueString value="Parameter" />
+      </extension>
+      <path value="Task.input" />
+    </element>
+    <element id="Task.input:message-name">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+        <valueString value="Parameter" />
+      </extension>
+      <path value="Task.input" />
+      <sliceName value="message-name" />
+    </element>
+    <element id="Task.input:message-name.value[x]">
+      <path value="Task.input.value[x]" />
+      <fixedString value="test" />
+    </element>
+    <element id="Task.input:correlation-key">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+        <valueString value="Parameter" />
+      </extension>
+      <path value="Task.input" />
+      <sliceName value="correlation-key" />
+      <max value="0" />
+    </element>
+    <element id="Task.input:string-example">
+      <path value="Task.input" />
+      <sliceName value="string-example" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Task.input:string-example.type">
+      <path value="Task.input.type" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://dsf.dev/fhir/ValueSet/test|1.4" />
+      </binding>
+    </element>
+    <element id="Task.input:string-example.type.coding">
+      <path value="Task.input.type.coding" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Task.input:string-example.system">
+      <path value="Task.input.type.coding.system" />
+      <min value="1" />
+      <fixedUri value="http://dsf.dev/fhir/CodeSystem/test" />
+    </element>
+    <element id="Task.input:string-example.type.coding.code">
+      <path value="Task.input.type.coding.code" />
+      <min value="1" />
+      <fixedCode value="string-example" />
+    </element>
+    <element id="Task.input:string-example.value[x]">
+      <path value="Task.input.value[x]" />
+      <type>
+        <code value="string" />
+      </type>
+      <min value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/dsf-fhir/dsf-fhir-validation/src/test/resources/fhir/ValueSet/dsf-test.xml
+++ b/dsf-fhir/dsf-fhir-validation/src/test/resources/fhir/ValueSet/dsf-test.xml
@@ -1,0 +1,24 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<url value="http://dsf.dev/fhir/ValueSet/test" />
+	<version value="1.4" />
+	<name value="DSF_Test" />
+	<title value="DSF Test" />
+	<status value="active" />
+	<experimental value="false" />
+	<date value="2023-12-03" />
+	<publisher value="DSF" />
+	<description value="ValueSet with standard values for a test process" />
+	<immutable value="true" />
+	<compose>
+		<include>
+			<system value="http://dsf.dev/fhir/CodeSystem/test" />
+			<version value="1.4" />
+		</include>
+	</compose>
+</ValueSet> 

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
@@ -428,7 +428,9 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 		logger.debug("HTTP {}: {}", response.getStatusInfo().getStatusCode(),
 				response.getStatusInfo().getReasonPhrase());
 		if (Status.OK.getStatusCode() == response.getStatus())
-			return (Resource) response.readEntity(RESOURCE_TYPES_BY_NAME.get(resourceTypeName));
+			// TODO remove workaround if HAPI bug fixed
+			return referenceCleaner.cleanReferenceResourcesIfBundle(
+					(Resource) response.readEntity(RESOURCE_TYPES_BY_NAME.get(resourceTypeName)));
 		else
 			throw handleError(response);
 	}
@@ -476,7 +478,8 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 		logger.debug("HTTP {}: {}", response.getStatusInfo().getStatusCode(),
 				response.getStatusInfo().getReasonPhrase());
 		if (Status.OK.getStatusCode() == response.getStatus())
-			return response.readEntity(resourceType);
+			// TODO remove workaround if HAPI bug fixed
+			return referenceCleaner.cleanReferenceResourcesIfBundle(response.readEntity(resourceType));
 		else if (oldValue != null && oldValue.hasMeta()
 				&& (oldValue.getMeta().hasVersionId() || oldValue.getMeta().hasLastUpdated())
 				&& Status.NOT_MODIFIED.getStatusCode() == response.getStatus())

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
@@ -428,9 +428,7 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 		logger.debug("HTTP {}: {}", response.getStatusInfo().getStatusCode(),
 				response.getStatusInfo().getReasonPhrase());
 		if (Status.OK.getStatusCode() == response.getStatus())
-			// TODO remove workaround if HAPI bug fixed
-			return referenceCleaner.cleanReferenceResourcesIfBundle(
-					(Resource) response.readEntity(RESOURCE_TYPES_BY_NAME.get(resourceTypeName)));
+			return (Resource) response.readEntity(RESOURCE_TYPES_BY_NAME.get(resourceTypeName));
 		else
 			throw handleError(response);
 	}
@@ -478,8 +476,7 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 		logger.debug("HTTP {}: {}", response.getStatusInfo().getStatusCode(),
 				response.getStatusInfo().getReasonPhrase());
 		if (Status.OK.getStatusCode() == response.getStatus())
-			// TODO remove workaround if HAPI bug fixed
-			return referenceCleaner.cleanReferenceResourcesIfBundle(response.readEntity(resourceType));
+			return response.readEntity(resourceType);
 		else if (oldValue != null && oldValue.hasMeta()
 				&& (oldValue.getMeta().hasVersionId() || oldValue.getMeta().hasLastUpdated())
 				&& Status.NOT_MODIFIED.getStatusCode() == response.getStatus())

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<spring.version>6.0.13</spring.version>
 		<jackson.version>2.15.3</jackson.version>
 		<camunda.version>7.20.0</camunda.version>
-		<hapi.fhir.version>5.1.0</hapi.fhir.version>
+		<hapi.fhir.version>6.10.0</hapi.fhir.version>
 	</properties>
 
 	<name>DSF</name>


### PR DESCRIPTION
Update hapi fhir version to 6.10.0, updated tests and removed some bugfixes, implemented test for string size restriction of json content (fixes #138).

No manual tests have yet been conducted with the published process plugins.