### PR TITLE
Issues/137 142 static code analysis logging fix

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractServiceDelegate.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractServiceDelegate.java
@@ -148,7 +148,9 @@ public abstract class AbstractServiceDelegate implements JavaDelegate, Initializ
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
+			logger.debug("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
+			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task),
+					e.getClass().getName(), e.getMessage());
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractServiceDelegate.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractServiceDelegate.java
@@ -70,7 +70,7 @@ public abstract class AbstractServiceDelegate implements JavaDelegate, Initializ
 		// Error boundary event, do not stop process execution
 		catch (BpmnError error)
 		{
-			logger.debug("Error while executing service delegate " + getClass().getName(), error);
+			logger.debug("Error while executing service delegate {}", getClass().getName(), error);
 			logger.error(
 					"Process {} encountered error boundary event in step {} for task {}, error-code: {}, message: {}",
 					execution.getProcessDefinitionId(), execution.getActivityInstanceId(),
@@ -82,7 +82,7 @@ public abstract class AbstractServiceDelegate implements JavaDelegate, Initializ
 		// Not an error boundary event, stop process execution
 		catch (Exception exception)
 		{
-			logger.debug("Error while executing service delegate " + getClass().getName(), exception);
+			logger.debug("Error while executing service delegate {}", getClass().getName(), exception);
 			logger.error("Process {} has fatal error in step {} for task {}, reason: {} - {}",
 					execution.getProcessDefinitionId(), execution.getActivityInstanceId(),
 					api.getTaskHelper().getLocalVersionlessAbsoluteUrl(variables.getStartTask()),
@@ -148,7 +148,7 @@ public abstract class AbstractServiceDelegate implements JavaDelegate, Initializ
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to update Task " + api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
+			logger.error("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
@@ -227,7 +227,7 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 	protected void handleIntermediateThrowEventError(DelegateExecution execution, Variables variables,
 			Exception exception, String errorMessage)
 	{
-		logger.debug("Error while executing Task message send " + getClass().getName(), exception);
+		logger.debug("Error while executing Task message send {}", getClass().getName(), exception);
 		logger.error("Process {} has fatal error in step {} for task {}, reason: {} - {}",
 				execution.getProcessDefinitionId(), execution.getActivityInstanceId(),
 				api.getTaskHelper().getLocalVersionlessAbsoluteUrl(variables.getStartTask()),
@@ -242,7 +242,7 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 	protected void handleEndEventError(DelegateExecution execution, Variables variables, Exception exception,
 			String errorMessage)
 	{
-		logger.debug("Error while executing Task message send " + getClass().getName(), exception);
+		logger.debug("Error while executing Task message send {}", getClass().getName(), exception);
 		logger.error("Process {} has fatal error in step {} for task {}, reason: {} - {}",
 				execution.getProcessDefinitionId(), execution.getActivityInstanceId(),
 				api.getTaskHelper().getLocalVersionlessAbsoluteUrl(variables.getStartTask()),
@@ -275,8 +275,8 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 		// if we are not a multi instance message send task or all sends have failed (targets emtpy)
 		else
 		{
-			logger.debug("Error while executing Task message send " + getClass().getName(), exception);
-			logger.error("Process {} has fatal error in step {} for task {}, last reason: {} - ",
+			logger.debug("Error while executing Task message send {}", getClass().getName(), exception);
+			logger.error("Process {} has fatal error in step {} for task {}, last reason: {} - {}",
 					execution.getProcessDefinitionId(), execution.getActivityInstanceId(),
 					api.getTaskHelper().getLocalVersionlessAbsoluteUrl(variables.getStartTask()),
 					exception.getClass().getName(), exception.getMessage());
@@ -342,7 +342,8 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to update Task " + api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
+			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e.getClass().getName(), e.getMessage());
+			logger.debug("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
@@ -197,9 +197,9 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 		catch (Exception e)
 		{
 			String exceptionMessage = e.getMessage();
-			if (e instanceof WebApplicationException && (e.getMessage() == null || e.getMessage().isBlank()))
+			if (e instanceof WebApplicationException w && (e.getMessage() == null || e.getMessage().isBlank()))
 			{
-				StatusType statusInfo = ((WebApplicationException) e).getResponse().getStatusInfo();
+				StatusType statusInfo = w.getResponse().getStatusInfo();
 				exceptionMessage = statusInfo.getStatusCode() + " " + statusInfo.getReasonPhrase();
 			}
 

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
@@ -203,6 +203,7 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 				exceptionMessage = statusInfo.getStatusCode() + " " + statusInfo.getReasonPhrase();
 			}
 
+			logger.debug("Error while sending Task", e);
 			String errorMessage = "Task " + instantiatesCanonical + " send failed [recipient: "
 					+ target.getOrganizationIdentifierValue() + ", endpoint: " + target.getEndpointIdentifierValue()
 					+ ", businessKey: " + businessKey
@@ -210,7 +211,6 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 					+ ", message: " + messageName + ", error: " + e.getClass().getName() + " - " + exceptionMessage
 					+ "]";
 			logger.warn(errorMessage);
-			logger.debug("Error while sending Task", e);
 
 			if (execution.getBpmnModelElementInstance() instanceof IntermediateThrowEvent)
 				handleIntermediateThrowEventError(execution, variables, e, errorMessage);
@@ -342,9 +342,9 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 		}
 		catch (Exception e)
 		{
+			logger.debug("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task),
 					e.getClass().getName(), e.getMessage());
-			logger.debug("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/AbstractTaskMessageSend.java
@@ -342,7 +342,8 @@ public abstract class AbstractTaskMessageSend implements JavaDelegate, Initializ
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e.getClass().getName(), e.getMessage());
+			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task),
+					e.getClass().getName(), e.getMessage());
 			logger.debug("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/DefaultUserTaskListener.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/DefaultUserTaskListener.java
@@ -255,9 +255,9 @@ public class DefaultUserTaskListener implements TaskListener, InitializingBean
 		}
 		catch (Exception e)
 		{
+			logger.debug("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task),
 					e.getClass().getName(), e.getMessage());
-			logger.error("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/DefaultUserTaskListener.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/bpe/v1/activity/DefaultUserTaskListener.java
@@ -95,7 +95,7 @@ public class DefaultUserTaskListener implements TaskListener, InitializingBean
 		}
 		catch (Exception exception)
 		{
-			logger.debug("Error while executing user task listener " + getClass().getName(), exception);
+			logger.debug("Error while executing user task listener {}", getClass().getName(), exception);
 			logger.error("Process {} has fatal error in step {} for task {}, reason: {} - {}",
 					execution.getProcessDefinitionId(), execution.getActivityInstanceId(),
 					api.getTaskHelper().getLocalVersionlessAbsoluteUrl(variables.getStartTask()),
@@ -255,7 +255,9 @@ public class DefaultUserTaskListener implements TaskListener, InitializingBean
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to update Task " + api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
+			logger.error("Unable to update Task {}: {} - {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task),
+					e.getClass().getName(), e.getMessage());
+			logger.error("Unable to update Task {}", api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/test/java/dev/dsf/bpe/start/ExampleStarter.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/test/java/dev/dsf/bpe/start/ExampleStarter.java
@@ -106,9 +106,8 @@ public class ExampleStarter
 	{
 		FhirWebserviceClient client = createClient(baseUrl);
 
-		if (resource instanceof Bundle)
+		if (resource instanceof Bundle bundle)
 		{
-			Bundle bundle = (Bundle) resource;
 			bundle.getEntry().stream().map(e -> e.getResource().getResourceType()).filter(ResourceType.Task::equals)
 					.findFirst()
 					.orElseThrow(() -> new IllegalArgumentException("Bundle does not contain a Task resource"));

--- a/dsf-bpe/dsf-bpe-server-jetty/src/main/java/dev/dsf/bpe/BpeJettyServer.java
+++ b/dsf-bpe/dsf-bpe-server-jetty/src/main/java/dev/dsf/bpe/BpeJettyServer.java
@@ -9,7 +9,7 @@ import dev.dsf.common.jetty.JettyServer;
 import dev.dsf.common.jetty.Log4jInitializer;
 import dev.dsf.tools.db.DbMigrator;
 
-public class BpeJettyServer
+public final class BpeJettyServer
 {
 	static
 	{
@@ -17,6 +17,10 @@ public class BpeJettyServer
 		SLF4JBridgeHandler.install();
 
 		Log4jInitializer.initializeLog4j();
+	}
+
+	private BpeJettyServer()
+	{
 	}
 
 	public static void main(String[] args)

--- a/dsf-bpe/dsf-bpe-server-jetty/src/main/java/dev/dsf/bpe/BpeJettyServerHttps.java
+++ b/dsf-bpe/dsf-bpe-server-jetty/src/main/java/dev/dsf/bpe/BpeJettyServerHttps.java
@@ -9,7 +9,7 @@ import dev.dsf.common.jetty.JettyServer;
 import dev.dsf.common.jetty.Log4jInitializer;
 import dev.dsf.tools.db.DbMigrator;
 
-public class BpeJettyServerHttps
+public final class BpeJettyServerHttps
 {
 	static
 	{
@@ -17,6 +17,10 @@ public class BpeJettyServerHttps
 		SLF4JBridgeHandler.install();
 
 		Log4jInitializer.initializeLog4j();
+	}
+
+	private BpeJettyServerHttps()
+	{
 	}
 
 	public static void main(String[] args)

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/FallbackSerializerFactoryImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/FallbackSerializerFactoryImpl.java
@@ -135,14 +135,13 @@ public class FallbackSerializerFactoryImpl implements FallbackSerializerFactory
 			return null;
 	}
 
-	@SuppressWarnings("rawtypes")
 	private String getName(TypedValue value)
 	{
 		if (value == null)
 			return null;
 
-		if (value instanceof PrimitiveValue)
-			return ((PrimitiveValue) value).getType().getJavaType().getName();
+		if (value instanceof PrimitiveValue p)
+			return p.getType().getJavaType().getName();
 		else if (value.getValue() != null)
 			return value.getClass().getName();
 		else if (value.getType() != null)

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateActivityBehavior.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateActivityBehavior.java
@@ -43,11 +43,9 @@ public class MultiVersionClassDelegateActivityBehavior extends ClassDelegateActi
 			return new ServiceTaskJavaDelegateActivityBehavior(d);
 
 		else
-		{
 			throw LOG.missingDelegateParentClassException(delegateInstance.getClass().getName(),
 					JavaDelegate.class.getName(), ActivityBehavior.class.getName());
-		}
-	};
+	}
 
 	private Object instantiateDelegate(ProcessIdAndVersion processKeyAndVersion, String className,
 			List<FieldDeclaration> fieldDeclarations)

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateActivityBehavior.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateActivityBehavior.java
@@ -36,14 +36,12 @@ public class MultiVersionClassDelegateActivityBehavior extends ClassDelegateActi
 
 		Object delegateInstance = instantiateDelegate(processKeyAndVersion, className, fieldDeclarations);
 
-		if (delegateInstance instanceof ActivityBehavior)
-		{
-			return new CustomActivityBehavior((ActivityBehavior) delegateInstance);
-		}
-		else if (delegateInstance instanceof JavaDelegate)
-		{
-			return new ServiceTaskJavaDelegateActivityBehavior((JavaDelegate) delegateInstance);
-		}
+		if (delegateInstance instanceof ActivityBehavior b)
+			return new CustomActivityBehavior(b);
+
+		else if (delegateInstance instanceof JavaDelegate d)
+			return new ServiceTaskJavaDelegateActivityBehavior(d);
+
 		else
 		{
 			throw LOG.missingDelegateParentClassException(delegateInstance.getClass().getName(),

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateExecutionListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateExecutionListener.java
@@ -54,10 +54,9 @@ public class MultiVersionClassDelegateExecutionListener extends ClassDelegateExe
 	{
 		Object delegateInstance = instantiateDelegate(processKeyAndVersion, className, fieldDeclarations);
 
-		if (delegateInstance instanceof ExecutionListener)
-		{
-			return (ExecutionListener) delegateInstance;
-		}
+		if (delegateInstance instanceof ExecutionListener l)
+			return l;
+
 		else
 		{
 			throw new ProcessEngineException(

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateExecutionListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateExecutionListener.java
@@ -58,10 +58,8 @@ public class MultiVersionClassDelegateExecutionListener extends ClassDelegateExe
 			return l;
 
 		else
-		{
 			throw new ProcessEngineException(
 					delegateInstance.getClass().getName() + " doesn't implement " + ExecutionListener.class);
-		}
 	}
 
 	private Object instantiateDelegate(ProcessIdAndVersion processKeyAndVersion, String className,

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateTaskListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateTaskListener.java
@@ -57,10 +57,8 @@ public class MultiVersionClassDelegateTaskListener extends ClassDelegateTaskList
 			return l;
 
 		else
-		{
 			throw new ProcessEngineException(
 					delegateInstance.getClass().getName() + " doesn't implement " + TaskListener.class);
-		}
 	}
 
 	private Object instantiateDelegate(ProcessIdAndVersion processKeyAndVersion, String className,

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateTaskListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateTaskListener.java
@@ -53,10 +53,9 @@ public class MultiVersionClassDelegateTaskListener extends ClassDelegateTaskList
 	{
 		Object delegateInstance = instantiateDelegate(processKeyAndVersion, className, fieldDeclarations);
 
-		if (delegateInstance instanceof TaskListener)
-		{
-			return (TaskListener) delegateInstance;
-		}
+		if (delegateInstance instanceof TaskListener l)
+			return l;
+
 		else
 		{
 			throw new ProcessEngineException(

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/FhirClientProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/FhirClientProviderImpl.java
@@ -200,7 +200,9 @@ public class FhirClientProviderImpl implements FhirClientProvider, InitializingB
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while disconnecting websocket client", e);
+				logger.debug("Error while disconnecting websocket client", e);
+				logger.warn("Error while disconnecting websocket client: {} - {}", e.getClass().getName(),
+						e.getMessage());
 			}
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/EndListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/EndListener.java
@@ -47,7 +47,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 			updateIfInprogress(task);
 			boolean subProcess = execution.getParentId() != null
 					&& !execution.getParentId().equals(execution.getProcessInstanceId());
-			logEnd(logger, subProcess, task, subProcess ? variables.getStartTask() : null);
+			logEnd(subProcess, task, subProcess ? variables.getStartTask() : null);
 		}
 
 		variables.onEnd();
@@ -84,7 +84,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 		}
 	}
 
-	private void logEnd(Logger logger, boolean subProcess, Task endTask, Task mainTask)
+	private void logEnd(boolean subProcess, Task endTask, Task mainTask)
 	{
 		String processUrl = endTask.getInstantiatesCanonical();
 		String businessKey = getFirstInputParameter(endTask, BpmnMessage.businessKey());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/EndListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/EndListener.java
@@ -78,7 +78,9 @@ public class EndListener extends AbstractListener implements ExecutionListener
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to update Task " + getLocalVersionlessAbsoluteUrl(task), e);
+			logger.error("Unable to update Task {}: {} - {}", getLocalVersionlessAbsoluteUrl(task),
+					e.getClass().getName(), e.getMessage());
+			logger.debug("Unable to update Task {}", getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 
@@ -111,7 +113,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 						processUrl, getCurrentTime(), endTaskUrl, requester, businessKey, correlationKey);
 			else
 				logger.info("Process {} finished at {} [task: {}, requester: {}, business-key: {}]", processUrl,
-						getCurrentTime(), endTaskUrl, requester, businessKey, correlationKey);
+						getCurrentTime(), endTaskUrl, requester, businessKey);
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/EndListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/EndListener.java
@@ -78,9 +78,9 @@ public class EndListener extends AbstractListener implements ExecutionListener
 		}
 		catch (Exception e)
 		{
+			logger.debug("Unable to update Task {}", getLocalVersionlessAbsoluteUrl(task), e);
 			logger.error("Unable to update Task {}: {} - {}", getLocalVersionlessAbsoluteUrl(task),
 					e.getClass().getName(), e.getMessage());
-			logger.debug("Unable to update Task {}", getLocalVersionlessAbsoluteUrl(task), e);
 		}
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
@@ -372,7 +372,7 @@ public class SmtpMailService implements MailService, InitializingBean
 			Optional<PrivateKey> pivateKey = getFirstPrivateKey(signStore, signStorePassword);
 			if (pivateKey.isEmpty())
 			{
-				logger.warn("Mail signing certificate store has no private key, not signing mails", fromAddress);
+				logger.warn("Mail signing certificate store has no private key, not signing mails");
 				return null;
 			}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
@@ -281,6 +281,7 @@ public class SmtpMailService implements MailService, InitializingBean
 		}
 		catch (AddressException e)
 		{
+			logger.debug("Unable to create {} from {}", InternetAddress.class.getName(), fromAddress, e);
 			logger.warn("Unable to create {} from {}: {} - {}", InternetAddress.class.getName(), fromAddress,
 					e.getClass().getName(), e.getMessage());
 
@@ -347,7 +348,9 @@ public class SmtpMailService implements MailService, InitializingBean
 		}
 		catch (UnrecoverableKeyException | KeyManagementException | KeyStoreException | NoSuchAlgorithmException e)
 		{
+			logger.debug("Unable to create custom ssl socket factory", e);
 			logger.warn("Unable to create custom ssl socket factory: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -535,7 +538,9 @@ public class SmtpMailService implements MailService, InitializingBean
 		}
 		catch (MessagingException e)
 		{
+			logger.debug("Unable to send message", e);
 			logger.warn("Unable to send message: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
@@ -583,19 +583,19 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		}
 		catch (BeanCreationException e)
 		{
-			logger.error("Unable to create spring application context for process plugin {}-{}: {} {}",
+			logger.error("Unable to create spring application context for process plugin {}-{}: {} - {}",
 					getDefinitionName(), getDefinitionVersion(), e.getClass().getSimpleName(), e.getMessage());
-			logger.debug("Unable to create spring application context for process plugin " + getDefinitionName() + "-"
-					+ getDefinitionVersion() + ", bean with error " + e.getBeanName(), e);
+			logger.debug("Unable to create spring application context for process plugin {}-{}, bean with error {}",
+					getDefinitionName(), getDefinitionVersion(), e.getBeanName(), e);
 
 			return null;
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to create spring application context for process plugin {}-{}: {} {}",
+			logger.error("Unable to create spring application context for process plugin {}-{}: {} - {}",
 					getDefinitionName(), getDefinitionVersion(), e.getClass().getSimpleName(), e.getMessage());
-			logger.debug("Unable to create spring application context for process plugin " + getDefinitionName() + "-"
-					+ getDefinitionVersion(), e);
+			logger.debug("Unable to create spring application context for process plugin {}-{}", getDefinitionName(),
+					getDefinitionVersion(), e);
 
 			return null;
 		}
@@ -701,6 +701,9 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			{
 				logger.warn("Ignoring BPMN model {} from process plugin {}-{}: {} - {}", file, getDefinitionName(),
 						getDefinitionVersion(), e.getClass().getName(), e.getMessage());
+				logger.debug("Ignoring BPMN model {} from process plugin {}-{}", file, getDefinitionName(),
+						getDefinitionVersion(), e);
+
 				return null;
 			}
 		};
@@ -732,6 +735,8 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		{
 			logger.warn("BPMN file {} not valid: {} - {}", fileAndModel.getFile(), e.getClass().getName(),
 					e.getMessage());
+			logger.debug("BPMN file {} not valid", fileAndModel.getFile(), e);
+
 			return false;
 		}
 
@@ -915,8 +920,8 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		{
 			logger.warn("{} '{}' defined in process {}, element {} not found", expectedInterface.getSimpleName(),
 					className, processKeyAndVersion.toString(), elementId);
-			logger.debug(expectedInterface.getSimpleName() + " '" + className + "' defined in process "
-					+ processKeyAndVersion.toString() + " not found", e);
+			logger.debug("{} '{}' defined in process {}, element {} not found", expectedInterface.getSimpleName(),
+					className, processKeyAndVersion.toString(), elementId, e);
 			return null;
 		}
 	}
@@ -1045,6 +1050,9 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			{
 				logger.warn("Ignoring FHIR resource {} from process plugin {}-{}: {} - {}", file, getDefinitionName(),
 						getDefinitionVersion(), e.getClass().getName(), e.getMessage());
+				logger.debug("Ignoring FHIR resource {} from process plugin {}-{}", file, getDefinitionName(),
+						getDefinitionVersion(), e);
+
 				return null;
 			}
 		};

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
@@ -579,6 +579,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 					.toArray(Class<?>[]::new));
 			context.setEnvironment(environment);
 			context.refresh();
+
 			return context;
 		}
 		catch (BeanCreationException e)
@@ -615,6 +616,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			{
 				logger.warn("Ignoring BPMN model {} from process plugin {}-{}: Filename not ending in '{}'", file,
 						getDefinitionName(), getDefinitionVersion(), BPMN_SUFFIX);
+
 				return null;
 			}
 
@@ -632,6 +634,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 					logger.warn(
 							"Ignoring BPMN model {} from process plugin {}-{}: File not readable, process plugin class loader getResourceAsStream returned null",
 							file, getDefinitionName(), getDefinitionVersion());
+
 					return null;
 				}
 
@@ -914,6 +917,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		try
 		{
 			ClassLoader classLoader = getProcessPluginClassLoader();
+
 			return classLoader.loadClass(className);
 		}
 		catch (ClassNotFoundException e)
@@ -922,6 +926,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 					className, processKeyAndVersion.toString(), elementId);
 			logger.debug("{} '{}' defined in process {}, element {} not found", expectedInterface.getSimpleName(),
 					className, processKeyAndVersion.toString(), elementId, e);
+
 			return null;
 		}
 	}
@@ -934,12 +939,14 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		{
 			logger.warn("Unable to find prototype bean of type {} for element {} in process {}", serviceClass.getName(),
 					elementId, processKeyAndVersion.toString());
+
 			return false;
 		}
 		else if (beanNames.length > 1)
 		{
 			logger.warn("Unable to find unique prototype bean of type {} for element {} in process {}, found {}",
 					serviceClass.getName(), elementId, processKeyAndVersion.toString(), beanNames.length);
+
 			return false;
 		}
 		else
@@ -986,6 +993,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			{
 				logger.warn("Ignoring FHIR resource {} from process plugin {}-{}: Filename not ending in '{}' or '{}'",
 						file, getDefinitionName(), getDefinitionVersion(), JSON_SUFFIX, XML_SUFFIX);
+
 				return null;
 			}
 
@@ -1043,6 +1051,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 					logger.warn(
 							"Ignoring FHIR resource {} from process plugin {}-{}: Not a ActivityDefinition, CodeSystem, Library, Measure, NamingSystem, Questionnaire, StructureDefinition, Task or ValueSet",
 							file, getDefinitionName(), getDefinitionVersion());
+
 					return null;
 				}
 			}
@@ -1310,6 +1319,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 						"Ignoring BPMN model {} from process plugin {}-{}: No FHIR metadata resources found for process-id '{}'",
 						model.getFile(), getDefinitionName(), getDefinitionVersion(),
 						model.getProcessIdAndVersion().getId());
+
 				return false;
 			}
 
@@ -1322,6 +1332,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 						"Ignoring BPMN model {} from process plugin {}-{}: No ActivityDefinition found for process-id '{}'",
 						model.getFile(), getDefinitionName(), getDefinitionVersion(),
 						model.getProcessIdAndVersion().getId());
+
 				return false;
 			}
 
@@ -1339,6 +1350,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 							"Ignoring BPMN model {} from process plugin {}-{}: Found ActivityDefinition.url does not match process id (url: '{}' vs. process-id '{}')",
 							model.getFile(), getDefinitionName(), getDefinitionVersion(), url,
 							model.getProcessIdAndVersion().getId());
+
 					return false;
 				}
 			}
@@ -1372,7 +1384,7 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			ProcessIdAndVersion expectedProcessIdAndVersion, FileAndResource fileAndResource)
 	{
 		String instantiatesCanonical = ((Task) fileAndResource.getResource()).getInstantiatesCanonical();
-		String identifierValue = TaskIdentifier.findFirst(((Task) fileAndResource.getResource()))
+		String identifierValue = TaskIdentifier.findFirst((Task) fileAndResource.getResource())
 				.map(Identifier::getValue).get();
 
 		Matcher instantiatesCanonicalMatcher = INSTANTIATES_CANONICAL_PATTERN.matcher(instantiatesCanonical);

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
@@ -1020,23 +1020,23 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 
 				IBaseResource resource = newParser(file).parseResource(content);
 
-				if (resource instanceof ActivityDefinition && isValid((ActivityDefinition) resource, file))
+				if (resource instanceof ActivityDefinition a && isValid(a, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof CodeSystem && isValid((CodeSystem) resource, file))
+				else if (resource instanceof CodeSystem c && isValid(c, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof Library && isValid((Library) resource, file))
+				else if (resource instanceof Library l && isValid(l, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof Measure && isValid((Measure) resource, file))
+				else if (resource instanceof Measure m && isValid(m, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof NamingSystem && isValid((NamingSystem) resource, file))
+				else if (resource instanceof NamingSystem n && isValid(n, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof Questionnaire && isValid((Questionnaire) resource, file))
+				else if (resource instanceof Questionnaire q && isValid(q, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof StructureDefinition && isValid((StructureDefinition) resource, file))
+				else if (resource instanceof StructureDefinition s && isValid(s, file))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof Task && isValid((Task) resource, file, localOrganizationIdentifierValue))
+				else if (resource instanceof Task t && isValid(t, file, localOrganizationIdentifierValue))
 					return FileAndResource.of(file, (Resource) resource);
-				else if (resource instanceof ValueSet && isValid((ValueSet) resource, file))
+				else if (resource instanceof ValueSet v && isValid(v, file))
 					return FileAndResource.of(file, (Resource) resource);
 				else
 				{

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
@@ -584,19 +584,19 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		}
 		catch (BeanCreationException e)
 		{
-			logger.error("Unable to create spring application context for process plugin {}-{}: {} - {}",
-					getDefinitionName(), getDefinitionVersion(), e.getClass().getSimpleName(), e.getMessage());
 			logger.debug("Unable to create spring application context for process plugin {}-{}, bean with error {}",
 					getDefinitionName(), getDefinitionVersion(), e.getBeanName(), e);
+			logger.error("Unable to create spring application context for process plugin {}-{}: {} - {}",
+					getDefinitionName(), getDefinitionVersion(), e.getClass().getName(), e.getMessage());
 
 			return null;
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to create spring application context for process plugin {}-{}: {} - {}",
-					getDefinitionName(), getDefinitionVersion(), e.getClass().getSimpleName(), e.getMessage());
 			logger.debug("Unable to create spring application context for process plugin {}-{}", getDefinitionName(),
 					getDefinitionVersion(), e);
+			logger.error("Unable to create spring application context for process plugin {}-{}: {} - {}",
+					getDefinitionName(), getDefinitionVersion(), e.getClass().getName(), e.getMessage());
 
 			return null;
 		}
@@ -702,10 +702,10 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			}
 			catch (IOException e)
 			{
-				logger.warn("Ignoring BPMN model {} from process plugin {}-{}: {} - {}", file, getDefinitionName(),
-						getDefinitionVersion(), e.getClass().getName(), e.getMessage());
 				logger.debug("Ignoring BPMN model {} from process plugin {}-{}", file, getDefinitionName(),
 						getDefinitionVersion(), e);
+				logger.warn("Ignoring BPMN model {} from process plugin {}-{}: {} - {}", file, getDefinitionName(),
+						getDefinitionVersion(), e.getClass().getName(), e.getMessage());
 
 				return null;
 			}
@@ -736,9 +736,9 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		}
 		catch (Exception e)
 		{
+			logger.debug("BPMN file {} not valid", fileAndModel.getFile(), e);
 			logger.warn("BPMN file {} not valid: {} - {}", fileAndModel.getFile(), e.getClass().getName(),
 					e.getMessage());
-			logger.debug("BPMN file {} not valid", fileAndModel.getFile(), e);
 
 			return false;
 		}
@@ -922,10 +922,11 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 		}
 		catch (ClassNotFoundException e)
 		{
-			logger.warn("{} '{}' defined in process {}, element {} not found", expectedInterface.getSimpleName(),
-					className, processKeyAndVersion.toString(), elementId);
 			logger.debug("{} '{}' defined in process {}, element {} not found", expectedInterface.getSimpleName(),
 					className, processKeyAndVersion.toString(), elementId, e);
+			logger.warn("{} '{}' defined in process {}, element {} not found: {} - {}",
+					expectedInterface.getSimpleName(), className, processKeyAndVersion.toString(), elementId,
+					e.getClass().getName(), e.getMessage());
 
 			return null;
 		}
@@ -1057,10 +1058,10 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 			}
 			catch (IOException e)
 			{
-				logger.warn("Ignoring FHIR resource {} from process plugin {}-{}: {} - {}", file, getDefinitionName(),
-						getDefinitionVersion(), e.getClass().getName(), e.getMessage());
 				logger.debug("Ignoring FHIR resource {} from process plugin {}-{}", file, getDefinitionName(),
 						getDefinitionVersion(), e);
+				logger.warn("Ignoring FHIR resource {} from process plugin {}-{}: {} - {}", file, getDefinitionName(),
+						getDefinitionVersion(), e.getClass().getName(), e.getMessage());
 
 				return null;
 			}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/BpmnProcessStateChangeServiceImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/BpmnProcessStateChangeServiceImpl.java
@@ -60,7 +60,10 @@ public class BpmnProcessStateChangeServiceImpl implements BpmnProcessStateChange
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while retrieving process states from db", e);
+			logger.debug("Error while retrieving process states from db", e);
+			logger.warn("Error while retrieving process states from db: {} - {}", e.getClass().getName(),
+					e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -159,7 +162,9 @@ public class BpmnProcessStateChangeServiceImpl implements BpmnProcessStateChange
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while updating process states in db", e);
+			logger.debug("Error while updating process states in db", e);
+			logger.warn("Error while updating process states in db: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/BpmnProcessStateChangeServiceImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/BpmnProcessStateChangeServiceImpl.java
@@ -98,7 +98,7 @@ public class BpmnProcessStateChangeServiceImpl implements BpmnProcessStateChange
 
 			newProcessStates.put(process, newState);
 
-			logger.debug("{}: {} -> {}", process.toString(), oldState, newState);
+			logger.debug("Process {} state change: {} -> {}", process.toString(), oldState, newState);
 
 			// NEW -> ACTIVE : - (new process active by default)
 			// NEW -> DRAFT : - (new process active by default)

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
@@ -142,8 +142,7 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 		Bundle batchBundle = new Bundle();
 		batchBundle.setType(BundleType.BATCH);
 
-		List<BundleEntryComponent> entries = resourceValues.stream()
-				.map(r -> r.toBundleEntry(localWebserviceClient.getBaseUrl())).collect(Collectors.toList());
+		List<BundleEntryComponent> entries = resourceValues.stream().map(ProcessesResource::toBundleEntry).toList();
 		batchBundle.setEntry(entries);
 
 		try
@@ -262,7 +261,7 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 						resource.getSearchBundleEntryUrl(), entry.getResponse().getStatus());
 			}
 			else if (!entry.hasResource() || !(entry.getResource() instanceof Bundle b)
-					|| !(BundleType.SEARCHSET.equals(b.getType())))
+					|| !BundleType.SEARCHSET.equals(b.getType()))
 			{
 				logger.warn("Response for {} not a searchset Bundle, missing resource will not be added",
 						resource.getSearchBundleEntryUrl());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
@@ -166,17 +166,23 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 				}
 				catch (SQLException e)
 				{
-					logger.error("Error while adding process plugin resource to the db", e);
+					logger.debug("Error while adding process plugin resource to the db", e);
+					logger.warn("Error while adding process plugin resource to the db: {} - {}", e.getClass().getName(),
+							e.getMessage());
+
 					throw new RuntimeException(e);
 				}
 			}
 		}
 		catch (Exception e)
 		{
-			logger.warn("Error while executing process plugins resource bundle: {}", e.getMessage());
+			logger.debug("Error while executing process plugins resource bundle", e);
+			logger.warn("Error while executing process plugins resource bundle: {} - {}", e.getClass().getName(),
+					e.getMessage());
 			logger.warn(
 					"Resources in FHIR server may not be consistent, please check resources and execute the following bundle if necessary: {}",
 					fhirContext.newJsonParser().encodeResourceToString(batchBundle));
+
 			throw e;
 		}
 	}
@@ -388,7 +394,10 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while retrieving resource infos from db", e);
+			logger.debug("Error while retrieving resource infos from db", e);
+			logger.warn("Error while retrieving resource infos from db: {} - {}", e.getClass().getName(),
+					e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
@@ -261,8 +261,8 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 				logger.warn("Response status for {} not 200 OK but {}, missing resource will not be added",
 						resource.getSearchBundleEntryUrl(), entry.getResponse().getStatus());
 			}
-			else if (!entry.hasResource() || !(entry.getResource() instanceof Bundle)
-					|| !(BundleType.SEARCHSET.equals(((Bundle) entry.getResource()).getType())))
+			else if (!entry.hasResource() || !(entry.getResource() instanceof Bundle b)
+					|| !(BundleType.SEARCHSET.equals(b.getType())))
 			{
 				logger.warn("Response for {} not a searchset Bundle, missing resource will not be added",
 						resource.getSearchBundleEntryUrl());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginLoaderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginLoaderImpl.java
@@ -84,7 +84,9 @@ public class ProcessPluginLoaderImpl implements ProcessPluginLoader, Initializin
 		}
 		catch (IOException e)
 		{
-			logger.warn("Error loading process plugins", e);
+			logger.debug("Error loading process plugins", e);
+			logger.warn("Error loading process plugins: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -132,8 +134,10 @@ public class ProcessPluginLoaderImpl implements ProcessPluginLoader, Initializin
 		}
 		catch (Exception e)
 		{
-			logger.warn("Ignoring {}: Unable to load process plugin {} - {}", jar.toString(), e.getClass().getName(),
+			logger.debug("Ignoring {}: Unable to load process plugin", jar.toString(), e);
+			logger.warn("Ignoring {}: Unable to load process plugin: {} - {}", jar.toString(), e.getClass().getName(),
 					e.getMessage());
+
 			return null;
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginManagerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginManagerImpl.java
@@ -209,8 +209,9 @@ public class ProcessPluginManagerImpl implements ProcessPluginManager, Initializ
 				logger.warn("Error while executing {} bean {} for process plugin {}, {} - {}",
 						ProcessPluginDeploymentStateListener.class.getName(), entry.getKey(),
 						plugin.getJarFile().toString(), e.getClass().getName(), e.getMessage());
-				logger.debug("Error while executing " + ProcessPluginDeploymentStateListener.class.getName() + " bean "
-						+ entry.getKey() + " for process plugin " + plugin.getJarFile().toString(), e);
+				logger.debug("Error while executing {} bean {} for process plugin {}",
+						ProcessPluginDeploymentStateListener.class.getName(), entry.getKey(),
+						plugin.getJarFile().toString(), e);
 			}
 		};
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginManagerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginManagerImpl.java
@@ -206,12 +206,12 @@ public class ProcessPluginManagerImpl implements ProcessPluginManager, Initializ
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while executing {} bean {} for process plugin {}, {} - {}",
-						ProcessPluginDeploymentStateListener.class.getName(), entry.getKey(),
-						plugin.getJarFile().toString(), e.getClass().getName(), e.getMessage());
 				logger.debug("Error while executing {} bean {} for process plugin {}",
 						ProcessPluginDeploymentStateListener.class.getName(), entry.getKey(),
 						plugin.getJarFile().toString(), e);
+				logger.warn("Error while executing {} bean {} for process plugin {}: {} - {}",
+						ProcessPluginDeploymentStateListener.class.getName(), entry.getKey(),
+						plugin.getJarFile().toString(), e.getClass().getName(), e.getMessage());
 			}
 		};
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessState.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessState.java
@@ -6,7 +6,7 @@ public enum ProcessState
 
 	private final int priority;
 
-	private ProcessState(int priority)
+	ProcessState(int priority)
 	{
 		this.priority = priority;
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessesResource.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessesResource.java
@@ -167,7 +167,7 @@ public final class ProcessesResource
 						&& ProcessState.RETIRED.equals(getNewProcessState()));
 	}
 
-	public BundleEntryComponent toBundleEntry(String baseUrl)
+	public BundleEntryComponent toBundleEntry()
 	{
 		switch (getOldProcessState())
 		{
@@ -176,11 +176,11 @@ public final class ProcessesResource
 			case NEW:
 				return fromNew();
 			case ACTIVE:
-				return fromActive(baseUrl);
+				return fromActive();
 			case DRAFT:
-				return fromDraft(baseUrl);
+				return fromDraft();
 			case RETIRED:
-				return fromRetired(baseUrl);
+				return fromRetired();
 			case EXCLUDED:
 				return fromExcluded();
 			default:
@@ -219,14 +219,14 @@ public final class ProcessesResource
 		}
 	}
 
-	private BundleEntryComponent fromActive(String baseUrl)
+	private BundleEntryComponent fromActive()
 	{
 		switch (getNewProcessState())
 		{
 			case DRAFT:
-				return updateToDraft(baseUrl);
+				return updateToDraft();
 			case RETIRED:
-				return updateToRetired(baseUrl);
+				return updateToRetired();
 			case EXCLUDED:
 				return delete();
 			default:
@@ -235,16 +235,16 @@ public final class ProcessesResource
 		}
 	}
 
-	private BundleEntryComponent fromDraft(String baseUrl)
+	private BundleEntryComponent fromDraft()
 	{
 		switch (getNewProcessState())
 		{
 			case ACTIVE:
-				return updateToActive(baseUrl);
+				return updateToActive();
 			case DRAFT:
-				return updateToDraft(baseUrl);
+				return updateToDraft();
 			case RETIRED:
-				return updateToRetired(baseUrl);
+				return updateToRetired();
 			case EXCLUDED:
 				return delete();
 			default:
@@ -253,14 +253,14 @@ public final class ProcessesResource
 		}
 	}
 
-	private BundleEntryComponent fromRetired(String baseUrl)
+	private BundleEntryComponent fromRetired()
 	{
 		switch (getNewProcessState())
 		{
 			case ACTIVE:
-				return updateToActive(baseUrl);
+				return updateToActive();
 			case DRAFT:
-				return updateToDraft(baseUrl);
+				return updateToDraft();
 			case EXCLUDED:
 				return delete();
 			default:
@@ -323,31 +323,31 @@ public final class ProcessesResource
 		return entry;
 	}
 
-	private BundleEntryComponent updateToActive(String baseUrl)
+	private BundleEntryComponent updateToActive()
 	{
 		if (getResource() instanceof MetadataResource m)
 			m.setStatus(PublicationStatus.ACTIVE);
 
-		return update(baseUrl);
+		return update();
 	}
 
-	private BundleEntryComponent updateToDraft(String baseUrl)
+	private BundleEntryComponent updateToDraft()
 	{
 		if (getResource() instanceof MetadataResource m)
 			m.setStatus(PublicationStatus.DRAFT);
 
-		return update(baseUrl);
+		return update();
 	}
 
-	private BundleEntryComponent updateToRetired(String baseUrl)
+	private BundleEntryComponent updateToRetired()
 	{
 		if (getResource() instanceof MetadataResource m)
 			m.setStatus(PublicationStatus.RETIRED);
 
-		return update(baseUrl);
+		return update();
 	}
 
-	private BundleEntryComponent update(String baseUrl)
+	private BundleEntryComponent update()
 	{
 		BundleEntryComponent entry = new BundleEntryComponent();
 		entry.setResource(getResource());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessesResource.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessesResource.java
@@ -33,24 +33,24 @@ public final class ProcessesResource
 	{
 		Objects.requireNonNull(resource, "resource");
 
-		if (resource instanceof ActivityDefinition)
-			return fromMetadataResource((ActivityDefinition) resource);
-		else if (resource instanceof CodeSystem)
-			return fromMetadataResource((CodeSystem) resource);
-		else if (resource instanceof Library)
-			return fromMetadataResource((Library) resource);
-		else if (resource instanceof Measure)
-			return fromMetadataResource((Measure) resource);
-		else if (resource instanceof NamingSystem)
-			return fromNamingSystem((NamingSystem) resource);
-		else if (resource instanceof Questionnaire)
-			return fromMetadataResource((Questionnaire) resource);
-		else if (resource instanceof StructureDefinition)
-			return fromMetadataResource((StructureDefinition) resource);
-		else if (resource instanceof Task)
-			return fromTask((Task) resource);
-		else if (resource instanceof ValueSet)
-			return fromMetadataResource((ValueSet) resource);
+		if (resource instanceof ActivityDefinition a)
+			return fromMetadataResource(a);
+		else if (resource instanceof CodeSystem c)
+			return fromMetadataResource(c);
+		else if (resource instanceof Library l)
+			return fromMetadataResource(l);
+		else if (resource instanceof Measure m)
+			return fromMetadataResource(m);
+		else if (resource instanceof NamingSystem n)
+			return fromNamingSystem(n);
+		else if (resource instanceof Questionnaire q)
+			return fromMetadataResource(q);
+		else if (resource instanceof StructureDefinition s)
+			return fromMetadataResource(s);
+		else if (resource instanceof Task t)
+			return fromTask(t);
+		else if (resource instanceof ValueSet v)
+			return fromMetadataResource(v);
 		else
 			throw new IllegalArgumentException(
 					"MetadataResource of type " + resource.getClass().getName() + " not supported");
@@ -287,24 +287,24 @@ public final class ProcessesResource
 
 	private BundleEntryComponent createAsActive()
 	{
-		if (getResource() instanceof MetadataResource)
-			((MetadataResource) getResource()).setStatus(PublicationStatus.ACTIVE);
+		if (getResource() instanceof MetadataResource m)
+			m.setStatus(PublicationStatus.ACTIVE);
 
 		return create();
 	}
 
 	private BundleEntryComponent createAsDraft()
 	{
-		if (getResource() instanceof MetadataResource)
-			((MetadataResource) getResource()).setStatus(PublicationStatus.DRAFT);
+		if (getResource() instanceof MetadataResource m)
+			m.setStatus(PublicationStatus.DRAFT);
 
 		return create();
 	}
 
 	private BundleEntryComponent createAsRetired()
 	{
-		if (getResource() instanceof MetadataResource)
-			((MetadataResource) getResource()).setStatus(PublicationStatus.RETIRED);
+		if (getResource() instanceof MetadataResource m)
+			m.setStatus(PublicationStatus.RETIRED);
 
 		return create();
 	}
@@ -325,24 +325,24 @@ public final class ProcessesResource
 
 	private BundleEntryComponent updateToActive(String baseUrl)
 	{
-		if (getResource() instanceof MetadataResource)
-			((MetadataResource) getResource()).setStatus(PublicationStatus.ACTIVE);
+		if (getResource() instanceof MetadataResource m)
+			m.setStatus(PublicationStatus.ACTIVE);
 
 		return update(baseUrl);
 	}
 
 	private BundleEntryComponent updateToDraft(String baseUrl)
 	{
-		if (getResource() instanceof MetadataResource)
-			((MetadataResource) getResource()).setStatus(PublicationStatus.DRAFT);
+		if (getResource() instanceof MetadataResource m)
+			m.setStatus(PublicationStatus.DRAFT);
 
 		return update(baseUrl);
 	}
 
 	private BundleEntryComponent updateToRetired(String baseUrl)
 	{
-		if (getResource() instanceof MetadataResource)
-			((MetadataResource) getResource()).setStatus(PublicationStatus.RETIRED);
+		if (getResource() instanceof MetadataResource m)
+			m.setStatus(PublicationStatus.RETIRED);
 
 		return update(baseUrl);
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PostStartupConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PostStartupConfig.java
@@ -28,11 +28,10 @@ public class PostStartupConfig
 		pluginConfig.processPluginManager().loadAndDeployPlugins();
 		logger.info("Deploying process plugins [Done]");
 
-		logger.info("Staring process engine ...");
+		logger.info("Starting process engine ...");
 		camundaConfig.processEngineConfiguration().getJobExecutor().start();
-		logger.info("Staring process engine [Done]");
+		logger.info("Starting process engine [Done]");
 
-		logger.info("Connecting to websockets ...");
 		fhirConfig.fhirConnectorTask().connect();
 		fhirConfig.fhirConnectorQuestionnaireResponse().connect();
 		// websocket connect is an async operation

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/WebsocketConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/WebsocketConfig.java
@@ -52,7 +52,7 @@ public class WebsocketConfig
 	@Bean
 	public FhirConnector fhirConnectorTask()
 	{
-		return new FhirConnectorImpl<>("Task", fhirClientConfig.clientProvider(), taskSubscriptionHandlerFactory(),
+		return new FhirConnectorImpl<>(Task.class, fhirClientConfig.clientProvider(), taskSubscriptionHandlerFactory(),
 				fhirConfig.fhirContext(), propertiesConfig.getTaskSubscriptionSearchParameter(),
 				propertiesConfig.getWebsocketRetrySleepMillis(), propertiesConfig.getWebsocketMaxRetries());
 	}
@@ -74,7 +74,7 @@ public class WebsocketConfig
 	@Bean
 	public FhirConnector fhirConnectorQuestionnaireResponse()
 	{
-		return new FhirConnectorImpl<>("QuestionnaireResponse", fhirClientConfig.clientProvider(),
+		return new FhirConnectorImpl<>(QuestionnaireResponse.class, fhirClientConfig.clientProvider(),
 				questionnaireResponseSubscriptionHandlerFactory(), fhirConfig.fhirContext(),
 				propertiesConfig.getQuestionnaireResponseSubscriptionSearchParameter(),
 				propertiesConfig.getWebsocketRetrySleepMillis(), propertiesConfig.getWebsocketMaxRetries());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventResourceHandlerImpl.java
@@ -51,7 +51,9 @@ public class EventResourceHandlerImpl<R extends Resource> implements EventResour
 		}
 		catch (SQLException e)
 		{
+			logger.debug("Unable to write last event time to db", e);
 			logger.warn("Unable to write last event time to db: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventType.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventType.java
@@ -6,7 +6,7 @@ public enum EventType
 
 	private final String value;
 
-	private EventType(String value)
+	EventType(String value)
 	{
 		this.value = value;
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/ExistingResourceLoaderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/ExistingResourceLoaderImpl.java
@@ -112,7 +112,9 @@ public class ExistingResourceLoaderImpl<R extends Resource> implements ExistingR
 		}
 		catch (SQLException e)
 		{
+			logger.debug("Unable to read last event time from db", e);
 			logger.warn("Unable to read last event time from db: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -125,7 +127,9 @@ public class ExistingResourceLoaderImpl<R extends Resource> implements ExistingR
 		}
 		catch (SQLException e)
 		{
+			logger.debug("Unable to write last event time to db", e);
 			logger.warn("Unable to write last event time to db: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/FhirConnectorImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/FhirConnectorImpl.java
@@ -204,20 +204,21 @@ public class FhirConnectorImpl<R extends Resource> implements FhirConnector, Ini
 
 		try
 		{
-			logger.info("Connecting websocket to local FHIR server with subscription id {}",
+			logger.info("Connecting websocket to local DSF FHIR server, subscription: {}",
 					subscription.getIdElement().getIdPart());
 			client.connect();
 		}
 		catch (Exception e)
 		{
-			logger.warn("Error while connecting websocket to local FHIR server", e);
+			logger.warn("Unable to connect websocket to local DSF FHIR server: {} - {}", e.getClass().getName(),
+					e.getMessage());
 			throw e;
 		}
 	}
 
 	private Void onError(Throwable t)
 	{
-		logger.error("Error while connecting to websocket", t);
+		logger.error("Error while connecting websocket: {} - {}", t.getClass().getName(), t.getMessage());
 		return null;
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/FhirConnectorImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/FhirConnectorImpl.java
@@ -107,9 +107,9 @@ public class FhirConnectorImpl<R extends Resource> implements FhirConnector, Ini
 		}
 		catch (Exception e)
 		{
+			logger.debug("Error while retrieving {} websocket subscription", resourceName, e);
 			logger.warn("Error while retrieving {} websocket subscription: {} - {}", resourceName,
 					e.getClass().getName(), e.getMessage());
-			logger.debug("Error while retrieving {} websocket subscription", resourceName, e);
 
 			throw e;
 		}
@@ -216,9 +216,9 @@ public class FhirConnectorImpl<R extends Resource> implements FhirConnector, Ini
 		}
 		catch (Exception e)
 		{
+			logger.debug("Error while downloading new {} resources", resourceName, e);
 			logger.warn("Error while downloading new {} resources: {} - {}", resourceName, e.getClass().getName(),
 					e.getMessage());
-			logger.debug("Error while downloading new {} resources", resourceName, e);
 
 			throw e;
 		}
@@ -243,13 +243,14 @@ public class FhirConnectorImpl<R extends Resource> implements FhirConnector, Ini
 
 			logger.info("Connecting {} websocket to local DSF FHIR server, subscription: {} ...", resourceName,
 					subscription.getIdElement().getIdPart());
+
 			client.connect();
 		}
 		catch (Exception e)
 		{
+			logger.debug("Unable to connect {} websocket to local DSF FHIR server", resourceName, e);
 			logger.warn("Unable to connect {} websocket to local DSF FHIR server: {} - {}", resourceName,
 					e.getClass().getName(), e.getMessage());
-			logger.debug("Unable to connect {} websocket to local DSF FHIR server", resourceName, e);
 
 			throw e;
 		}
@@ -257,6 +258,8 @@ public class FhirConnectorImpl<R extends Resource> implements FhirConnector, Ini
 
 	private Void onError(Throwable t)
 	{
+		// no debug log, exception previously logged by retrieveWebsocketSubscription, loadNewResources and
+		// connectWebsocket methods
 		logger.error("Error while loading existing {} resources and connecting websocket: {} - {}", resourceName,
 				t.getClass().getName(), t.getMessage());
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/QuestionnaireResponseHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/QuestionnaireResponseHandler.java
@@ -71,7 +71,8 @@ public class QuestionnaireResponseHandler implements ResourceHandler<Questionnai
 		}
 		catch (Exception e)
 		{
-			logger.warn("Unable to complete UserTask", e);
+			logger.debug("Unable to complete UserTask", e);
+			logger.warn("Unable to complete UserTask: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/TaskHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/TaskHandler.java
@@ -151,17 +151,23 @@ public class TaskHandler implements ResourceHandler<Task>, InitializingBean
 		}
 		catch (MismatchingMessageCorrelationException e)
 		{
-			logger.warn("Unable to handle Task with id {}: {}", task.getId(), e.getMessage());
+			logger.warn("Unable to handle Task with id {}: {} - {}", task.getId(), e.getClass().getName(),
+					e.getMessage());
+			logger.debug("Unable to handle Task with id {}", task.getId(), e);
 			updateTaskFailed(task, "Unable to correlate Task");
 		}
 		catch (ProcessNotFoundException e)
 		{
-			logger.warn("Unable to handle Task with id {}: {}", task.getId(), e.getMessage());
+			logger.warn("Unable to handle Task with id {}: {} - {}", task.getId(), e.getClass().getName(),
+					e.getMessage());
+			logger.debug("Unable to handle Task with id {}", task.getId(), e);
 			updateTaskFailed(task, e.getShortMessage());
 		}
 		catch (Exception e)
 		{
-			logger.error("Unable to handle Task with id " + task.getId(), e);
+			logger.error("Unable to handle Task with id {}: {} - {}", task.getId(), e.getClass().getName(),
+					e.getMessage());
+			logger.debug("Unable to handle Task with id {}", task.getId(), e);
 			updateTaskFailed(task, e);
 		}
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/TaskHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/TaskHandler.java
@@ -151,23 +151,26 @@ public class TaskHandler implements ResourceHandler<Task>, InitializingBean
 		}
 		catch (MismatchingMessageCorrelationException e)
 		{
+			logger.debug("Unable to handle Task with id {}", task.getId(), e);
 			logger.warn("Unable to handle Task with id {}: {} - {}", task.getId(), e.getClass().getName(),
 					e.getMessage());
-			logger.debug("Unable to handle Task with id {}", task.getId(), e);
+
 			updateTaskFailed(task, "Unable to correlate Task");
 		}
 		catch (ProcessNotFoundException e)
 		{
+			logger.debug("Unable to handle Task with id {}", task.getId(), e);
 			logger.warn("Unable to handle Task with id {}: {} - {}", task.getId(), e.getClass().getName(),
 					e.getMessage());
-			logger.debug("Unable to handle Task with id {}", task.getId(), e);
+
 			updateTaskFailed(task, e.getShortMessage());
 		}
 		catch (Exception e)
 		{
+			logger.debug("Unable to handle Task with id {}", task.getId(), e);
 			logger.error("Unable to handle Task with id {}: {} - {}", task.getId(), e.getClass().getName(),
 					e.getMessage());
-			logger.debug("Unable to handle Task with id {}", task.getId(), e);
+
 			updateTaskFailed(task, e);
 		}
 	}
@@ -186,9 +189,11 @@ public class TaskHandler implements ResourceHandler<Task>, InitializingBean
 		{
 			webserviceClient.update(task);
 		}
-		catch (Exception ex)
+		catch (Exception e)
 		{
-			logger.error("Unable to update Task with id {} (status failed)", task.getId());
+			logger.debug("Unable to update Task with id {} (status failed)", task.getId(), e);
+			logger.error("Unable to update Task with id {} (status failed): {} - {}", task.getId(),
+					e.getClass().getName(), e.getMessage());
 		}
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/MailServiceImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/MailServiceImpl.java
@@ -10,9 +10,9 @@ import org.springframework.beans.factory.InitializingBean;
 
 public class MailServiceImpl implements MailService, InitializingBean
 {
-	private dev.dsf.bpe.v1.service.MailService delegate;
+	private MailService delegate;
 
-	public MailServiceImpl(dev.dsf.bpe.v1.service.MailService delegate)
+	public MailServiceImpl(MailService delegate)
 	{
 		this.delegate = delegate;
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/FhirResourceValues.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/FhirResourceValues.java
@@ -11,7 +11,7 @@ import org.hl7.fhir.r4.model.Resource;
 
 public final class FhirResourceValues
 {
-	public static interface FhirResourceValue extends PrimitiveValue<Resource>
+	public interface FhirResourceValue extends PrimitiveValue<Resource>
 	{
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/FhirResourcesListValues.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/FhirResourcesListValues.java
@@ -13,7 +13,7 @@ import org.hl7.fhir.r4.model.Resource;
 
 public final class FhirResourcesListValues
 {
-	public static interface FhirResourcesListValue extends PrimitiveValue<FhirResourcesList>
+	public interface FhirResourcesListValue extends PrimitiveValue<FhirResourcesList>
 	{
 		@SuppressWarnings("unchecked")
 		default <R extends Resource> List<R> getFhirResources()

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/TargetValues.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/TargetValues.java
@@ -10,7 +10,7 @@ import org.camunda.bpm.engine.variable.value.TypedValue;
 
 public final class TargetValues
 {
-	public static interface TargetValue extends PrimitiveValue<TargetImpl>
+	public interface TargetValue extends PrimitiveValue<TargetImpl>
 	{
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/TargetsValues.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/TargetsValues.java
@@ -10,7 +10,7 @@ import org.camunda.bpm.engine.variable.value.TypedValue;
 
 public final class TargetsValues
 {
-	public static interface TargetsValue extends PrimitiveValue<TargetsImpl>
+	public interface TargetsValue extends PrimitiveValue<TargetsImpl>
 	{
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/VariablesImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/VariablesImpl.java
@@ -130,12 +130,12 @@ public class VariablesImpl implements Variables, ListenerVariables
 		if (targets == null)
 			execution.setVariable(BpmnExecutionVariables.TARGETS, null);
 
-		else if (!(targets instanceof TargetsImpl))
-			throw new IllegalArgumentException(
-					"Given targets implementing class " + targets.getClass().getName() + " not supported");
+		else if (targets instanceof TargetsImpl t)
+			execution.setVariable(BpmnExecutionVariables.TARGETS, TargetsValues.create(t));
 
 		else
-			execution.setVariable(BpmnExecutionVariables.TARGETS, TargetsValues.create((TargetsImpl) targets));
+			throw new IllegalArgumentException(
+					"Given targets implementing class " + targets.getClass().getName() + " not supported");
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/VariablesImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/variables/VariablesImpl.java
@@ -24,7 +24,6 @@ import dev.dsf.bpe.v1.variables.Variables;
 import dev.dsf.bpe.variables.FhirResourceValues.FhirResourceValue;
 import dev.dsf.bpe.variables.FhirResourcesListValues.FhirResourcesListValue;
 import dev.dsf.bpe.variables.TargetValues.TargetValue;
-import dev.dsf.bpe.variables.TargetsValues.TargetsValue;
 
 public class VariablesImpl implements Variables, ListenerVariables
 {
@@ -129,17 +128,14 @@ public class VariablesImpl implements Variables, ListenerVariables
 	public void setTargets(Targets targets) throws IllegalArgumentException
 	{
 		if (targets == null)
-		{
 			execution.setVariable(BpmnExecutionVariables.TARGETS, null);
-			return;
-		}
 
-		if (!(targets instanceof TargetsImpl))
+		else if (!(targets instanceof TargetsImpl))
 			throw new IllegalArgumentException(
 					"Given targets implementing class " + targets.getClass().getName() + " not supported");
 
-		TargetsValue variable = targets == null ? null : TargetsValues.create((TargetsImpl) targets);
-		execution.setVariable(BpmnExecutionVariables.TARGETS, variable);
+		else
+			execution.setVariable(BpmnExecutionVariables.TARGETS, TargetsValues.create((TargetsImpl) targets));
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/webservice/RootService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/webservice/RootService.java
@@ -58,11 +58,8 @@ public class RootService
 	private String getDisplayName(SecurityContext securityContext)
 	{
 		Principal userPrincipal = securityContext.getUserPrincipal();
-		if (userPrincipal != null && userPrincipal instanceof Identity)
-		{
-			Identity identity = (Identity) userPrincipal;
+		if (userPrincipal != null && userPrincipal instanceof Identity identity)
 			return identity.getDisplayName();
-		}
 		else
 			return "?";
 

--- a/dsf-common/dsf-common-auth/src/main/java/dev/dsf/common/auth/conf/RoleConfig.java
+++ b/dsf-common/dsf-common-auth/src/main/java/dev/dsf/common/auth/conf/RoleConfig.java
@@ -128,36 +128,29 @@ public class RoleConfig
 	public RoleConfig(Object config, Function<String, DsfRole> dsfRoleFactory,
 			Function<String, Coding> practitionerRoleFactory)
 	{
-		if (config != null && config instanceof List)
+		if (config != null && config instanceof List<?> l)
 		{
-			@SuppressWarnings("unchecked")
-			List<Object> cList = (List<Object>) config;
-			cList.forEach(mapping ->
+			l.forEach(mapping ->
 			{
-				if (mapping != null && mapping instanceof Map)
+				if (mapping != null && mapping instanceof Map<?, ?> m)
 				{
-					@SuppressWarnings("unchecked")
-					Map<Object, Object> m = (Map<Object, Object>) mapping;
 					m.forEach((mappingKey, mappingValues) ->
 					{
 						if (mappingKey != null && mappingKey instanceof String && mappingValues != null
-								&& mappingValues instanceof Map)
+								&& mappingValues instanceof Map<?, ?> v)
 						{
-							@SuppressWarnings("unchecked")
-							Map<Object, Object> properties = (Map<Object, Object>) mappingValues;
-
-							// Map<String, Object>
 							List<String> thumbprints = null, emails = null, tokenRoles = null, tokenGroups = null;
 							List<DsfRole> dsfRoles = null;
 							List<Coding> practitionerRoles = null;
-							for (Entry<Object, Object> p : properties.entrySet())
+
+							for (Entry<?, ?> property : v.entrySet())
 							{
-								if (p.getKey() != null && p.getKey() instanceof String)
+								if (property.getKey() != null && property.getKey() instanceof String key)
 								{
-									switch ((String) p.getKey())
+									switch (key)
 									{
 										case PROPERTY_THUMBPRINT:
-											thumbprints = getValues(p.getValue()).stream().map(value ->
+											thumbprints = getValues(property.getValue()).stream().map(value ->
 											{
 												if (value == null || value.isBlank())
 												{
@@ -177,7 +170,7 @@ public class RoleConfig
 											}).filter(g -> g != null).toList();
 											break;
 										case PROPERTY_EMAIL:
-											emails = getValues(p.getValue()).stream().map(value ->
+											emails = getValues(property.getValue()).stream().map(value ->
 											{
 												if (value == null || value.isBlank())
 												{
@@ -197,7 +190,7 @@ public class RoleConfig
 											}).filter(g -> g != null).toList();
 											break;
 										case PROPERTY_TOKEN_ROLE:
-											tokenRoles = getValues(p.getValue()).stream().map(value ->
+											tokenRoles = getValues(property.getValue()).stream().map(value ->
 											{
 												if (value == null || value.isBlank())
 												{
@@ -210,7 +203,7 @@ public class RoleConfig
 											}).filter(g -> g != null).toList();
 											break;
 										case PROPERTY_TOKEN_GROUP:
-											tokenGroups = getValues(p.getValue()).stream().map(value ->
+											tokenGroups = getValues(property.getValue()).stream().map(value ->
 											{
 												if (value == null || value.isBlank())
 												{
@@ -223,7 +216,7 @@ public class RoleConfig
 											}).filter(g -> g != null).toList();
 											break;
 										case PROPERTY_DSF_ROLE:
-											dsfRoles = getValues(p.getValue()).stream().map(value ->
+											dsfRoles = getValues(property.getValue()).stream().map(value ->
 											{
 												if (value == null || value.isBlank())
 												{
@@ -241,7 +234,7 @@ public class RoleConfig
 											}).filter(r -> r != null).toList();
 											break;
 										case PROPERTY_PRACTITIONER_ROLE:
-											practitionerRoles = getValues(p.getValue()).stream().map(value ->
+											practitionerRoles = getValues(property.getValue()).stream().map(value ->
 											{
 												if (value == null || value.isBlank())
 												{
@@ -263,7 +256,7 @@ public class RoleConfig
 										default:
 											logger.warn(
 													"Unknown role config property '{}' expected one of {}, ignoring property in rule '{}'",
-													p.getKey(), PROPERTIES, mappingKey);
+													property.getKey(), PROPERTIES, mappingKey);
 									}
 								}
 							}
@@ -289,10 +282,10 @@ public class RoleConfig
 	@SuppressWarnings("unchecked")
 	private static List<String> getValues(Object o)
 	{
-		if (o instanceof String)
-			return Collections.singletonList((String) o);
-		else if (o instanceof List)
-			return ((List<String>) o);
+		if (o instanceof String s)
+			return Collections.singletonList(s);
+		else if (o instanceof List l)
+			return l;
 		else
 			return Collections.emptyList();
 	}

--- a/dsf-common/dsf-common-auth/src/main/java/dev/dsf/common/auth/conf/RoleConfig.java
+++ b/dsf-common/dsf-common-auth/src/main/java/dev/dsf/common/auth/conf/RoleConfig.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -273,10 +274,10 @@ public class RoleConfig
 						else if (mappingKey != null && mappingKey instanceof String
 								&& (mappingValues == null || !(mappingValues instanceof Map)))
 						{
-							logger.warn("Ignoring invalud rule '{}'", mappingKey);
+							logger.warn("Ignoring invalid rule '{}', no value specified or value not map", mappingKey);
 						}
 						else
-							logger.warn("Ignoring invalud rule '{}'", mappingKey);
+							logger.warn("Ignoring invalid rule '{}'", Objects.toString(mappingKey));
 					});
 				}
 				else

--- a/dsf-common/dsf-common-auth/src/main/java/dev/dsf/common/auth/conf/RoleConfig.java
+++ b/dsf-common/dsf-common-auth/src/main/java/dev/dsf/common/auth/conf/RoleConfig.java
@@ -35,7 +35,7 @@ public class RoleConfig
 	private static final String EMAIL_PATTERN_STRING = "^[\\w!#$%&'*+/=?`{\\|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{\\|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
 	private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_PATTERN_STRING);
 
-	public class Mapping
+	public static final class Mapping
 	{
 		private final String name;
 
@@ -169,6 +169,7 @@ public class RoleConfig
 													return value.trim();
 											}).filter(g -> g != null).toList();
 											break;
+
 										case PROPERTY_EMAIL:
 											emails = getValues(property.getValue()).stream().map(value ->
 											{
@@ -189,6 +190,7 @@ public class RoleConfig
 													return value.trim();
 											}).filter(g -> g != null).toList();
 											break;
+
 										case PROPERTY_TOKEN_ROLE:
 											tokenRoles = getValues(property.getValue()).stream().map(value ->
 											{
@@ -202,6 +204,7 @@ public class RoleConfig
 													return value.trim();
 											}).filter(g -> g != null).toList();
 											break;
+
 										case PROPERTY_TOKEN_GROUP:
 											tokenGroups = getValues(property.getValue()).stream().map(value ->
 											{
@@ -215,6 +218,7 @@ public class RoleConfig
 													return value.trim();
 											}).filter(g -> g != null).toList();
 											break;
+
 										case PROPERTY_DSF_ROLE:
 											dsfRoles = getValues(property.getValue()).stream().map(value ->
 											{
@@ -233,6 +237,7 @@ public class RoleConfig
 												return dsfRole;
 											}).filter(r -> r != null).toList();
 											break;
+
 										case PROPERTY_PRACTITIONER_ROLE:
 											practitionerRoles = getValues(property.getValue()).stream().map(value ->
 											{
@@ -253,6 +258,7 @@ public class RoleConfig
 												return coding;
 											}).filter(r -> r != null).toList();
 											break;
+
 										default:
 											logger.warn(
 													"Unknown role config property '{}' expected one of {}, ignoring property in rule '{}'",

--- a/dsf-common/dsf-common-config/src/main/java/dev/dsf/common/config/ProxyConfigImpl.java
+++ b/dsf-common/dsf-common-config/src/main/java/dev/dsf/common/config/ProxyConfigImpl.java
@@ -137,7 +137,7 @@ public class ProxyConfigImpl implements ProxyConfig, InitializingBean
 		}
 		catch (URISyntaxException e)
 		{
-			logger.debug("Given targetUrl '{}' is malformed, {}", targetUrl, e.getMessage());
+			logger.debug("Given targetUrl '{}' is malformed: {}", targetUrl, e.getMessage());
 			return false;
 		}
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/ClientCertificateAuthenticator.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/ClientCertificateAuthenticator.java
@@ -58,6 +58,7 @@ public class ClientCertificateAuthenticator extends LoginAuthenticator
 		if (certificates == null || certificates.length <= 0)
 		{
 			logger.warn("X509Certificate could not be retrieved, sending unauthorized");
+
 			return Authentication.UNAUTHENTICATED;
 		}
 
@@ -67,8 +68,10 @@ public class ClientCertificateAuthenticator extends LoginAuthenticator
 		}
 		catch (CertificateException e)
 		{
+			logger.debug("Unable to validate client certificates, sending unauthorized", e);
 			logger.warn("Unable to validate client certificates, sending unauthorized: {} - {}", e.getClass().getName(),
 					e.getMessage());
+
 			return Authentication.UNAUTHENTICATED;
 		}
 
@@ -76,6 +79,7 @@ public class ClientCertificateAuthenticator extends LoginAuthenticator
 		if (user == null)
 		{
 			logger.warn("User '{}' not found, sending unauthorized", getSubjectDn(certificates));
+
 			return Authentication.UNAUTHENTICATED;
 		}
 
@@ -95,7 +99,9 @@ public class ClientCertificateAuthenticator extends LoginAuthenticator
 		}
 		catch (NoSuchAlgorithmException | KeyStoreException e)
 		{
+			logger.debug("Unable to create trust manager", e);
 			logger.warn("Unable to create trust manager: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -109,7 +115,9 @@ public class ClientCertificateAuthenticator extends LoginAuthenticator
 		}
 		catch (KeyStoreException | InvalidAlgorithmParameterException e)
 		{
+			logger.debug("Unable to extract trust anchors", e);
 			logger.warn("Unable to extract trust anchors: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfLoginService.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfLoginService.java
@@ -19,7 +19,7 @@ import jakarta.servlet.ServletRequest;
 
 public class DsfLoginService implements LoginService
 {
-	private final class UserIdentityImpl implements UserIdentity
+	private static final class UserIdentityImpl implements UserIdentity
 	{
 		private final Principal principal;
 

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfLoginService.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfLoginService.java
@@ -72,12 +72,12 @@ public class DsfLoginService implements LoginService
 			return null;
 
 		Principal principal = null;
-		if (credentials instanceof X509Certificate[])
-			principal = identityProvider.getIdentity((X509Certificate[]) credentials);
-		else if (credentials instanceof OpenIdCredentials)
-			principal = identityProvider.getIdentity(new DsfOpenIdCredentialsImpl((OpenIdCredentials) credentials));
-		else if (credentials instanceof String)
-			principal = identityProvider.getIdentity(new DsfOpenIdCredentialsImpl((String) credentials));
+		if (credentials instanceof X509Certificate[] c)
+			principal = identityProvider.getIdentity(c);
+		else if (credentials instanceof OpenIdCredentials o)
+			principal = identityProvider.getIdentity(new DsfOpenIdCredentialsImpl(o));
+		else if (credentials instanceof String s)
+			principal = identityProvider.getIdentity(new DsfOpenIdCredentialsImpl(s));
 
 		if (principal == null)
 			return null;

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdConfiguration.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdConfiguration.java
@@ -80,7 +80,7 @@ public class DsfOpenIdConfiguration extends OpenIdConfiguration
 						return key.get();
 					else
 					{
-						logger.warn("Unable to retrieve key with id " + kid);
+						logger.warn("Unable to retrieve key with id {}", kid);
 						return null;
 					}
 				}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdConfiguration.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdConfiguration.java
@@ -100,7 +100,9 @@ public class DsfOpenIdConfiguration extends OpenIdConfiguration
 		}
 		catch (InterruptedException | ExecutionException | TimeoutException e)
 		{
+			logger.debug("Unable to retrieve keys from {}: {} - {}", jwksUri, e);
 			logger.warn("Unable to retrieve keys from {}: {} - {}", jwksUri, e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdCredentialsImpl.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdCredentialsImpl.java
@@ -48,13 +48,13 @@ public class DsfOpenIdCredentialsImpl implements DsfOpenIdCredentials
 	public Long getLongClaim(String key)
 	{
 		Object o = getAccessToken().get(key);
-		return o instanceof Long ? (Long) o : null;
+		return o instanceof Long l ? l : null;
 	}
 
 	@Override
 	public String getStringClaimOrDefault(String key, String defaultValue)
 	{
 		Object o = getAccessToken().getOrDefault(key, defaultValue);
-		return o instanceof String ? (String) o : defaultValue;
+		return o instanceof String s ? s : defaultValue;
 	}
 }

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
@@ -36,7 +36,9 @@ public class DsfOpenIdLoginService extends OpenIdLoginService
 		}
 		catch (Throwable e)
 		{
-			logger.warn("Unable to redeem auth code", e);
+			logger.debug("Unable to redeem auth code", e);
+			logger.warn("Unable to redeem auth code: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return null;
 		}
 

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
@@ -34,7 +34,7 @@ public class DsfOpenIdLoginService extends OpenIdLoginService
 		{
 			openIdCredentials.redeemAuthCode(configuration);
 		}
-		catch (Throwable e)
+		catch (Exception e)
 		{
 			logger.debug("Unable to redeem auth code", e);
 			logger.warn("Unable to redeem auth code: {} - {}", e.getClass().getName(), e.getMessage());

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
@@ -46,10 +46,8 @@ public class DsfOpenIdLoginService extends OpenIdLoginService
 	@Override
 	public boolean validate(UserIdentity user)
 	{
-		if (!(user.getUserPrincipal() instanceof PractitionerIdentity))
+		if (!(user.getUserPrincipal() instanceof PractitionerIdentity identity))
 			return false;
-
-		PractitionerIdentity identity = (PractitionerIdentity) user.getUserPrincipal();
 
 		if (identity.getCredentials().isEmpty())
 		{

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractJettyConfig.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractJettyConfig.java
@@ -233,8 +233,7 @@ public abstract class AbstractJettyConfig
 						Collectors.toMap(e -> Objects.toString(e.getKey()), e -> Objects.toString(e.getValue())));
 
 		return new JettyServer(apiConnector(), statusConnector(), mavenServerModuleName(), contextPath,
-				servletContainerInitializers(), initParameters, clientCertificateTrustStore(),
-				this::configureSecurityHandler);
+				servletContainerInitializers(), initParameters, this::configureSecurityHandler);
 	}
 
 	private KeyStore serverCertificateKeyStore(char[] keyStorePassword)

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/HttpClientWithGetRetry.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/HttpClientWithGetRetry.java
@@ -51,8 +51,9 @@ public class HttpClientWithGetRetry extends HttpClient
 
 			if (cause instanceof ConnectException && times > 1)
 			{
-				logger.warn("Error while accessing {}: {}", uri == null ? "null" : uri.toString(), e.getMessage());
-				logger.warn("ConnectException: trying again in 5s");
+				logger.debug("Error while accessing {}, trying again in 5s", uri == null ? "null" : uri.toString(), e);
+				logger.warn("Error while accessing {}, trying again in 5s: {} - {}",
+						uri == null ? "null" : uri.toString(), e.getClass().getName(), e.getMessage());
 				try
 				{
 					Thread.sleep(5000);
@@ -65,8 +66,9 @@ public class HttpClientWithGetRetry extends HttpClient
 			}
 			else if (cause instanceof UnknownHostException && times > 1)
 			{
-				logger.warn("Error while accessing {}: {}", uri == null ? "null" : uri.toString(), e.getMessage());
-				logger.warn("UnknownHostException: trying again in 10s");
+				logger.debug("Error while accessing {}, trying again in 10s", uri == null ? "null" : uri.toString(), e);
+				logger.warn("Error while accessing {}, trying again in 10s: {} - {}",
+						uri == null ? "null" : uri.toString(), e.getClass().getName(), e.getMessage());
 				try
 				{
 					Thread.sleep(10_000);
@@ -79,7 +81,10 @@ public class HttpClientWithGetRetry extends HttpClient
 			}
 			else
 			{
-				logger.error("Error while accessing {}: {}", uri == null ? "null" : uri.toString(), e.getMessage());
+				logger.debug("Error while accessing {}", uri == null ? "null" : uri.toString(), e);
+				logger.warn("Error while accessing {}: {} - {}", uri == null ? "null" : uri.toString(),
+						e.getClass().getName(), e.getMessage());
+
 				throw e;
 			}
 		}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/HttpClientWithGetRetry.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/HttpClientWithGetRetry.java
@@ -45,7 +45,6 @@ public class HttpClientWithGetRetry extends HttpClient
 		}
 		catch (InterruptedException | ExecutionException | TimeoutException | RuntimeException e)
 		{
-
 			Throwable cause = e;
 			while (!(cause instanceof ConnectException) && cause.getCause() != null)
 				cause = cause.getCause();

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
@@ -1,6 +1,7 @@
 package dev.dsf.common.jetty;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.net.StandardSocketOptions;
 import java.nio.channels.ServerSocketChannel;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import de.rwh.utils.crypto.CertificateHelper;
 import jakarta.servlet.ServletContainerInitializer;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
 
 public final class JettyServer
 {
@@ -323,8 +325,8 @@ public final class JettyServer
 		return new ErrorHandler()
 		{
 			@Override
-			protected void writeErrorPage(jakarta.servlet.http.HttpServletRequest request, java.io.Writer writer,
-					int code, String message, boolean showStacks) throws IOException
+			protected void writeErrorPage(HttpServletRequest request, Writer writer, int code, String message,
+					boolean showStacks) throws IOException
 			{
 				logger.info("Error {}: {}", code, message);
 			}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
@@ -110,7 +110,9 @@ public final class JettyServer
 			}
 			catch (IOException e)
 			{
-				logger.warn("Unable to open server socket channel: {}", e.getMessage());
+				logger.debug("Unable to open server socket channel", e);
+				logger.warn("Unable to open server socket channel: {} - {}", e.getClass().getName(), e.getMessage());
+
 				throw new RuntimeException(e);
 			}
 		};
@@ -147,7 +149,9 @@ public final class JettyServer
 			}
 			catch (IOException e)
 			{
-				logger.warn("Unable to open server socket channel: {}", e.getMessage());
+				logger.debug("Unable to open server socket channel", e);
+				logger.warn("Unable to open server socket channel: {} - {}", e.getClass().getName(), e.getMessage());
+
 				throw new RuntimeException(e);
 			}
 		};
@@ -171,7 +175,9 @@ public final class JettyServer
 			}
 			catch (IOException e)
 			{
-				logger.warn("Unable to open server socket channel: {}", e.getMessage());
+				logger.debug("Unable to open server socket channel", e);
+				logger.warn("Unable to open server socket channel: {} - {}", e.getClass().getName(), e.getMessage());
+
 				throw new RuntimeException(e);
 			}
 		};
@@ -236,7 +242,9 @@ public final class JettyServer
 		}
 		catch (KeyStoreException e)
 		{
-			logger.warn("Error while printing trust store / key store config", e);
+			logger.debug("Error while printing trust store / key store config", e);
+			logger.warn("Error while printing trust store / key store config: {} - {}", e.getClass().getName(),
+					e.getMessage());
 		}
 	}
 
@@ -318,7 +326,7 @@ public final class JettyServer
 			protected void writeErrorPage(jakarta.servlet.http.HttpServletRequest request, java.io.Writer writer,
 					int code, String message, boolean showStacks) throws IOException
 			{
-				logger.warn("Error {}: {}", code, message);
+				logger.info("Error {}: {}", code, message);
 			}
 		};
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
@@ -116,7 +116,7 @@ public final class JettyServer
 		};
 	}
 
-	public static final Function<Server, ServerConnector> httpConnector(String host, int port,
+	public static Function<Server, ServerConnector> httpConnector(String host, int port,
 			String clientCertificateHeaderName)
 	{
 		return server ->
@@ -131,7 +131,7 @@ public final class JettyServer
 		};
 	}
 
-	public static final Function<Server, ServerConnector> httpConnector(ServerSocketChannel channel,
+	public static Function<Server, ServerConnector> httpConnector(ServerSocketChannel channel,
 			String clientCertificateHeaderName)
 	{
 		return server ->
@@ -249,8 +249,7 @@ public final class JettyServer
 	public JettyServer(Function<Server, ServerConnector> apiConnectorProvider,
 			Function<Server, ServerConnector> statusConnectorProvider, String mavenServerModuleName, String contextPath,
 			List<Class<? extends ServletContainerInitializer>> servletContainerInitializers,
-			Map<String, String> initParameters, KeyStore clientTrustStore,
-			BiConsumer<WebAppContext, Supplier<Integer>> securityHandlerConfigurer)
+			Map<String, String> initParameters, BiConsumer<WebAppContext, Supplier<Integer>> securityHandlerConfigurer)
 	{
 		server = new Server(threadPool());
 		apiConnector = apiConnectorProvider.apply(server);
@@ -317,14 +316,14 @@ public final class JettyServer
 		{
 			@Override
 			protected void writeErrorPage(jakarta.servlet.http.HttpServletRequest request, java.io.Writer writer,
-					int code, String message, boolean showStacks) throws java.io.IOException
+					int code, String message, boolean showStacks) throws IOException
 			{
 				logger.warn("Error {}: {}", code, message);
 			}
 		};
 	}
 
-	public final void start()
+	public void start()
 	{
 		Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
 
@@ -351,7 +350,7 @@ public final class JettyServer
 		}
 	}
 
-	public final void stop()
+	public void stop()
 	{
 		logger.info("Stopping jetty server ...");
 		try
@@ -367,7 +366,7 @@ public final class JettyServer
 	/**
 	 * @return <code>null</code> if server not started or web application failed to start
 	 */
-	public final ServletContext getServletContext()
+	public ServletContext getServletContext()
 	{
 		return webAppContext == null ? null : webAppContext.getServletContext();
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/jetty/JettyServer.java
@@ -344,8 +344,8 @@ public final class JettyServer
 				e.addSuppressed(e1);
 			}
 
-			if (e instanceof RuntimeException)
-				throw (RuntimeException) e;
+			if (e instanceof RuntimeException r)
+				throw r;
 			else
 				throw new RuntimeException(e);
 		}

--- a/dsf-common/dsf-common-status/src/main/java/dev/dsf/common/status/webservice/StatusService.java
+++ b/dsf-common/dsf-common-status/src/main/java/dev/dsf/common/status/webservice/StatusService.java
@@ -62,9 +62,8 @@ public class StatusService implements InitializingBean
 		{
 			String errorMessage = getErrorMessage(e);
 
+			logger.debug("Error while accessing DB", e);
 			logger.error("Error while accessing DB: {}", errorMessage);
-			if (logger.isDebugEnabled())
-				logger.debug("Error while accessing DB", e);
 
 			return Response.serverError().entity(errorMessage).build();
 		}

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/All.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/All.java
@@ -220,10 +220,10 @@ public class All implements Recipient, Requester
 	{
 		if (coding != null && coding.hasSystem()
 				&& ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_SYSTEM.equals(coding.getSystem())
-				&& coding.hasCode())
+				&& coding.hasCode()
+				&& ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_VALUE_LOCAL_ALL.equals(coding.getCode()))
 		{
-			if (ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_VALUE_LOCAL_ALL.equals(coding.getCode()))
-				return Optional.of(new All(true, null, null));
+			return Optional.of(new All(true, null, null));
 			// remote not allowed for recipient
 		}
 

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/All.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/All.java
@@ -58,8 +58,8 @@ public class All implements Recipient, Requester
 
 	private Set<Coding> getPractitionerRoles(Identity identity)
 	{
-		if (identity instanceof PractitionerIdentity)
-			return ((PractitionerIdentity) identity).getPractionerRoles();
+		if (identity instanceof PractitionerIdentity p)
+			return p.getPractionerRoles();
 		else
 			return Collections.emptySet();
 	}
@@ -130,7 +130,7 @@ public class All implements Recipient, Requester
 	private boolean matches(Extension extension, String url)
 	{
 		return extension != null && url.equals(extension.getUrl()) && extension.hasValue()
-				&& extension.getValue() instanceof Coding && matches((Coding) extension.getValue());
+				&& extension.getValue() instanceof Coding value && matches(value);
 	}
 
 	private boolean hasMatchingPractitionerExtension(List<Extension> extensions)
@@ -142,8 +142,8 @@ public class All implements Recipient, Requester
 	private boolean practitionerExtensionMatches(Extension extension)
 	{
 		return ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PRACTITIONER.equals(extension.getUrl())
-				&& extension.hasValue() && extension.getValue() instanceof Coding
-				&& practitionerRoleMatches((Coding) extension.getValue());
+				&& extension.hasValue() && extension.getValue() instanceof Coding value
+				&& practitionerRoleMatches(value);
 	}
 
 	private boolean practitionerRoleMatches(Coding coding)
@@ -205,13 +205,10 @@ public class All implements Recipient, Requester
 			if (practitionerRoles.size() == 1)
 			{
 				Extension practitionerRole = practitionerRoles.get(0);
-				if (practitionerRole.hasValue() && practitionerRole.getValue() instanceof Coding)
+				if (practitionerRole.hasValue() && practitionerRole.getValue() instanceof Coding value
+						&& value.hasSystem() && value.hasCode() && practitionerRoleExists.test(coding))
 				{
-					Coding practitionerRoleCoding = (Coding) practitionerRole.getValue();
-					if (practitionerRoleCoding.hasSystem() && practitionerRoleCoding.hasCode()
-							&& practitionerRoleExists.test(coding))
-						return Optional.of(
-								new All(true, practitionerRoleCoding.getSystem(), practitionerRoleCoding.getCode()));
+					return Optional.of(new All(true, value.getSystem(), value.getCode()));
 				}
 			}
 		}

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Organization.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Organization.java
@@ -274,10 +274,10 @@ public class Organization implements Recipient, Requester
 	{
 		if (coding != null && coding.hasSystem()
 				&& ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_SYSTEM.equals(coding.getSystem())
-				&& coding.hasCode())
+				&& coding.hasCode()
+				&& ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_VALUE_LOCAL_ORGANIZATION.equals(coding.getCode()))
 		{
-			if (ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_VALUE_LOCAL_ORGANIZATION.equals(coding.getCode()))
-				return from(true, coding, organizationWithIdentifierExists).map(r -> (Recipient) r);
+			return from(true, coding, organizationWithIdentifierExists).map(r -> (Recipient) r);
 		}
 
 		return Optional.empty();

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Organization.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Organization.java
@@ -76,8 +76,8 @@ public class Organization implements Recipient, Requester
 
 	private Set<Coding> getPractitionerRoles(Identity identity)
 	{
-		if (identity instanceof PractitionerIdentity)
-			return ((PractitionerIdentity) identity).getPractionerRoles();
+		if (identity instanceof PractitionerIdentity p)
+			return p.getPractionerRoles();
 		else
 			return Collections.emptySet();
 	}
@@ -162,9 +162,8 @@ public class Organization implements Recipient, Requester
 	private boolean matches(Extension extension, String url, boolean needsPractitionerRole)
 	{
 		return extension != null && url.equals(extension.getUrl()) && extension.hasValue()
-				&& extension.getValue() instanceof Coding && matches((Coding) extension.getValue())
-				&& extension.getValue().hasExtension()
-				&& hasMatchingOrganizationExtension(extension.getValue().getExtension(), needsPractitionerRole);
+				&& extension.getValue() instanceof Coding value && matches(value) && value.hasExtension()
+				&& hasMatchingOrganizationExtension(value.getExtension(), needsPractitionerRole);
 	}
 
 	private boolean hasMatchingOrganizationExtension(List<Extension> extensions, boolean needsPractitionerRole)
@@ -184,8 +183,8 @@ public class Organization implements Recipient, Requester
 		else
 		{
 			return extension -> ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_ORGANIZATION
-					.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Identifier
-					&& organizationIdentifierMatches((Identifier) extension.getValue());
+					.equals(extension.getUrl()) && extension.hasValue()
+					&& extension.getValue() instanceof Identifier value && organizationIdentifierMatches(value);
 		}
 	}
 
@@ -204,8 +203,8 @@ public class Organization implements Recipient, Requester
 	private boolean subOrganizationExtensionMatches(Extension extension)
 	{
 		return ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_ORGANIZATION_PRACTITIONER_ORGANIZATION
-				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Identifier
-				&& organizationIdentifierMatches((Identifier) extension.getValue());
+				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Identifier value
+				&& organizationIdentifierMatches(value);
 	}
 
 	private boolean hasMatchingPractitionerExtension(List<Extension> extensions)
@@ -216,8 +215,8 @@ public class Organization implements Recipient, Requester
 	private boolean practitionerExtensionMatches(Extension extension)
 	{
 		return ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_ORGANIZATION_PRACTITIONER_PRACTITIONER_ROLE
-				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Coding
-				&& practitionerRoleMatches((Coding) extension.getValue());
+				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Coding value
+				&& practitionerRoleMatches(value);
 	}
 
 	private boolean practitionerRoleMatches(Coding coding)
@@ -295,12 +294,11 @@ public class Organization implements Recipient, Requester
 			if (organizations.size() == 1)
 			{
 				Extension organization = organizations.get(0);
-				if (organization.hasValue() && organization.getValue() instanceof Identifier)
+				if (organization.hasValue() && organization.getValue() instanceof Identifier identifier
+						&& ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM.equals(identifier.getSystem())
+						&& organizationWithIdentifierExists.test(identifier))
 				{
-					Identifier identifier = (Identifier) organization.getValue();
-					if (ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM.equals(identifier.getSystem())
-							&& organizationWithIdentifierExists.test(identifier))
-						return Optional.of(new Organization(localIdentity, identifier.getValue(), null, null));
+					return Optional.of(new Organization(localIdentity, identifier.getValue(), null, null));
 				}
 			}
 		}
@@ -335,20 +333,16 @@ public class Organization implements Recipient, Requester
 					Extension organization = organizations.get(0);
 					Extension practitionerRole = practitionerRoles.get(0);
 
-					if (organization.hasValue() && organization.getValue() instanceof Identifier
-							&& practitionerRole.hasValue() && practitionerRole.getValue() instanceof Coding)
+					if (organization.hasValue() && organization.getValue() instanceof Identifier organizationIdentifier
+							&& practitionerRole.hasValue()
+							&& practitionerRole.getValue() instanceof Coding practitionerRoleCoding
+							&& ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM
+									.equals(organizationIdentifier.getSystem())
+							&& organizationWithIdentifierExists.test(organizationIdentifier)
+							&& practitionerRoleExists.test(practitionerRoleCoding))
 					{
-						Identifier organizationIdentifier = (Identifier) organization.getValue();
-						Coding practitionerRoleCoding = (Coding) practitionerRole.getValue();
-
-						if (ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM
-								.equals(organizationIdentifier.getSystem())
-								&& organizationWithIdentifierExists.test(organizationIdentifier)
-								&& practitionerRoleExists.test(practitionerRoleCoding))
-						{
-							return Optional.of(new Organization(true, organizationIdentifier.getValue(),
-									practitionerRoleCoding.getSystem(), practitionerRoleCoding.getCode()));
-						}
+						return Optional.of(new Organization(true, organizationIdentifier.getValue(),
+								practitionerRoleCoding.getSystem(), practitionerRoleCoding.getCode()));
 					}
 				}
 			}

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
@@ -207,8 +207,8 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 				.equals(messageName.getUrl()))
 			return false;
 
-		return messageName.hasValue() && messageName.getValue() instanceof StringType
-				&& !((StringType) messageName.getValue()).getValueAsString().isBlank();
+		return messageName.hasValue() && messageName.getValue() instanceof StringType value
+				&& !value.getValueAsString().isBlank();
 	}
 
 	private boolean isTaskProfileValid(Extension taskProfile, Predicate<CanonicalType> profileExists)
@@ -217,8 +217,8 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 				.equals(taskProfile.getUrl()))
 			return false;
 
-		return taskProfile.hasValue() && taskProfile.getValue() instanceof CanonicalType
-				&& profileExists.test((CanonicalType) taskProfile.getValue());
+		return taskProfile.hasValue() && taskProfile.getValue() instanceof CanonicalType value
+				&& profileExists.test(value);
 	}
 
 	private boolean isRequestersValid(List<Extension> requesters, Predicate<Coding> practitionerRoleExists,
@@ -235,10 +235,10 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 				|| !ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_REQUESTER.equals(requester.getUrl()))
 			return false;
 
-		if (requester.hasValue() && requester.getValue() instanceof Coding)
+		if (requester.hasValue() && requester.getValue() instanceof Coding value)
 		{
-			return requesterFrom((Coding) requester.getValue(), practitionerRoleExists,
-					organizationWithIdentifierExists, organizationRoleExists).isPresent();
+			return requesterFrom(value, practitionerRoleExists, organizationWithIdentifierExists,
+					organizationRoleExists).isPresent();
 		}
 
 		return false;
@@ -283,10 +283,10 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 				|| !ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_RECIPIENT.equals(recipient.getUrl()))
 			return false;
 
-		if (recipient.hasValue() && recipient.getValue() instanceof Coding)
+		if (recipient.hasValue() && recipient.getValue() instanceof Coding value)
 		{
-			return recipientFrom((Coding) recipient.getValue(), practitionerRoleExists,
-					organizationWithIdentifierExists, organizationRoleExists).isPresent();
+			return recipientFrom(value, practitionerRoleExists, organizationWithIdentifierExists,
+					organizationRoleExists).isPresent();
 		}
 
 		return false;

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
@@ -197,8 +197,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 		return isMessageNameValid(messageNames.get(0)) && isTaskProfileValid(taskProfiles.get(0), profileExists)
 				&& isRequestersValid(requesters, practitionerRoleExists, organizationWithIdentifierExists,
 						organizationRoleExists)
-				&& isRecipientsValid(recipients, practitionerRoleExists, organizationWithIdentifierExists,
-						organizationRoleExists);
+				&& isRecipientsValid(recipients, organizationWithIdentifierExists, organizationRoleExists);
 	}
 
 	private boolean isMessageNameValid(Extension messageName)
@@ -269,15 +268,15 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 		return Optional.empty();
 	}
 
-	private boolean isRecipientsValid(List<Extension> recipients, Predicate<Coding> practitionerRoleExists,
+	private boolean isRecipientsValid(List<Extension> recipients,
 			Predicate<Identifier> organizationWithIdentifierExists, Predicate<Coding> organizationRoleExists)
 	{
-		return recipients.stream().allMatch(r -> isRecipientValid(r, practitionerRoleExists,
-				organizationWithIdentifierExists, organizationRoleExists));
+		return recipients.stream()
+				.allMatch(r -> isRecipientValid(r, organizationWithIdentifierExists, organizationRoleExists));
 	}
 
-	private boolean isRecipientValid(Extension recipient, Predicate<Coding> practitionerRoleExists,
-			Predicate<Identifier> organizationWithIdentifierExists, Predicate<Coding> organizationRoleExists)
+	private boolean isRecipientValid(Extension recipient, Predicate<Identifier> organizationWithIdentifierExists,
+			Predicate<Coding> organizationRoleExists)
 	{
 		if (recipient == null
 				|| !ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_RECIPIENT.equals(recipient.getUrl()))
@@ -285,15 +284,14 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 
 		if (recipient.hasValue() && recipient.getValue() instanceof Coding value)
 		{
-			return recipientFrom(value, practitionerRoleExists, organizationWithIdentifierExists,
-					organizationRoleExists).isPresent();
+			return recipientFrom(value, organizationWithIdentifierExists, organizationRoleExists).isPresent();
 		}
 
 		return false;
 	}
 
-	private Optional<Recipient> recipientFrom(Coding coding, Predicate<Coding> practitionerRoleExists,
-			Predicate<Identifier> organizationWithIdentifierExists, Predicate<Coding> organizationRoleExists)
+	private Optional<Recipient> recipientFrom(Coding coding, Predicate<Identifier> organizationWithIdentifierExists,
+			Predicate<Coding> organizationRoleExists)
 	{
 		switch (coding.getCode())
 		{
@@ -343,7 +341,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 							.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> recipientFrom(coding, c -> true, i -> true, c -> true).stream());
+					.flatMap(coding -> recipientFrom(coding, i -> true, c -> true).stream());
 	}
 
 	private Optional<Extension> getAuthorizationExtension(ActivityDefinition activityDefinition, String processUrl,

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Role.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Role.java
@@ -347,11 +347,10 @@ public class Role implements Recipient, Requester
 	{
 		if (coding != null && coding.hasSystem()
 				&& ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_SYSTEM.equals(coding.getSystem())
-				&& coding.hasCode())
+				&& coding.hasCode()
+				&& ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_VALUE_LOCAL_ROLE.equals(coding.getCode()))
 		{
-			if (ProcessAuthorizationHelper.PROCESS_AUTHORIZATION_VALUE_LOCAL_ROLE.equals(coding.getCode()))
-				return from(true, coding, organizationWithIdentifierExists, organizationRoleExists)
-						.map(r -> (Recipient) r);
+			return from(true, coding, organizationWithIdentifierExists, organizationRoleExists).map(r -> (Recipient) r);
 		}
 
 		return Optional.empty();
@@ -366,6 +365,7 @@ public class Role implements Recipient, Requester
 					.filter(e -> ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE
 							.equals(e.getUrl()))
 					.collect(Collectors.toList());
+
 			if (parentOrganizationRoles.size() == 1)
 			{
 				Extension parentOrganizationRole = parentOrganizationRoles.get(0);
@@ -379,6 +379,7 @@ public class Role implements Recipient, Requester
 						.filter(e -> ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_ORGANIZATION_ROLE
 								.equals(e.getUrl()))
 						.collect(Collectors.toList());
+
 				if (parentOrganizations.size() == 1 && organizationRoles.size() == 1)
 				{
 					Extension parentOrganization = parentOrganizations.get(0);
@@ -414,6 +415,7 @@ public class Role implements Recipient, Requester
 					.filter(e -> ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_PRACTITIONER
 							.equals(e.getUrl()))
 					.collect(Collectors.toList());
+
 			if (parentOrganizationRolePractitioners.size() == 1)
 			{
 				Extension parentOrganizationRolePractitioner = parentOrganizationRolePractitioners.get(0);
@@ -432,6 +434,7 @@ public class Role implements Recipient, Requester
 						.filter(e -> ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_PRACTITIONER_PRACTITIONER_ROLE
 								.equals(e.getUrl()))
 						.collect(Collectors.toList());
+
 				if (parentOrganizations.size() == 1 && organizationRoles.size() == 1 && practitionerRoles.size() == 1)
 				{
 					Extension parentOrganization = parentOrganizations.get(0);

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Role.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/Role.java
@@ -117,8 +117,8 @@ public class Role implements Recipient, Requester
 
 	private Set<Coding> getPractitionerRoles(Identity identity)
 	{
-		if (identity instanceof PractitionerIdentity)
-			return ((PractitionerIdentity) identity).getPractionerRoles();
+		if (identity instanceof PractitionerIdentity p)
+			return p.getPractionerRoles();
 		else
 			return Collections.emptySet();
 	}
@@ -213,9 +213,8 @@ public class Role implements Recipient, Requester
 	private boolean matches(Extension extension, String url, boolean needsPractitionerRole)
 	{
 		return extension != null && url.equals(extension.getUrl()) && extension.hasValue()
-				&& extension.getValue() instanceof Coding && matches((Coding) extension.getValue())
-				&& extension.getValue().hasExtension() && hasMatchingParentOrganizationRoleExtension(
-						extension.getValue().getExtension(), needsPractitionerRole);
+				&& extension.getValue() instanceof Coding value && matches(value) && value.hasExtension()
+				&& hasMatchingParentOrganizationRoleExtension(value.getExtension(), needsPractitionerRole);
 	}
 
 	private boolean hasMatchingParentOrganizationRoleExtension(List<Extension> extension, boolean needsPractitionerRole)
@@ -250,8 +249,8 @@ public class Role implements Recipient, Requester
 	private boolean parentOrganizationExtensionMatches(Extension extension)
 	{
 		return ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_PARENT_ORGANIZATION
-				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Identifier
-				&& parentOrganizationIdentifierMatches((Identifier) extension.getValue());
+				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Identifier value
+				&& parentOrganizationIdentifierMatches(value);
 	}
 
 	private boolean parentOrganizationIdentifierMatches(Identifier identifier)
@@ -269,8 +268,8 @@ public class Role implements Recipient, Requester
 	private boolean organizationRoleExtensionMatches(Extension extension)
 	{
 		return ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_ORGANIZATION_ROLE
-				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Coding
-				&& organizationRoleMatches((Coding) extension.getValue());
+				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Coding value
+				&& organizationRoleMatches(value);
 	}
 
 	private boolean organizationRoleMatches(Coding coding)
@@ -287,8 +286,8 @@ public class Role implements Recipient, Requester
 	private boolean practitionerRoleExtensionMatches(Extension extension)
 	{
 		return ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_PRACTITIONER_PRACTITIONER_ROLE
-				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Coding
-				&& practitionerRoleMatches((Coding) extension.getValue());
+				.equals(extension.getUrl()) && extension.hasValue() && extension.getValue() instanceof Coding value
+				&& practitionerRoleMatches(value);
 	}
 
 	private boolean practitionerRoleMatches(Coding coding)
@@ -385,20 +384,17 @@ public class Role implements Recipient, Requester
 					Extension parentOrganization = parentOrganizations.get(0);
 					Extension organizationRole = organizationRoles.get(0);
 
-					if (parentOrganization.hasValue() && parentOrganization.getValue() instanceof Identifier
-							&& organizationRole.hasValue() && organizationRole.getValue() instanceof Coding)
+					if (parentOrganization.hasValue()
+							&& parentOrganization.getValue() instanceof Identifier parentOrganizationIdentifier
+							&& organizationRole.hasValue()
+							&& organizationRole.getValue() instanceof Coding organizationRoleCoding
+							&& ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM
+									.equals(parentOrganizationIdentifier.getSystem())
+							&& organizationWithIdentifierExists.test(parentOrganizationIdentifier)
+							&& organizationRoleExists.test(organizationRoleCoding))
 					{
-						Identifier parentOrganizationIdentifier = (Identifier) parentOrganization.getValue();
-						Coding organizationRoleCoding = (Coding) organizationRole.getValue();
-
-						if (ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM
-								.equals(parentOrganizationIdentifier.getSystem())
-								&& organizationWithIdentifierExists.test(parentOrganizationIdentifier)
-								&& organizationRoleExists.test(organizationRoleCoding))
-						{
-							return Optional.of(new Role(localIdentity, parentOrganizationIdentifier.getValue(),
-									organizationRoleCoding.getSystem(), organizationRoleCoding.getCode(), null, null));
-						}
+						return Optional.of(new Role(localIdentity, parentOrganizationIdentifier.getValue(),
+								organizationRoleCoding.getSystem(), organizationRoleCoding.getCode(), null, null));
 					}
 				}
 			}
@@ -442,24 +438,21 @@ public class Role implements Recipient, Requester
 					Extension organizationRole = organizationRoles.get(0);
 					Extension practitionerRole = practitionerRoles.get(0);
 
-					if (parentOrganization.hasValue() && parentOrganization.getValue() instanceof Identifier
-							&& organizationRole.hasValue() && organizationRole.getValue() instanceof Coding
-							&& practitionerRole.hasValue() && practitionerRole.getValue() instanceof Coding)
+					if (parentOrganization.hasValue()
+							&& parentOrganization.getValue() instanceof Identifier parentOrganizationIdentifier
+							&& organizationRole.hasValue()
+							&& organizationRole.getValue() instanceof Coding organizationRoleCoding
+							&& practitionerRole.hasValue()
+							&& practitionerRole.getValue() instanceof Coding practitionerRoleCoding
+							&& ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM
+									.equals(parentOrganizationIdentifier.getSystem())
+							&& organizationWithIdentifierExists.test(parentOrganizationIdentifier)
+							&& organizationRoleExists.test(organizationRoleCoding)
+							&& practitionerRoleExists.test(practitionerRoleCoding))
 					{
-						Identifier parentOrganizationIdentifier = (Identifier) parentOrganization.getValue();
-						Coding organizationRoleCoding = (Coding) organizationRole.getValue();
-						Coding practitionerRoleCoding = (Coding) practitionerRole.getValue();
-
-						if (ProcessAuthorizationHelper.ORGANIZATION_IDENTIFIER_SYSTEM
-								.equals(parentOrganizationIdentifier.getSystem())
-								&& organizationWithIdentifierExists.test(parentOrganizationIdentifier)
-								&& organizationRoleExists.test(organizationRoleCoding)
-								&& practitionerRoleExists.test(practitionerRoleCoding))
-						{
-							return Optional.of(new Role(true, parentOrganizationIdentifier.getValue(),
-									organizationRoleCoding.getSystem(), organizationRoleCoding.getCode(),
-									practitionerRoleCoding.getSystem(), practitionerRoleCoding.getCode()));
-						}
+						return Optional.of(new Role(true, parentOrganizationIdentifier.getValue(),
+								organizationRoleCoding.getSystem(), organizationRoleCoding.getCode(),
+								practitionerRoleCoding.getSystem(), practitionerRoleCoding.getCode()));
 					}
 				}
 			}

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
@@ -351,8 +351,8 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 	private boolean isValidExtensionReadAccesOrganization(Extension extension,
 			Predicate<Identifier> organizationWithIdentifierExists)
 	{
-		return extension.hasValue() && extension.getValue() instanceof Identifier
-				&& isValidOrganizationIdentifier((Identifier) extension.getValue(), organizationWithIdentifierExists);
+		return extension.hasValue() && extension.getValue() instanceof Identifier value
+				&& isValidOrganizationIdentifier(value, organizationWithIdentifierExists);
 	}
 
 	private boolean isValidOrganizationIdentifier(Identifier identifier,
@@ -390,15 +390,15 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 			Predicate<Identifier> organizationWithIdentifierExists)
 	{
 		return e.hasUrl() && EXTENSION_READ_ACCESS_PARENT_ORGANIZATION_ROLE_PARENT_ORGANIZATION.equals(e.getUrl())
-				&& e.hasValue() && e.getValue() instanceof Identifier
-				&& isValidOrganizationIdentifier((Identifier) e.getValue(), organizationWithIdentifierExists);
+				&& e.hasValue() && e.getValue() instanceof Identifier value
+				&& isValidOrganizationIdentifier(value, organizationWithIdentifierExists);
 	}
 
 	private boolean isValidExtensionReadAccessParentOrganizationMemberRoleRole(Extension e,
 			Predicate<Coding> roleExists)
 	{
 		return e.hasUrl() && EXTENSION_READ_ACCESS_PARENT_ORGANIZATION_ROLE_ORGANIZATION_ROLE.equals(e.getUrl())
-				&& e.hasValue() && e.getValue() instanceof Coding && isValidRole((Coding) e.getValue(), roleExists);
+				&& e.hasValue() && e.getValue() instanceof Coding value && isValidRole(value, roleExists);
 	}
 
 	private boolean isValidRole(Coding coding, Predicate<Coding> roleExists)

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/adapter/FhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/adapter/FhirAdapter.java
@@ -82,10 +82,10 @@ public class FhirAdapter extends AbstractAdapter
 
 	private BaseResource fixResource(BaseResource resource)
 	{
-		if (resource instanceof Bundle)
-			return fixBundle((Bundle) resource);
-		else if (resource instanceof Binary)
-			return fixBinary((Binary) resource);
+		if (resource instanceof Bundle b)
+			return fixBundle(b);
+		else if (resource instanceof Binary b)
+			return fixBinary(b);
 		else
 			return resource;
 	}

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferHandlingType.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferHandlingType.java
@@ -6,7 +6,7 @@ public enum PreferHandlingType
 
 	private final String headerValue;
 
-	private PreferHandlingType(String headerValue)
+	PreferHandlingType(String headerValue)
 	{
 		this.headerValue = headerValue;
 	}

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferReturnType.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferReturnType.java
@@ -6,7 +6,7 @@ public enum PreferReturnType
 
 	private final String headerValue;
 
-	private PreferReturnType(String headerValue)
+	PreferReturnType(String headerValue)
 	{
 		this.headerValue = headerValue;
 	}

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ReferenceCleanerImpl.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ReferenceCleanerImpl.java
@@ -50,11 +50,8 @@ public class ReferenceCleanerImpl implements ReferenceCleaner
 		if (resource == null)
 			return null;
 
-		if (resource instanceof Bundle)
-		{
-			Bundle bundle = (Bundle) resource;
-			bundle.getEntry().stream().map(e -> e.getResource()).forEach(this::fixBundleEntry);
-		}
+		if (resource instanceof Bundle b)
+			b.getEntry().stream().map(e -> e.getResource()).forEach(this::fixBundleEntry);
 
 		return resource;
 	}
@@ -71,10 +68,10 @@ public class ReferenceCleanerImpl implements ReferenceCleaner
 
 			references.filter(ResourceReference::hasReference).forEach(r -> r.getReference().setResource(null));
 
-			if (resource instanceof DomainResource && ((DomainResource) resource).hasContained())
+			if (resource instanceof DomainResource d && d.hasContained())
 			{
 				logger.warn("{} has contained resources, removing resources", resource.getClass().getName());
-				((DomainResource) resource).setContained(null);
+				d.setContained(null);
 			}
 		}
 	}

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ReferenceCleanerImpl.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ReferenceCleanerImpl.java
@@ -15,7 +15,7 @@ public class ReferenceCleanerImpl implements ReferenceCleaner
 {
 	private static final Logger logger = LoggerFactory.getLogger(ReferenceCleanerImpl.class);
 
-	private ReferenceExtractor referenceExtractor;
+	private final ReferenceExtractor referenceExtractor;
 
 	public ReferenceCleanerImpl(ReferenceExtractor referenceExtractor)
 	{

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ResourceReference.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ResourceReference.java
@@ -1,22 +1,5 @@
 package dev.dsf.fhir.service;
 
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.ATTACHMENT_CONDITIONAL_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.ATTACHMENT_LITERAL_EXTERNAL_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.ATTACHMENT_LITERAL_INTERNAL_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.ATTACHMENT_TEMPORARY_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.ATTACHMENT_UNKNOWN_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.CONDITIONAL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.LITERAL_EXTERNAL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.LITERAL_INTERNAL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.LOGICAL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_CONDITIONAL_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_LITERAL_INTERNAL_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_TEMPORARY_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_UNKNOWN_URL;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.TEMPORARY;
-import static dev.dsf.fhir.service.ResourceReference.ReferenceType.UNKNOWN;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -95,7 +78,7 @@ public class ResourceReference
 					+ "|SupplyDelivery|SupplyRequest|Task|TerminologyCapabilities|TestReport|TestScript|ValueSet"
 					+ "|VerificationResult|VisionPrescription)" + "(?<query>\\?.*)");
 
-	public static enum ReferenceType
+	public enum ReferenceType
 	{
 		/**
 		 * temporary reference starting with <code>urn:uuid:</code>
@@ -279,24 +262,24 @@ public class ResourceReference
 			{
 				Matcher tempIdRefMatcher = TEMP_ID_PATTERN.matcher(relatedArtifact.getUrl());
 				if (tempIdRefMatcher.matches())
-					return RELATED_ARTEFACT_TEMPORARY_URL;
+					return ReferenceType.RELATED_ARTEFACT_TEMPORARY_URL;
 
 				Matcher idRefMatcher = ID_PATTERN.matcher(relatedArtifact.getUrl());
 				if (idRefMatcher.matches())
 				{
 					IdType id = new IdType(relatedArtifact.getUrl());
 					if (!id.isAbsolute() || localServerBase.equals(id.getBaseUrl()))
-						return RELATED_ARTEFACT_LITERAL_INTERNAL_URL;
+						return ReferenceType.RELATED_ARTEFACT_LITERAL_INTERNAL_URL;
 					else
-						return RELATED_ARTEFACT_LITERAL_EXTERNAL_URL;
+						return ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL;
 				}
 
 				Matcher conditionalRefMatcher = CONDITIONAL_REF_PATTERN.matcher(relatedArtifact.getUrl());
 				if (conditionalRefMatcher.matches())
-					return RELATED_ARTEFACT_CONDITIONAL_URL;
+					return ReferenceType.RELATED_ARTEFACT_CONDITIONAL_URL;
 			}
 
-			return RELATED_ARTEFACT_UNKNOWN_URL;
+			return ReferenceType.RELATED_ARTEFACT_UNKNOWN_URL;
 		}
 		else if (attachment != null)
 		{
@@ -304,24 +287,24 @@ public class ResourceReference
 			{
 				Matcher tempIdRefMatcher = TEMP_ID_PATTERN.matcher(attachment.getUrl());
 				if (tempIdRefMatcher.matches())
-					return ATTACHMENT_TEMPORARY_URL;
+					return ReferenceType.ATTACHMENT_TEMPORARY_URL;
 
 				Matcher idRefMatcher = ID_PATTERN.matcher(attachment.getUrl());
 				if (idRefMatcher.matches())
 				{
 					IdType id = new IdType(attachment.getUrl());
 					if (!id.isAbsolute() || localServerBase.equals(id.getBaseUrl()))
-						return ATTACHMENT_LITERAL_INTERNAL_URL;
+						return ReferenceType.ATTACHMENT_LITERAL_INTERNAL_URL;
 					else
-						return ATTACHMENT_LITERAL_EXTERNAL_URL;
+						return ReferenceType.ATTACHMENT_LITERAL_EXTERNAL_URL;
 				}
 
 				Matcher conditionalRefMatcher = CONDITIONAL_REF_PATTERN.matcher(attachment.getUrl());
 				if (conditionalRefMatcher.matches())
-					return ATTACHMENT_CONDITIONAL_URL;
+					return ReferenceType.ATTACHMENT_CONDITIONAL_URL;
 			}
 
-			return ATTACHMENT_UNKNOWN_URL;
+			return ReferenceType.ATTACHMENT_UNKNOWN_URL;
 		}
 		else if (reference != null)
 		{
@@ -329,29 +312,29 @@ public class ResourceReference
 			{
 				Matcher tempIdRefMatcher = TEMP_ID_PATTERN.matcher(reference.getReference());
 				if (tempIdRefMatcher.matches())
-					return TEMPORARY;
+					return ReferenceType.TEMPORARY;
 
 				Matcher idRefMatcher = ID_PATTERN.matcher(reference.getReference());
 				if (idRefMatcher.matches())
 				{
 					IdType id = new IdType(reference.getReference());
 					if (!id.isAbsolute() || localServerBase.equals(id.getBaseUrl()))
-						return LITERAL_INTERNAL;
+						return ReferenceType.LITERAL_INTERNAL;
 					else
-						return LITERAL_EXTERNAL;
+						return ReferenceType.LITERAL_EXTERNAL;
 				}
 
 				Matcher conditionalRefMatcher = CONDITIONAL_REF_PATTERN.matcher(reference.getReference());
 				if (conditionalRefMatcher.matches())
-					return CONDITIONAL;
+					return ReferenceType.CONDITIONAL;
 			}
 			else if (reference.hasType() && reference.hasIdentifier() && reference.getIdentifier().hasSystem()
 					&& reference.getIdentifier().hasValue())
 			{
-				return LOGICAL;
+				return ReferenceType.LOGICAL;
 			}
 
-			return UNKNOWN;
+			return ReferenceType.UNKNOWN;
 		}
 		else
 			throw new IllegalStateException("Either reference or relatedArtifact expected");
@@ -373,8 +356,8 @@ public class ResourceReference
 	{
 		Objects.requireNonNull(localServerBase, "localServerBase");
 
-		if (EnumSet.of(LITERAL_EXTERNAL, RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, ATTACHMENT_LITERAL_EXTERNAL_URL)
-				.contains(getType(localServerBase)))
+		if (EnumSet.of(ReferenceType.LITERAL_EXTERNAL, ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL,
+				ReferenceType.ATTACHMENT_LITERAL_EXTERNAL_URL).contains(getType(localServerBase)))
 			return new IdType(getValue()).getBaseUrl();
 		else
 			return "";

--- a/dsf-fhir/dsf-fhir-server-jetty/src/main/java/dev/dsf/fhir/FhirJettyServer.java
+++ b/dsf-fhir/dsf-fhir-server-jetty/src/main/java/dev/dsf/fhir/FhirJettyServer.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.config.FhirDbMigratorConfig;
 import dev.dsf.fhir.config.FhirHttpJettyConfig;
 import dev.dsf.tools.db.DbMigrator;
 
-public class FhirJettyServer
+public final class FhirJettyServer
 {
 	static
 	{
@@ -17,6 +17,10 @@ public class FhirJettyServer
 		SLF4JBridgeHandler.install();
 
 		Log4jInitializer.initializeLog4j();
+	}
+
+	private FhirJettyServer()
+	{
 	}
 
 	public static void main(String[] args)

--- a/dsf-fhir/dsf-fhir-server-jetty/src/main/java/dev/dsf/fhir/FhirJettyServerHttps.java
+++ b/dsf-fhir/dsf-fhir-server-jetty/src/main/java/dev/dsf/fhir/FhirJettyServerHttps.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.config.FhirDbMigratorConfig;
 import dev.dsf.fhir.config.FhirHttpsJettyConfig;
 import dev.dsf.tools.db.DbMigrator;
 
-public class FhirJettyServerHttps
+public final class FhirJettyServerHttps
 {
 	static
 	{
@@ -17,6 +17,10 @@ public class FhirJettyServerHttps
 		SLF4JBridgeHandler.install();
 
 		Log4jInitializer.initializeLog4j();
+	}
+
+	private FhirJettyServerHttps()
+	{
 	}
 
 	public static void main(String[] args)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractHtmlAdapter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractHtmlAdapter.java
@@ -1,0 +1,51 @@
+package dev.dsf.fhir.adapter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Objects;
+
+import org.hl7.fhir.r4.model.Resource;
+
+public abstract class AbstractHtmlAdapter
+{
+	protected static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+	protected static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+	protected static final DateTimeFormatter DATE_TIME_DISPLAY_FORMAT = DateTimeFormatter
+			.ofPattern("dd.MM.yyyy HH:mm:ss");
+
+	/**
+	 * @param date
+	 *            may be <code>null</code>
+	 * @param formatter
+	 *            not <code>null</code>
+	 * @return empty String if given date is <code>null</code>
+	 */
+	protected String format(Date date, DateTimeFormatter formatter)
+	{
+		Objects.requireNonNull(formatter, "formatter");
+
+		if (date == null)
+			return "";
+		else
+			return formatter.format(LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()));
+	}
+
+	/**
+	 * @param resource
+	 *            may be <code>null</code>
+	 * @param formatter
+	 *            not <code>null</code>
+	 * @return empty String if given resource is <code>null</code> or has no meta or meta.lastUpdated
+	 */
+	protected String formatLastUpdated(Resource resource, DateTimeFormatter formatter)
+	{
+		Objects.requireNonNull(formatter, "formatter");
+
+		if (resource == null || !resource.hasMeta() || !resource.getMeta().hasLastUpdated())
+			return "";
+		else
+			return format(resource.getMeta().getLastUpdated(), formatter);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/EndpointHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/EndpointHtmlGenerator.java
@@ -27,7 +27,7 @@ public class EndpointHtmlGenerator extends ResourceHtmlGenerator implements Html
 		out.write("</div>\n");
 
 		writeMeta(resource, out);
-		writeRow("Status", (resource.hasStatus() ? resource.getStatus().toCode() : ""), out);
+		writeRow("Status", resource.hasStatus() ? resource.getStatus().toCode() : "", out);
 
 		writeSectionHeader("Endpoint", out);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
@@ -176,12 +176,11 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 		out.write("<div id=\"icons\">\n");
 
 		Principal userPrincipal = securityContext.getUserPrincipal();
-		if (userPrincipal instanceof Identity)
+		if (userPrincipal instanceof Identity i)
 		{
-			Identity identity = (Identity) userPrincipal;
 			out.write("<span id=\"hello-user\">");
 			out.write("Hello, ");
-			out.write(identity.getDisplayName());
+			out.write(i.getDisplayName());
 			out.write("</span>\n");
 		}
 
@@ -344,7 +343,7 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 
 	private Optional<String> getResourceUrlString(Resource resource) throws MalformedURLException
 	{
-		if (resource instanceof Resource && resource.getIdElement().hasIdPart())
+		if (resource.getIdElement().hasIdPart())
 		{
 			if (!uriInfo.getPath().contains("_history"))
 				return Optional.of(String.format("%s/%s/%s", serverBaseUrl, resource.getIdElement().getResourceType(),
@@ -354,9 +353,8 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 						String.format("%s/%s/%s/_history/%s", serverBaseUrl, resource.getIdElement().getResourceType(),
 								resource.getIdElement().getIdPart(), resource.getIdElement().getVersionIdPart()));
 		}
-		else if (resource instanceof Bundle && !resource.getIdElement().hasIdPart())
-			return ((Bundle) resource).getLink().stream().filter(c -> "self".equals(c.getRelation())).findFirst()
-					.map(c -> c.getUrl());
+		else if (resource instanceof Bundle b && !resource.getIdElement().hasIdPart())
+			return b.getLink().stream().filter(c -> "self".equals(c.getRelation())).findFirst().map(c -> c.getUrl());
 		else
 			return Optional.empty();
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
@@ -492,9 +492,7 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 						return new IdType(c.getResponse().getLocation()).getResourceType();
 				}).findFirst();
 		}
-		else if (resource instanceof Resource)
-			return Optional.of(resource.getClass().getAnnotation(ResourceDef.class).name());
 		else
-			return Optional.empty();
+			return Optional.of(resource.getClass().getAnnotation(ResourceDef.class).name());
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/InputHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/InputHtmlGenerator.java
@@ -190,7 +190,7 @@ public abstract class InputHtmlGenerator
 	{
 		out.write("<div class=\"input-group\">\n");
 		writeInput(type, value, elementName, elementIndex, Optional.empty(), writable, out);
-		writePlaceholderButton(elementName, value, writable, out);
+		writePlaceholderButton(writable, out);
 		out.write("</div>\n");
 	}
 
@@ -199,13 +199,13 @@ public abstract class InputHtmlGenerator
 	{
 		out.write("<div class=\"input-group\">\n");
 		writeInput("url", system, elementName + "-system", elementIndex, Optional.empty(), writable, out);
-		writePlaceholderButton(elementName + "-system", system, writable, out);
+		writePlaceholderButton(writable, out);
 		out.write("</div>\n");
 
 		out.write("<div class=\"input-group\">\n");
 		writeInput("text", code, elementName + "-code", elementIndex, Optional.of("identifier-coding-code"), writable,
 				out);
-		writePlaceholderButton(elementName + "-code", code, writable, out);
+		writePlaceholderButton(writable, out);
 		out.write("</div>\n");
 	}
 
@@ -217,8 +217,7 @@ public abstract class InputHtmlGenerator
 				+ (writable ? "placeholder=\"" + value + "\"" : "value=\"" + value + "\"") + "></input>\n");
 	}
 
-	private void writePlaceholderButton(String elementName, String value, boolean writable, OutputStreamWriter out)
-			throws IOException
+	private void writePlaceholderButton(boolean writable, OutputStreamWriter out) throws IOException
 	{
 		if (writable)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/InputHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/InputHtmlGenerator.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.adapter;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,12 +22,8 @@ import org.hl7.fhir.r4.model.TimeType;
 import org.hl7.fhir.r4.model.Type;
 import org.hl7.fhir.r4.model.UriType;
 
-public abstract class InputHtmlGenerator
+public abstract class InputHtmlGenerator extends AbstractHtmlAdapter
 {
-	protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-	protected static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-	protected static final SimpleDateFormat DATE_TIME_DISPLAY_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
-
 	protected void writeDisplayRow(String text, String elementName, boolean display, OutputStreamWriter out)
 			throws IOException
 	{
@@ -116,7 +111,7 @@ public abstract class InputHtmlGenerator
 			}
 			else if (type instanceof DateType d)
 			{
-				String date = d.hasValue() ? DATE_FORMAT.format(d.getValue()) : "";
+				String date = d.hasValue() ? format(d.getValue(), DATE_FORMAT) : "";
 				writeInputFieldValueInput("date", date, elementName, elementIndex, writable, out);
 			}
 			else if (type instanceof TimeType t)
@@ -126,12 +121,12 @@ public abstract class InputHtmlGenerator
 			}
 			else if (type instanceof DateTimeType dt)
 			{
-				String dateTime = dt.hasValue() ? DATE_TIME_FORMAT.format(dt.getValue()) : "";
+				String dateTime = dt.hasValue() ? format(dt.getValue(), DATE_TIME_FORMAT) : "";
 				writeInputFieldValueInput("datetime-local", dateTime, elementName, elementIndex, writable, out);
 			}
 			else if (type instanceof InstantType i)
 			{
-				String dateTime = i.hasValue() ? DATE_TIME_FORMAT.format(i.getValue()) : "";
+				String dateTime = i.hasValue() ? format(i.getValue(), DATE_TIME_FORMAT) : "";
 				writeInputFieldValueInput("datetime-local", dateTime, elementName, elementIndex, writable, out);
 			}
 			else if (type instanceof UriType u)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/OrganizationHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/OrganizationHtmlGenerator.java
@@ -92,9 +92,9 @@ public class OrganizationHtmlGenerator extends ResourceHtmlGenerator implements 
 
 				if (contact.hasName())
 					writeRow("Name",
-							(contact.getName().getNameAsSingleString() != null
+							contact.getName().getNameAsSingleString() != null
 									? contact.getName().getNameAsSingleString()
-									: ""),
+									: "",
 							out);
 
 				if (contact.hasAddress())
@@ -135,11 +135,11 @@ public class OrganizationHtmlGenerator extends ResourceHtmlGenerator implements 
 
 			if (eMail.isPresent())
 				writeRowWithAdditionalRowClasses("eMail", eMail.get().getValue(),
-						(phone.isPresent() ? "contact-element-50 contact-element-margin" : "contact-element-100"), out);
+						phone.isPresent() ? "contact-element-50 contact-element-margin" : "contact-element-100", out);
 
 			if (phone.isPresent())
 				writeRowWithAdditionalRowClasses("Phone", phone.get().getValue(),
-						(eMail.isPresent() ? "contact-element-50" : "contact-element-100"), out);
+						eMail.isPresent() ? "contact-element-50" : "contact-element-100", out);
 
 			out.write("</div>\n");
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/QuestionnaireResponseHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/QuestionnaireResponseHtmlGenerator.java
@@ -57,9 +57,7 @@ public class QuestionnaireResponseHtmlGenerator extends InputHtmlGenerator
 				+ " / " + (questionnaireResponse.getIdElement() == null ? ""
 						: questionnaireResponse.getIdElement().getVersionIdPart())
 				+ "</li>\n");
-		out.write("<li><b>Last Updated:</b> "
-				+ (questionnaireResponse.getMeta().getLastUpdated() == null ? ""
-						: DATE_TIME_DISPLAY_FORMAT.format(questionnaireResponse.getMeta().getLastUpdated()))
+		out.write("<li><b>Last Updated:</b> " + formatLastUpdated(questionnaireResponse, DATE_TIME_DISPLAY_FORMAT)
 				+ "</li>\n");
 		out.write("<li><b>Status:</b> "
 				+ (questionnaireResponse.getStatus() == null ? "" : questionnaireResponse.getStatus().toCode())

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceHtmlGenerator.java
@@ -4,15 +4,12 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.text.SimpleDateFormat;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.Resource;
 
-public abstract class ResourceHtmlGenerator
+public abstract class ResourceHtmlGenerator extends AbstractHtmlAdapter
 {
-	protected static final SimpleDateFormat DATE_TIME_DISPLAY_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
-
 	protected String getServerBaseUrlPath(String serverBaseUrl)
 	{
 		try
@@ -39,8 +36,8 @@ public abstract class ResourceHtmlGenerator
 
 		if (resource.getMeta().hasLastUpdated())
 		{
-			writeRowWithAdditionalRowClasses("Last Updated",
-					DATE_TIME_DISPLAY_FORMAT.format(resource.getMeta().getLastUpdated()), "last-updated", out);
+			writeRowWithAdditionalRowClasses("Last Updated", formatLastUpdated(resource, DATE_TIME_DISPLAY_FORMAT),
+					"last-updated", out);
 		}
 
 		out.write("</div>\n");

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/SearchBundleHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/SearchBundleHtmlGenerator.java
@@ -5,7 +5,6 @@ import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -40,9 +39,8 @@ import org.springframework.web.util.HtmlUtils;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements HtmlGenerator<Bundle>
+public class SearchBundleHtmlGenerator extends AbstractHtmlAdapter implements HtmlGenerator<Bundle>
 {
-	private static final SimpleDateFormat DATE_TIME_DISPLAY_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
 	private static final String INSTANTIATES_CANONICAL_PATTERN_STRING = "(?<processUrl>http[s]{0,1}://(?<domain>(?:(?:[a-zA-Z0-9]{1,63}|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])\\.)+(?:[a-zA-Z0-9]{1,63}))"
 			+ "/bpe/Process/(?<processName>[a-zA-Z0-9-]+))\\|(?<processVersion>\\d+\\.\\d+)$";
 	private static final Pattern INSTANTIATES_CANONICAL_PATTERN = Pattern
@@ -317,14 +315,6 @@ public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements Htm
 		}
 	}
 
-	private String toLastUpdated(Resource resource)
-	{
-		if (resource == null || !resource.hasMeta() || !resource.getMeta().hasLastUpdated())
-			return "";
-		else
-			return DATE_TIME_DISPLAY_FORMAT.format(resource.getMeta().getLastUpdated());
-	}
-
 	private String getTaskRow(Task resource)
 	{
 		String domain = "", processName = "", processVersion = "";
@@ -364,7 +354,8 @@ public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements Htm
 								? resource.getRequester().getIdentifier().getValue()
 								: "")
 				+ "</td><td " + (TaskStatus.DRAFT.equals(resource.getStatus()) ? "" : "class=\"id-value\"") + ">"
-				+ businessKeyOrIdentifier + "</td><td>" + toLastUpdated(resource) + "</td>";
+				+ businessKeyOrIdentifier + "</td><td>" + formatLastUpdated(resource, DATE_TIME_DISPLAY_FORMAT)
+				+ "</td>";
 	}
 
 	private Predicate<ParameterComponent> isStringParam(String system, String code)
@@ -386,7 +377,8 @@ public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements Htm
 				+ createResourceLink(resource) + "</td><td>"
 				+ (resource.hasStatus() ? resource.getStatus().toCode() : "") + "</td><td>"
 				+ (resource.hasQuestionnaire() ? resource.getQuestionnaire().replaceAll("\\|", " \\| ") : "")
-				+ "</td><td class=\"id-value\">" + businessKey + "</td><td>" + toLastUpdated(resource) + "</td>";
+				+ "</td><td class=\"id-value\">" + businessKey + "</td><td>"
+				+ formatLastUpdated(resource, DATE_TIME_DISPLAY_FORMAT) + "</td>";
 	}
 
 	private <D extends DomainResource> String getIdentifierValues(D resource, Function<D, Boolean> hasIdentifier,
@@ -414,7 +406,8 @@ public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements Htm
 		return "<td class=\"id-value\" active=\"" + (resource.hasActive() ? resource.getActive() : "") + "\">"
 				+ createResourceLink(resource) + "</td><td>" + (resource.hasActive() ? resource.getActive() : "")
 				+ "</td><td>" + identifier + "</td><td>" + name + "</td><td class=\"id-value\">"
-				+ createResourceLink(resource.getEndpoint()) + "</td><td>" + toLastUpdated(resource) + "</td>";
+				+ createResourceLink(resource.getEndpoint()) + "</td><td>"
+				+ formatLastUpdated(resource, DATE_TIME_DISPLAY_FORMAT) + "</td>";
 	}
 
 	private String getOrganizationAffiliationRow(OrganizationAffiliation resource)
@@ -428,7 +421,7 @@ public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements Htm
 				+ "</td><td class=\"id-value\">" + createResourceLink(resource.getOrganization())
 				+ "</td><td class=\"id-value\">" + createResourceLink(resource.getParticipatingOrganization())
 				+ "</td><td>" + role + "</td><td class=\"id-value\">" + createResourceLink(resource.getEndpoint())
-				+ "</td><td>" + toLastUpdated(resource) + "</td>";
+				+ "</td><td>" + formatLastUpdated(resource, DATE_TIME_DISPLAY_FORMAT) + "</td>";
 	}
 
 	private String getEndpointRow(Endpoint resource)
@@ -442,6 +435,6 @@ public class SearchBundleHtmlGenerator extends InputHtmlGenerator implements Htm
 				+ (resource.hasStatus() ? resource.getStatus().toCode() : "") + "</td><td>" + identifier + "</td><td>"
 				+ name + "</td><td>" + (resource.hasAddress() ? resource.getAddress() : "")
 				+ "</td><td class=\"id-value\">" + createResourceLink(resource.getManagingOrganization()) + "</td><td>"
-				+ toLastUpdated(resource) + "</td>";
+				+ formatLastUpdated(resource, DATE_TIME_DISPLAY_FORMAT) + "</td>";
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/TaskHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/TaskHtmlGenerator.java
@@ -60,8 +60,7 @@ public class TaskHtmlGenerator extends InputHtmlGenerator implements HtmlGenerat
 		out.write("<ul class=\"info-list\">\n");
 		out.write("<li><b>ID / Version:</b> " + (task.getIdElement() == null ? "" : task.getIdElement().getIdPart())
 				+ " / " + (task.getIdElement() == null ? "" : task.getIdElement().getVersionIdPart()) + "</li>\n");
-		out.write("<li><b>Last Updated:</b> " + (task.getMeta().getLastUpdated() == null ? ""
-				: DATE_TIME_DISPLAY_FORMAT.format(task.getMeta().getLastUpdated())) + "</li>\n");
+		out.write("<li><b>Last Updated:</b> " + formatLastUpdated(task, DATE_TIME_DISPLAY_FORMAT) + "</li>\n");
 		out.write("<li><b>Status:</b> " + (task.getStatus() == null ? "" : task.getStatus().toCode()) + "</li>\n");
 		out.write("<li><b>Process:</b> <a href=\"ActivityDefinition?url="
 				+ (task.getInstantiatesCanonical() == null ? "" : task.getInstantiatesCanonical()) + "\">"
@@ -94,7 +93,7 @@ public class TaskHtmlGenerator extends InputHtmlGenerator implements HtmlGenerat
 				+ "\"></input>\n");
 		out.write("</div>\n");
 
-		String authoredOn = DATE_TIME_FORMAT.format(task.getAuthoredOn());
+		String authoredOn = format(task.getAuthoredOn(), DATE_TIME_FORMAT);
 		out.write("<div class=\"row " + (draft ? "invisible" : "") + "\" name=\"authored-on-row\">\n");
 		out.write("<label class=\"row-label\">authored-on</label>\n");
 		out.write("<input type=\"datetime-local\" name=\"authored-on\" "

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authentication/IdentityProviderImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authentication/IdentityProviderImpl.java
@@ -128,8 +128,8 @@ public class IdentityProviderImpl extends AbstractProvider implements IdentityPr
 	private Map<String, Object> getPropertyMap(Map<String, Object> map, String property)
 	{
 		Object propertyValue = map.get(property);
-		if (propertyValue != null && propertyValue instanceof Map)
-			return (Map<String, Object>) propertyValue;
+		if (propertyValue != null && propertyValue instanceof Map m)
+			return m;
 		else
 			return Collections.emptyMap();
 	}
@@ -137,9 +137,8 @@ public class IdentityProviderImpl extends AbstractProvider implements IdentityPr
 	private List<String> getPropertyArray(Map<String, Object> map, String property)
 	{
 		Object propertyValue = map.get(property);
-		if (propertyValue != null && propertyValue instanceof Object[])
-			return Arrays.stream((Object[]) propertyValue).filter(v -> v instanceof String).map(v -> (String) v)
-					.toList();
+		if (propertyValue != null && propertyValue instanceof Object[] o)
+			return Arrays.stream(o).filter(v -> v instanceof String).map(v -> (String) v).toList();
 		else
 			return Collections.emptyList();
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authentication/PractitionerProviderImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authentication/PractitionerProviderImpl.java
@@ -70,7 +70,9 @@ public class PractitionerProviderImpl extends AbstractProvider implements Practi
 		}
 		catch (CertificateEncodingException e)
 		{
+			logger.debug("Unable to get X500Name from certificate", e);
 			logger.warn("Unable to get X500Name from certificate: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/AbstractAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/AbstractAuthorizationRule.java
@@ -106,7 +106,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing database", e);
+			logger.debug("Error while accessing database", e);
+			logger.warn("Error while accessing database: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -120,7 +122,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing database", e);
+			logger.debug("Error while accessing database", e);
+			logger.warn("Error while accessing database: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -138,7 +142,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing database", e);
+			logger.debug("Error while accessing database", e);
+			logger.warn("Error while accessing database: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -152,7 +158,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing database", e);
+			logger.debug("Error while accessing database", e);
+			logger.warn("Error while accessing database: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -166,7 +174,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing database", e);
+			logger.debug("Error while accessing database", e);
+			logger.warn("Error while accessing database: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -186,6 +196,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		if (!uQp.isEmpty())
 		{
 			logger.warn("Unable to search for Organization: Unsupported query parameters: {}", uQp);
+
 			throw new IllegalStateException("Unable to search for Organization: Unsupported query parameters.");
 		}
 
@@ -196,7 +207,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for Organization", e);
+			logger.debug("Unable to search for Organization", e);
+			logger.warn("Unable to search for Organization: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException("Unable to search for Organization", e);
 		}
 	}
@@ -217,6 +230,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		if (!uQp.isEmpty())
 		{
 			logger.warn("Unable to search for CodeSystem: Unsupported query parameters: {}", uQp);
+
 			throw new IllegalStateException("Unable to search for CodeSystem: Unsupported query parameters");
 		}
 
@@ -227,7 +241,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for CodeSystem", e);
+			logger.debug("Unable to search for CodeSystem", e);
+			logger.warn("Unable to search for CodeSystem: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException("Unable to search for CodeSystem", e);
 		}
 	}
@@ -258,6 +274,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		if (reference == null)
 		{
 			logger.warn("Null reference while checking if user part of referenced organization");
+
 			return false;
 		}
 		else
@@ -269,6 +286,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 			{
 				logger.warn("Reference of type {} not supported while checking if user part of referenced organization",
 						type);
+
 				return false;
 			}
 
@@ -289,6 +307,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 			{
 				logger.warn(
 						"Reference to organization could not be resolved while checking if user part of referenced organization");
+
 				return false;
 			}
 		}
@@ -332,7 +351,9 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing database", e);
+			logger.debug("Error while accessing database", e);
+			logger.warn("Error while accessing database: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -343,12 +364,14 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		if (identity.hasDsfRole(FhirServerRole.SEARCH))
 		{
 			logger.info("Search of {} authorized for identity '{}'", getResourceTypeName(), identity.getName());
+
 			return Optional.of("Identity has role " + FhirServerRole.SEARCH);
 		}
 		else
 		{
 			logger.warn("Search of {} unauthorized for identity '{}', no role {}", getResourceTypeName(),
 					identity.getName(), FhirServerRole.SEARCH);
+
 			return Optional.empty();
 		}
 	}
@@ -359,12 +382,14 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		if (identity.hasDsfRole(FhirServerRole.HISTORY))
 		{
 			logger.info("History of {} authorized for identity '{}'", getResourceTypeName(), identity.getName());
+
 			return Optional.of("Identity has role " + FhirServerRole.HISTORY);
 		}
 		else
 		{
 			logger.warn("History of {} unauthorized for identity '{}', no role {}", getResourceTypeName(),
 					identity.getName(), FhirServerRole.HISTORY);
+
 			return Optional.empty();
 		}
 	}
@@ -380,6 +405,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 		{
 			logger.info("Permanent delete of {}/{}/_history/{} authorized for identity '{}'", getResourceTypeName(),
 					resourceId, resourceVersion, identity.getName());
+
 			return Optional.of("Identity is local identity and has role " + FhirServerRole.PERMANENT_DELETE);
 		}
 		else
@@ -388,6 +414,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 					"Permanent delete of {}/{}/_history/{} unauthorized for identity '{}', not a local identity or no role {}",
 					getResourceTypeName(), resourceId, resourceVersion, identity.getName(),
 					FhirServerRole.PERMANENT_DELETE);
+
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/AbstractMetaTagAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/AbstractMetaTagAuthorizationRule.java
@@ -57,17 +57,20 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 				if (!resourceExists(connection, newResource))
 				{
 					logger.info("Create of {} authorized for identity '{}'", getResourceTypeName(), identity.getName());
+
 					return Optional.of("Identity is local identity and has role " + FhirServerRole.CREATE);
 				}
 				else
 				{
 					logger.warn("Create of {} unauthorized, unique resource already exists", getResourceTypeName());
+
 					return Optional.empty();
 				}
 			}
 			else
 			{
 				logger.warn("Create of {} unauthorized, {}", getResourceTypeName(), errors.get());
+
 				return Optional.empty();
 			}
 		}
@@ -75,6 +78,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 		{
 			logger.warn("Create of {} unauthorized for identity '{}', not a local identity or no role {}",
 					getResourceTypeName(), identity.getName(), FhirServerRole.CREATE);
+
 			return Optional.empty();
 		}
 	}
@@ -104,6 +108,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 				{
 					logger.warn("Read of {}/{}/_history/{} unauthorized for identity '{}', no matching access tags",
 							getResourceTypeName(), resourceId.toString(), resourceVersion, identity.getName());
+
 					return Optional.empty();
 				}
 				else
@@ -113,13 +118,16 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 					logger.info("Read of {}/{}/_history/{} authorized for identity '{}', matching access {} {}",
 							getResourceTypeName(), resourceId.toString(), resourceVersion, identity.getName(),
 							accessTypes.size() == 1 ? "tag" : "tags", tags);
+
 					return Optional.of("Identity has role " + FhirServerRole.READ + ", matching access "
 							+ (accessTypes.size() == 1 ? "tag" : "tags") + " " + tags);
 				}
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Error while checking read access", e);
+				logger.debug("Error while checking read access", e);
+				logger.warn("Error while checking read access: {} - {}", e.getClass().getName(), e.getMessage());
+
 				throw new RuntimeException(e);
 			}
 		}
@@ -127,6 +135,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 		{
 			logger.warn("Read of {}/{}/_history/{} unauthorized for identity '{}', no role {}", getResourceTypeName(),
 					resourceId.toString(), resourceVersion, identity.getName(), FhirServerRole.READ);
+
 			return Optional.empty();
 		}
 	}
@@ -149,12 +158,14 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 				{
 					logger.info("Update of {}/{}/_history/{} authorized for identity '{}'", getResourceTypeName(),
 							resourceId.toString(), resourceVersion, identity.getName());
+
 					return Optional.of("Identity is local identity and has role " + FhirServerRole.UPDATE);
 				}
 				else
 				{
 					logger.warn("Update of {}/{}/_history/{} unauthorized, modification not allowed",
 							getResourceTypeName(), resourceId.toString(), resourceVersion);
+
 					return Optional.empty();
 				}
 			}
@@ -162,6 +173,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 			{
 				logger.warn("Update of {}/{}/_history/{} unauthorized, {}", getResourceTypeName(),
 						resourceId.toString(), resourceVersion, errors.get());
+
 				return Optional.empty();
 			}
 		}
@@ -171,6 +183,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 					"Update of {}/{}/_history/{} unauthorized for identity '{}', not a local identity or no role {}",
 					getResourceTypeName(), resourceId.toString(), resourceVersion, identity.getName(),
 					FhirServerRole.UPDATE);
+
 			return Optional.empty();
 		}
 	}
@@ -199,6 +212,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 		{
 			logger.info("Delete of {}/{}/_history/{} authorized for identity '{}'", getResourceTypeName(), resourceId,
 					resourceVersion, identity.getName());
+
 			return Optional.of("Identity is local identity and has role " + FhirServerRole.DELETE);
 		}
 		else
@@ -206,6 +220,7 @@ public abstract class AbstractMetaTagAuthorizationRule<R extends Resource, D ext
 			logger.warn(
 					"Delete of {}/{}/_history/{} unauthorized for identity '{}', not a local identity or no role {}",
 					getResourceTypeName(), resourceId, resourceVersion, identity.getName(), FhirServerRole.DELETE);
+
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
@@ -120,7 +120,10 @@ public class ActivityDefinitionAuthorizationRule
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while searching for ActivityDefinition", e);
+			logger.debug("Error while searching for ActivityDefinition", e);
+			logger.warn("Error while searching for ActivityDefinition: {} - {}", e.getClass().getName(),
+					e.getMessage());
+
 			return false;
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
@@ -50,20 +50,20 @@ public class ActivityDefinitionAuthorizationRule
 	}
 
 	@Override
-	protected Optional<String> newResourceOkForCreate(Connection connection, Identity user,
+	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			ActivityDefinition newResource)
 	{
-		return newResourceOk(connection, user, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
-	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity user,
+	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			ActivityDefinition newResource)
 	{
-		return newResourceOk(connection, user, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, ActivityDefinition newResource)
+	private Optional<String> newResourceOk(Connection connection, ActivityDefinition newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/BundleAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/BundleAuthorizationRule.java
@@ -29,16 +29,16 @@ public class BundleAuthorizationRule extends AbstractMetaTagAuthorizationRule<Bu
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Bundle newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Bundle newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Bundle newResource)
+	private Optional<String> newResourceOk(Connection connection, Bundle newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/CodeSystemAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/CodeSystemAuthorizationRule.java
@@ -93,7 +93,9 @@ public class CodeSystemAuthorizationRule extends AbstractMetaTagAuthorizationRul
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while searching for CodeSystem", e);
+			logger.debug("Error while searching for CodeSystem", e);
+			logger.warn("Error while searching for CodeSystem: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return false;
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/CodeSystemAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/CodeSystemAuthorizationRule.java
@@ -36,16 +36,16 @@ public class CodeSystemAuthorizationRule extends AbstractMetaTagAuthorizationRul
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, CodeSystem newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, CodeSystem newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, CodeSystem newResource)
+	private Optional<String> newResourceOk(Connection connection, CodeSystem newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/DocumentReferenceAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/DocumentReferenceAuthorizationRule.java
@@ -31,17 +31,17 @@ public class DocumentReferenceAuthorizationRule
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			DocumentReference newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			DocumentReference newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, DocumentReference newResource)
+	private Optional<String> newResourceOk(Connection connection, DocumentReference newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/EndpointAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/EndpointAuthorizationRule.java
@@ -116,6 +116,7 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 		if (!uQp.isEmpty())
 		{
 			logger.warn("Unable to search for Endpoint: Unsupported query parameters: {}", uQp);
+
 			throw new IllegalStateException("Unable to search for Endpoint: Unsupported query parameters");
 		}
 
@@ -126,7 +127,9 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for Endpoint", e);
+			logger.debug("Unable to search for Endpoint", e);
+			logger.warn("Unable to search for Endpoint: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException("Unable to search for Endpoint", e);
 		}
 	}
@@ -142,6 +145,7 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 		if (!uQp.isEmpty())
 		{
 			logger.warn("Unable to search for Endpoint: Unsupported query parameters: {}", uQp);
+
 			throw new IllegalStateException("Unable to search for Endpoint: Unsupported query parameters");
 		}
 
@@ -152,7 +156,9 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for Endpoint", e);
+			logger.debug("Unable to search for Endpoint", e);
+			logger.warn("Unable to search for Endpoint: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException("Unable to search for Endpoint", e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/EndpointAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/EndpointAuthorizationRule.java
@@ -44,16 +44,16 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Endpoint newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Endpoint newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Endpoint newResource)
+	private Optional<String> newResourceOk(Connection connection, Endpoint newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/GroupAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/GroupAuthorizationRule.java
@@ -29,16 +29,16 @@ public class GroupAuthorizationRule extends AbstractMetaTagAuthorizationRule<Gro
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Group newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Group newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Group newResource)
+	private Optional<String> newResourceOk(Connection connection, Group newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/HealthcareServiceAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/HealthcareServiceAuthorizationRule.java
@@ -31,17 +31,17 @@ public class HealthcareServiceAuthorizationRule
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			HealthcareService newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			HealthcareService newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, HealthcareService newResource)
+	private Optional<String> newResourceOk(Connection connection, HealthcareService newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LibraryAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LibraryAuthorizationRule.java
@@ -29,16 +29,16 @@ public class LibraryAuthorizationRule extends AbstractMetaTagAuthorizationRule<L
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Library newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Library newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Library newResource)
+	private Optional<String> newResourceOk(Connection connection, Library newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LocationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LocationAuthorizationRule.java
@@ -29,16 +29,16 @@ public class LocationAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Location newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Location newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Location newResource)
+	private Optional<String> newResourceOk(Connection connection, Location newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureAuthorizationRule.java
@@ -29,16 +29,16 @@ public class MeasureAuthorizationRule extends AbstractMetaTagAuthorizationRule<M
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Measure newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Measure newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Measure newResource)
+	private Optional<String> newResourceOk(Connection connection, Measure newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureReportAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureReportAuthorizationRule.java
@@ -30,17 +30,17 @@ public class MeasureReportAuthorizationRule extends AbstractMetaTagAuthorization
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			MeasureReport newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			MeasureReport newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, MeasureReport newResource)
+	private Optional<String> newResourceOk(Connection connection, MeasureReport newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/NamingSystemAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/NamingSystemAuthorizationRule.java
@@ -116,7 +116,9 @@ public class NamingSystemAuthorizationRule extends AbstractMetaTagAuthorizationR
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while searching for NamingSystem", e);
+			logger.debug("Error while searching for NamingSystem", e);
+			logger.warn("Error while searching for NamingSystem: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return false;
 		}
 	}
@@ -131,7 +133,9 @@ public class NamingSystemAuthorizationRule extends AbstractMetaTagAuthorizationR
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Error while searching for NamingSystem", e);
+				logger.debug("Error while searching for NamingSystem", e);
+				logger.warn("Error while searching for NamingSystem: {} - {}", e.getClass().getName(), e.getMessage());
+
 				return false;
 			}
 		};

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/NamingSystemAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/NamingSystemAuthorizationRule.java
@@ -40,17 +40,17 @@ public class NamingSystemAuthorizationRule extends AbstractMetaTagAuthorizationR
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			NamingSystem newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			NamingSystem newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, NamingSystem newResource)
+	private Optional<String> newResourceOk(Connection connection, NamingSystem newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAffiliationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAffiliationAuthorizationRule.java
@@ -161,6 +161,7 @@ public class OrganizationAffiliationAuthorizationRule
 		if (!uQp.isEmpty())
 		{
 			logger.warn("Unable to search for OrganizationAffiliation: Unsupported query parameters: {}", uQp);
+
 			throw new IllegalStateException(
 					"Unable to search for OrganizationAffiliation: Unsupported query parameters");
 		}
@@ -172,7 +173,10 @@ public class OrganizationAffiliationAuthorizationRule
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for OrganizationAffiliation", e);
+			logger.debug("Unable to search for OrganizationAffiliation", e);
+			logger.warn("Unable to search for OrganizationAffiliation: {} - {}", e.getClass().getName(),
+					e.getMessage());
+
 			throw new RuntimeException("Unable to search for OrganizationAffiliation", e);
 		}
 	}
@@ -211,7 +215,10 @@ public class OrganizationAffiliationAuthorizationRule
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Unable to search for OrganizationAffiliation", e);
+				logger.debug("Unable to search for OrganizationAffiliation", e);
+				logger.warn("Unable to search for OrganizationAffiliation: {} - {}", e.getClass().getName(),
+						e.getMessage());
+
 				throw new RuntimeException("Unable to search for OrganizationAffiliation", e);
 			}
 		};

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAffiliationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAffiliationAuthorizationRule.java
@@ -45,18 +45,17 @@ public class OrganizationAffiliationAuthorizationRule
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			OrganizationAffiliation newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			OrganizationAffiliation newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity,
-			OrganizationAffiliation newResource)
+	private Optional<String> newResourceOk(Connection connection, OrganizationAffiliation newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
@@ -47,17 +47,17 @@ public class OrganizationAuthorizationRule extends AbstractMetaTagAuthorizationR
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			Organization newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			Organization newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Organization newResource)
+	private Optional<String> newResourceOk(Connection connection, Organization newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
@@ -81,9 +81,8 @@ public class OrganizationAuthorizationRule extends AbstractMetaTagAuthorizationR
 		{
 			if (!newResource.getExtension().stream().filter(Extension::hasUrl)
 					.filter(e -> EXTENSION_THUMBPRINT_URL.equals(e.getUrl()))
-					.allMatch(e -> e.hasValue() && e.getValue() instanceof StringType
-							&& EXTENSION_THUMBPRINT_VALUE_PATTERN.matcher(((StringType) e.getValue()).getValue())
-									.matches()))
+					.allMatch(e -> e.hasValue() && e.getValue() instanceof StringType value
+							&& EXTENSION_THUMBPRINT_VALUE_PATTERN.matcher(value.getValue()).matches()))
 			{
 				errors.add("Organization with '" + EXTENSION_THUMBPRINT_URL + "' has value not matching pattern: "
 						+ EXTENSION_THUMBPRINT_VALUE_PATTERN_STRING);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
@@ -134,7 +134,9 @@ public class OrganizationAuthorizationRule extends AbstractMetaTagAuthorizationR
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for Organization", e);
+			logger.debug("Unable to search for Organization", e);
+			logger.warn("Unable to search for Organization: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException("Unable to search for OrganizationAffiliation", e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PatientAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PatientAuthorizationRule.java
@@ -29,16 +29,16 @@ public class PatientAuthorizationRule extends AbstractMetaTagAuthorizationRule<P
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Patient newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Patient newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Patient newResource)
+	private Optional<String> newResourceOk(Connection connection, Patient newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerAuthorizationRule.java
@@ -30,17 +30,17 @@ public class PractitionerAuthorizationRule extends AbstractMetaTagAuthorizationR
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			Practitioner newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			Practitioner newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Practitioner newResource)
+	private Optional<String> newResourceOk(Connection connection, Practitioner newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerRoleAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerRoleAuthorizationRule.java
@@ -31,17 +31,17 @@ public class PractitionerRoleAuthorizationRule
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			PractitionerRole newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			PractitionerRole newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, PractitionerRole newResource)
+	private Optional<String> newResourceOk(Connection connection, PractitionerRole newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ProvenanceAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ProvenanceAuthorizationRule.java
@@ -29,16 +29,16 @@ public class ProvenanceAuthorizationRule extends AbstractMetaTagAuthorizationRul
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, Provenance newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, Provenance newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Provenance newResource)
+	private Optional<String> newResourceOk(Connection connection, Provenance newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireAuthorizationRule.java
@@ -30,17 +30,17 @@ public class QuestionnaireAuthorizationRule extends AbstractMetaTagAuthorization
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			Questionnaire newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			Questionnaire newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Questionnaire newResource)
+	private Optional<String> newResourceOk(Connection connection, Questionnaire newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireResponseAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireResponseAuthorizationRule.java
@@ -48,22 +48,12 @@ public class QuestionnaireResponseAuthorizationRule
 	{
 		if (identity.isLocalIdentity() && identity.hasDsfRole(FhirServerRole.CREATE))
 		{
-			Optional<String> errors = newResourceOk(connection, identity, newResource,
-					EnumSet.of(QuestionnaireResponseStatus.INPROGRESS));
+			Optional<String> errors = newResourceOk(newResource, EnumSet.of(QuestionnaireResponseStatus.INPROGRESS));
 			if (errors.isEmpty())
 			{
-				if (!resourceExists(connection, newResource))
-				{
-					logger.info(
-							"Create of QuestionnaireResponse authorized for local user '{}', QuestionnaireResponse does not exist",
-							identity.getName());
-					return Optional.of("local user, QuestionnaireResponse does not exist yet");
-				}
-				else
-				{
-					logger.warn("Create of QuestionnaireResponse unauthorized, QuestionnaireResponse already exists");
-					return Optional.empty();
-				}
+				// TODO implement unique criteria based on UserTask.id when implemented as identifier
+				logger.info("Create of QuestionnaireResponse authorized for local user '{}'", identity.getName());
+				return Optional.of("local user");
 			}
 			else
 			{
@@ -78,7 +68,7 @@ public class QuestionnaireResponseAuthorizationRule
 		}
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, QuestionnaireResponse newResource,
+	private Optional<String> newResourceOk(QuestionnaireResponse newResource,
 			EnumSet<QuestionnaireResponseStatus> allowedStatus)
 	{
 		List<String> errors = new ArrayList<String>();
@@ -150,12 +140,6 @@ public class QuestionnaireResponseAuthorizationRule
 		return Optional.of(value.getValue());
 	}
 
-	private boolean resourceExists(Connection connection, QuestionnaireResponse newResource)
-	{
-		// TODO implement unique criteria based on UserTask.id when implemented as identifier
-		return false;
-	}
-
 	@Override
 	public Optional<String> reasonReadAllowed(Connection connection, Identity identity,
 			QuestionnaireResponse existingResource)
@@ -178,11 +162,11 @@ public class QuestionnaireResponseAuthorizationRule
 	{
 		if (identity.isLocalIdentity() && identity.hasDsfRole(FhirServerRole.UPDATE))
 		{
-			Optional<String> errors = newResourceOk(connection, identity, newResource,
+			Optional<String> errors = newResourceOk(newResource,
 					EnumSet.of(QuestionnaireResponseStatus.COMPLETED, QuestionnaireResponseStatus.STOPPED));
 			if (errors.isEmpty())
 			{
-				if (modificationsOk(connection, oldResource, newResource))
+				if (modificationsOk(oldResource, newResource))
 				{
 					logger.info("Update of QuestionnaireResponse authorized for local user '{}', modification allowed",
 							identity.getName());
@@ -207,8 +191,7 @@ public class QuestionnaireResponseAuthorizationRule
 		}
 	}
 
-	private boolean modificationsOk(Connection connection, QuestionnaireResponse oldResource,
-			QuestionnaireResponse newResource)
+	private boolean modificationsOk(QuestionnaireResponse oldResource, QuestionnaireResponse newResource)
 	{
 		boolean statusModificationOk = QuestionnaireResponseStatus.INPROGRESS.equals(oldResource.getStatus())
 				&& (QuestionnaireResponseStatus.COMPLETED.equals(newResource.getStatus())

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ResearchStudyAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ResearchStudyAuthorizationRule.java
@@ -30,17 +30,17 @@ public class ResearchStudyAuthorizationRule extends AbstractMetaTagAuthorization
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			ResearchStudy newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			ResearchStudy newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, ResearchStudy newResource)
+	private Optional<String> newResourceOk(Connection connection, ResearchStudy newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
@@ -38,17 +38,17 @@ public class StructureDefinitionAuthorizationRule
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			StructureDefinition newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			StructureDefinition newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, StructureDefinition newResource)
+	private Optional<String> newResourceOk(Connection connection, StructureDefinition newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
@@ -96,7 +96,10 @@ public class StructureDefinitionAuthorizationRule
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while searching for StructureDefinition", e);
+			logger.debug("Error while searching for StructureDefinition", e);
+			logger.warn("Error while searching for StructureDefinition: {} - {}", e.getClass().getName(),
+					e.getMessage());
+
 			return false;
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
@@ -138,6 +138,7 @@ public class SubscriptionAuthorizationRule extends AbstractMetaTagAuthorizationR
 		if (!uQp.isEmpty())
 		{
 			logger.warn("Unable to search for Subscription: Unsupported query parameters: {}", uQp);
+
 			throw new IllegalStateException("Unable to search for Subscription: Unsupported query parameters");
 		}
 
@@ -148,7 +149,9 @@ public class SubscriptionAuthorizationRule extends AbstractMetaTagAuthorizationR
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Unable to search for Subscription", e);
+			logger.debug("Unable to search for Subscription", e);
+			logger.warn("Unable to search for Subscription: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException("Unable to search for Subscription", e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
@@ -45,17 +45,17 @@ public class SubscriptionAuthorizationRule extends AbstractMetaTagAuthorizationR
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity,
 			Subscription newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity,
 			Subscription newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, Subscription newResource)
+	private Optional<String> newResourceOk(Connection connection, Subscription newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
@@ -724,8 +724,8 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 							oldResourceId, oldResourceVersion,
 							oldResource.getStatus() != null ? oldResource.getStatus().toCode() : null,
 							newResource.getStatus() != null ? newResource.getStatus().toCode() : null,
-							identity.getName(), Stream.of(Stream.of(TaskStatus.DRAFT, TaskStatus.DRAFT),
-									// Stream.of(TaskStatus.DRAFT, TaskStatus.REQUESTED),
+							identity.getName(),
+							Stream.of(Stream.of(TaskStatus.DRAFT, TaskStatus.DRAFT),
 									Stream.of(TaskStatus.REQUESTED, TaskStatus.INPROGRESS),
 									Stream.of(TaskStatus.INPROGRESS, TaskStatus.COMPLETED),
 									Stream.of(TaskStatus.INPROGRESS, TaskStatus.FAILED))

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
@@ -86,12 +86,14 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 					{
 						logger.info("Create of Task authorized for local organization identity '{}', Task.status draft",
 								identity.getName());
+
 						return Optional.of("Local identity, Task.status draft");
 					}
 					else
 					{
 						logger.warn("Create of Task unauthorized for identity '{}', Task.status draft, {}",
 								identity.getName(), errors.get());
+
 						return Optional.empty();
 					}
 				}
@@ -100,6 +102,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 					logger.warn(
 							"Create of Task unauthorized for identity '{}', Task.status draft, not allowed for non local organization identity",
 							identity.getName());
+
 					return Optional.empty();
 				}
 			}
@@ -113,6 +116,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 						logger.info(
 								"Create of Task authorized for identity '{}', Task.status requested, process allowed for current identity",
 								identity.getName());
+
 						return Optional.of(
 								"Local or remote identity, Task.status requested, Task.requester current identity's organization, Task.restriction.recipient local organization, "
 										+ "process with instantiatesCanonical and message-name allowed for current identity, Task defines needed profile");
@@ -122,6 +126,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 						logger.warn(
 								"Create of Task unauthorized for identity '{}', Task.status requested, process with instantiatesCanonical, message-name, requester or recipient not allowed",
 								identity.getName());
+
 						return Optional.empty();
 					}
 				}
@@ -129,6 +134,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				{
 					logger.warn("Create of Task unauthorized for identity '{}', Task.status requested, {}",
 							identity.getName(), errors.get());
+
 					return Optional.empty();
 				}
 			}
@@ -136,6 +142,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			{
 				logger.warn("Create of Task unauthorized for identity '{}', Task.status not {} and not {}",
 						identity.getName(), TaskStatus.DRAFT.toCode(), TaskStatus.REQUESTED.toCode());
+
 				return Optional.empty();
 			}
 		}
@@ -143,6 +150,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		{
 			logger.warn("Create of Task unauthorized for identity '{}', no role {}", identity.getName(),
 					FhirServerRole.CREATE);
+
 			return Optional.empty();
 		}
 	}
@@ -393,6 +401,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		if (recipientOpt.isEmpty())
 		{
 			logger.warn("Local organization does not exist");
+
 			return false;
 		}
 
@@ -412,6 +421,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				{
 					logger.warn("No ActivityDefinition with process-url '{}' and process-version '{}'", processUrl,
 							processVersion);
+
 					return false;
 				}
 				else
@@ -446,13 +456,16 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Error while reading ActivityDefinitions", e);
+				logger.debug("Error while reading ActivityDefinitions", e);
+				logger.warn("Error while reading ActivityDefinitions: {} - {}", e.getClass().getName(), e.getMessage());
+
 				return false;
 			}
 		}
 		else
 		{
 			logger.warn("Task.instantiatesCanonical not matching {} pattern", INSTANTIATES_CANONICAL_PATTERN_STRING);
+
 			return false;
 		}
 	}
@@ -463,6 +476,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		if (recipientOpt.isEmpty())
 		{
 			logger.warn("Local organization does not exist");
+
 			return false;
 		}
 
@@ -482,6 +496,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				{
 					logger.warn("No ActivityDefinition with process-url '{}' and process-version '{}'", processUrl,
 							processVersion);
+
 					return false;
 				}
 				else
@@ -507,13 +522,16 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Error while reading ActivityDefinitions", e);
+				logger.debug("Error while reading ActivityDefinitions", e);
+				logger.warn("Error while reading ActivityDefinitions: {} - {}", e.getClass().getName(), e.getMessage());
+
 				return false;
 			}
 		}
 		else
 		{
 			logger.warn("Task.instantiatesCanonical not matching {} pattern", INSTANTIATES_CANONICAL_PATTERN_STRING);
+
 			return false;
 		}
 	}
@@ -533,6 +551,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				logger.info(
 						"Read of Task/{}/_history/{} authorized for identity '{}', Task.requester reference could be resolved and current identity part of referenced organization",
 						resourceId, resourceVersion, identity.getName());
+
 				return Optional.of("Task.requester resolved and identity part of referenced organization");
 			}
 			else if (identity.isLocalIdentity() && isCurrentIdentityPartOfReferencedOrganization(connection, identity,
@@ -541,6 +560,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				logger.info(
 						"Read of Task/{}/_history/{} authorized for identity '{}', Task.restriction.recipient reference could be resolved and current identity part of referenced organization",
 						resourceId, resourceVersion, identity.getName());
+
 				return Optional
 						.of("Task.restriction.recipient resolved and local identity part of referenced organization");
 			}
@@ -549,6 +569,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				logger.warn(
 						"Read of Task/{}/_history/{} unauthorized for identity '{}', Task.requester or Task.restriction.recipient references could not be resolved or current identity not part of referenced organizations",
 						resourceId, resourceVersion, identity.getName());
+
 				return Optional.empty();
 			}
 		}
@@ -556,6 +577,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		{
 			logger.warn("Read of Task/{}/_history/{} unauthorized for identity '{}', no role {}", resourceId,
 					resourceVersion, identity.getName(), FhirServerRole.READ);
+
 			return Optional.empty();
 		}
 	}
@@ -582,6 +604,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 						logger.info("Update of Task/{}/_history/{} ({} -> {}) authorized for local identity '{}'",
 								oldResourceId, oldResourceVersion, TaskStatus.DRAFT.toCode(), TaskStatus.DRAFT.toCode(),
 								identity.getName());
+
 						return Optional.of("Local identity, old Task.status draft, new Task.status draft");
 					}
 					else
@@ -589,6 +612,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 						logger.warn("Update of Task/{}/_history/{} ({} -> {}) unauthorized for identity '{}', {}",
 								oldResourceId, oldResourceVersion, TaskStatus.DRAFT.toCode(), TaskStatus.DRAFT.toCode(),
 								identity.getName(), errors.get());
+
 						return Optional.empty();
 					}
 				}
@@ -612,6 +636,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 										"Update of Task/{}/_history/{} ({} -> {}) authorized for local identity '{}', old Task.status requested, new Task.status in-progress, process allowed for current identity",
 										oldResourceId, oldResourceVersion, TaskStatus.REQUESTED.toCode(),
 										TaskStatus.INPROGRESS.toCode(), identity.getName());
+
 								return Optional.of(
 										"Local identity, Task.status in-progress, Task.restriction.recipient local organization, process with instantiatesCanonical and message-name allowed for current identity"
 												+ ", Task defines needed profile, Task.instantiatesCanonical not modified, Task.requester not modified, Task.restriction not modified, Task.input not modified"
@@ -623,6 +648,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 										"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', Task.output not expected",
 										oldResourceId, oldResourceVersion, TaskStatus.REQUESTED.toCode(),
 										TaskStatus.INPROGRESS.toCode(), identity.getName());
+
 								return Optional.empty();
 							}
 						}
@@ -632,6 +658,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 									"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', process with instantiatesCanonical, message-name, requester or recipient not allowed",
 									oldResourceId, oldResourceVersion, TaskStatus.REQUESTED.toCode(),
 									TaskStatus.INPROGRESS.toCode(), identity.getName());
+
 							return Optional.empty();
 						}
 					}
@@ -641,6 +668,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 								"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', modification of Task properties {} not allowed",
 								oldResourceId, oldResourceVersion, TaskStatus.REQUESTED.toCode(),
 								TaskStatus.INPROGRESS.toCode(), identity.getName(), same.get());
+
 						return Optional.empty();
 					}
 				}
@@ -658,6 +686,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 									"Update of Task/{}/_history/{} ({} -> {}) authorized for local identity '{}', old Task.status in-progress, new Task.status completed, process allowed for current identity",
 									oldResourceId, oldResourceVersion, TaskStatus.INPROGRESS.toCode(),
 									TaskStatus.COMPLETED.toCode(), identity.getName());
+
 							return Optional.of(
 									"Local identity, Task.status completed, Task.restriction.recipient local organization, process with instantiatesCanonical and message-name allowed for current identity"
 											+ ", Task defines needed profile, Task.instantiatesCanonical not modified, Task.requester not modified, Task.restriction not modified, Task.input not modified");
@@ -668,6 +697,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 									"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', process with instantiatesCanonical, message-name, requester or recipient not allowed",
 									oldResourceId, oldResourceVersion, TaskStatus.INPROGRESS.toCode(),
 									TaskStatus.COMPLETED.toCode(), identity.getName());
+
 							return Optional.empty();
 						}
 					}
@@ -677,6 +707,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 								"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', modification of Task properties {} not allowed",
 								oldResourceId, oldResourceVersion, TaskStatus.INPROGRESS.toCode(),
 								TaskStatus.COMPLETED.toCode(), identity.getName(), same.get());
+
 						return Optional.empty();
 					}
 				}
@@ -694,6 +725,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 									"Update of Task/{}/_history/{} ({} -> {}) authorized for local identity '{}', old Task.status in-progress, new Task.status failed, process allowed for current identity",
 									oldResourceId, oldResourceVersion, TaskStatus.INPROGRESS.toCode(),
 									TaskStatus.FAILED.toCode(), identity.getName());
+
 							return Optional.of(
 									"Local identity, Task.status failed, Task.restriction.recipient local organization, process with instantiatesCanonical and message-name allowed for current identity"
 											+ ", Task defines needed profile, Task.instantiatesCanonical not modified, Task.requester not modified, Task.restriction not modified, Task.input not modified");
@@ -704,6 +736,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 									"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', process with instantiatesCanonical, message-name, requester or recipient not allowed",
 									oldResourceId, oldResourceVersion, TaskStatus.INPROGRESS.toCode(),
 									TaskStatus.FAILED.toCode(), identity.getName());
+
 							return Optional.empty();
 						}
 					}
@@ -713,6 +746,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 								"Update of Task/{}/_history/{} ({} -> {}) unauthorized for local identity '{}', modification of Task properties {} not allowed",
 								oldResourceId, oldResourceVersion, TaskStatus.INPROGRESS.toCode(),
 								TaskStatus.FAILED.toCode(), identity.getName(), same.get());
+
 						return Optional.empty();
 					}
 				}
@@ -731,6 +765,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 									Stream.of(TaskStatus.INPROGRESS, TaskStatus.FAILED))
 									.map(s -> s.map(TaskStatus::toCode).collect(Collectors.joining("->")))
 									.collect(Collectors.joining(", ", "[", "]")));
+
 					return Optional.empty();
 				}
 			}
@@ -738,6 +773,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			{
 				logger.warn("Update of Task/{}/_history/{} unauthorized for non local organization identity '{}'",
 						oldResourceId, oldResourceVersion, identity.getName());
+
 				return Optional.empty();
 			}
 		}
@@ -745,6 +781,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		{
 			logger.warn("Update of Task/{}/_history/{} unauthorized for identity '{}', no role {}", oldResourceId,
 					oldResourceVersion, identity.getName(), FhirServerRole.UPDATE);
+
 			return Optional.empty();
 		}
 	}
@@ -801,6 +838,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 					.encodeResourceToString(oldResource));
 			logger.debug("New Task: {}", FhirContext.forR4().newJsonParser().setStripVersionsFromReferences(false)
 					.encodeResourceToString(newResource));
+
 			return Optional.of(errors.stream().collect(Collectors.joining(", ")));
 		}
 	}
@@ -831,6 +869,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				{
 					logger.info("Delete of Task/{}/_history/{} authorized for local identity '{}', Task.status draft",
 							oldResourceId, oldResourceVersion, identity.getName());
+
 					return Optional.of("Local identity, Task.status draft");
 				}
 				else
@@ -838,6 +877,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 					logger.warn(
 							"Delete of Task/{}/_history/{} unauthorized for local identity '{}', Task.status not draft",
 							oldResourceId, oldResourceVersion, identity.getName());
+
 					return Optional.empty();
 				}
 			}
@@ -845,6 +885,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			{
 				logger.warn("Delete of Task/{}/_history/{} unauthorized for non local organization identity '{}'",
 						oldResourceId, oldResourceVersion, identity.getName());
+
 				return Optional.empty();
 			}
 		}
@@ -852,6 +893,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		{
 			logger.warn("Delete of Task/{}/_history/{} unauthorized for identity '{}', no role {}", oldResourceId,
 					oldResourceVersion, identity.getName(), FhirServerRole.DELETE);
+
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
@@ -53,15 +53,18 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 	private static final String NAMING_SYSTEM_TASK_IDENTIFIER = "http://dsf.dev/sid/task-identifier";
 
 	private final ProcessAuthorizationHelper processAuthorizationHelper;
+	private final FhirContext fhirContext;
 
 	public TaskAuthorizationRule(DaoProvider daoProvider, String serverBase, ReferenceResolver referenceResolver,
 			OrganizationProvider organizationProvider, ReadAccessHelper readAccessHelper,
-			ParameterConverter parameterConverter, ProcessAuthorizationHelper processAuthorizationHelper)
+			ParameterConverter parameterConverter, ProcessAuthorizationHelper processAuthorizationHelper,
+			FhirContext fhirContext)
 	{
 		super(Task.class, daoProvider, serverBase, referenceResolver, organizationProvider, readAccessHelper,
 				parameterConverter);
 
 		this.processAuthorizationHelper = processAuthorizationHelper;
+		this.fhirContext = fhirContext;
 	}
 
 	@Override
@@ -70,6 +73,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		super.afterPropertiesSet();
 
 		Objects.requireNonNull(processAuthorizationHelper, "processAuthorizationHelper");
+		Objects.requireNonNull(fhirContext, "fhirContext");
 	}
 
 	@Override
@@ -834,9 +838,9 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			return Optional.empty();
 		else
 		{
-			logger.debug("Old Task: {}", FhirContext.forR4().newJsonParser().setStripVersionsFromReferences(false)
+			logger.debug("Old Task: {}", fhirContext.newJsonParser().setStripVersionsFromReferences(false)
 					.encodeResourceToString(oldResource));
-			logger.debug("New Task: {}", FhirContext.forR4().newJsonParser().setStripVersionsFromReferences(false)
+			logger.debug("New Task: {}", fhirContext.newJsonParser().setStripVersionsFromReferences(false)
 					.encodeResourceToString(newResource));
 
 			return Optional.of(errors.stream().collect(Collectors.joining(", ")));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
@@ -192,9 +192,9 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				Optional<Resource> recipient = referenceResolver.resolveReference(identity, reference, connection);
 				if (recipient.isPresent())
 				{
-					if (recipient.get() instanceof Organization)
+					if (recipient.get() instanceof Organization o)
 					{
-						if (!isLocalOrganization((Organization) recipient.get()))
+						if (!isLocalOrganization(o))
 							errors.add("Task.restriction.recipient not local organization");
 					}
 					else
@@ -284,9 +284,9 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 			Optional<Resource> requester = referenceResolver.resolveReference(identity, reference, connection);
 			if (requester.isPresent())
 			{
-				if (requester.get() instanceof Organization)
+				if (requester.get() instanceof Organization o)
 				{
-					if (!isLocalOrganization((Organization) requester.get()))
+					if (!isLocalOrganization(o))
 						errors.add("Task.requester not local organization");
 				}
 				else
@@ -313,9 +313,9 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 				Optional<Resource> recipient = referenceResolver.resolveReference(identity, reference, connection);
 				if (recipient.isPresent())
 				{
-					if (recipient.get() instanceof Organization)
+					if (recipient.get() instanceof Organization o)
 					{
-						if (!isLocalOrganization((Organization) recipient.get()))
+						if (!isLocalOrganization(o))
 							errors.add("Task.restriction.recipient not local organization");
 					}
 					else

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
@@ -743,9 +743,8 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		}
 		else
 		{
-			logger.warn("Update of Task/{}/_history/{} unauthorized for identity '{}', no role {}",
-					getResourceTypeName(), oldResourceId, oldResourceVersion, identity.getName(),
-					FhirServerRole.UPDATE);
+			logger.warn("Update of Task/{}/_history/{} unauthorized for identity '{}', no role {}", oldResourceId,
+					oldResourceVersion, identity.getName(), FhirServerRole.UPDATE);
 			return Optional.empty();
 		}
 	}
@@ -851,8 +850,8 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 		}
 		else
 		{
-			logger.warn("Delete of Task/{}/_history/{} unauthorized for identity '{}', no role {}", identity.getName(),
-					FhirServerRole.DELETE);
+			logger.warn("Delete of Task/{}/_history/{} unauthorized for identity '{}', no role {}", oldResourceId,
+					oldResourceVersion, identity.getName(), FhirServerRole.DELETE);
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ValueSetAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ValueSetAuthorizationRule.java
@@ -93,7 +93,9 @@ public class ValueSetAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while searching for ValueSet", e);
+			logger.debug("Error while searching for ValueSet", e);
+			logger.warn("Error while searching for ValueSet: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return false;
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ValueSetAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ValueSetAuthorizationRule.java
@@ -36,16 +36,16 @@ public class ValueSetAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 	@Override
 	protected Optional<String> newResourceOkForCreate(Connection connection, Identity identity, ValueSet newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
 	@Override
 	protected Optional<String> newResourceOkForUpdate(Connection connection, Identity identity, ValueSet newResource)
 	{
-		return newResourceOk(connection, identity, newResource);
+		return newResourceOk(connection, newResource);
 	}
 
-	private Optional<String> newResourceOk(Connection connection, Identity identity, ValueSet newResource)
+	private Optional<String> newResourceOk(Connection connection, ValueSet newResource)
 	{
 		List<String> errors = new ArrayList<String>();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AbstractCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AbstractCommandList.java
@@ -91,11 +91,10 @@ class AbstractCommandList
 			audit.info("Update of {} for identity '{}' via bundle at index {} abborted", command.getResourceTypeName(),
 					command.getIdentity().getName(), command.getIndex());
 		}
-		else if (command instanceof ReadCommand)
+		else if (command instanceof ReadCommand r)
 		{
-			audit.info("{} of {} for identity '{}' via bundle at index {} abborted",
-					((ReadCommand) command).isSearch() ? "Search" : "Read", command.getResourceTypeName(),
-					command.getIdentity().getName(), command.getIndex());
+			audit.info("{} of {} for identity '{}' via bundle at index {} abborted", r.isSearch() ? "Search" : "Read",
+					command.getResourceTypeName(), command.getIdentity().getName(), command.getIndex());
 		}
 	}
 
@@ -117,8 +116,8 @@ class AbstractCommandList
 		var entry = new BundleEntryComponent();
 		var response = entry.getResponse();
 
-		if (!(exception instanceof WebApplicationException)
-				|| !(((WebApplicationException) exception).getResponse().getEntity() instanceof OperationOutcome))
+		if (!(exception instanceof WebApplicationException w)
+				|| !(w.getResponse().getEntity() instanceof OperationOutcome))
 		{
 			exception = exceptionHandler.internalServerErrorBundleBatch(exception);
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AbstractCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AbstractCommandList.java
@@ -40,7 +40,7 @@ class AbstractCommandList
 
 	private static boolean hasModifyingCommands(List<? extends Command> commands)
 	{
-		return commands.stream().anyMatch(c -> c instanceof ModifyingCommand);
+		return commands != null && commands.stream().anyMatch(c -> c instanceof ModifyingCommand);
 	}
 
 	protected void auditLogResult(Command command, BundleEntryComponent result)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AuthorizationHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AuthorizationHelperImpl.java
@@ -182,7 +182,7 @@ public class AuthorizationHelperImpl implements AuthorizationHelper
 		{
 			logger.debug(
 					"Inclusion of {}/{}/_history/{} denied for identity '{} via bundle at index {}: read not allowed",
-					resourceTypeName, resourceId, resourceVersion, index, identity.getName(), index);
+					resourceTypeName, resourceId, resourceVersion, identity.getName(), index);
 			return false;
 		});
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
@@ -86,7 +86,7 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 				connection.setTransactionIsolation(initialTransactionIsolationLevel);
 			}
 
-			Map<Integer, BundleEntryComponent> results = new HashMap<>((int) ((commands.size() / 0.75) + 1));
+			Map<Integer, BundleEntryComponent> results = new HashMap<>((int) (commands.size() / 0.75) + 1);
 
 			commands.forEach(postExecute(connection, caughtExceptions, results));
 			caughtExceptions.forEach((k, v) -> results.put(k, toEntry(v)));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
@@ -154,10 +154,10 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while running pre-execute of command {} for entry at index {}: {} - {}",
-						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
 				logger.debug("Error while running pre-execute of command {} for entry at index {}",
 						command.getClass().getName(), command.getIndex(), e);
+				logger.warn("Error while running pre-execute of command {} for entry at index {}: {} - {}",
+						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
 
 				caughtExceptions.put(command.getIndex(), e);
 			}
@@ -190,10 +190,10 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while executing command {}, rolling back transaction for entry at index {}: {} - {}",
-						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
 				logger.debug("Error while executing command {}, rolling back transaction for entry at index {}",
 						command.getClass().getName(), command.getIndex(), e);
+				logger.warn("Error while executing command {}, rolling back transaction for entry at index {}: {} - {}",
+						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
 
 				caughtExceptions.put(command.getIndex(), e);
 
@@ -204,12 +204,12 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 				}
 				catch (SQLException e1)
 				{
-					logger.warn(
-							"Error while executing command {}, error while rolling back transaction for entry at index {}: {} - {}",
-							command.getClass().getName(), command.getIndex(), e1.getClass().getName(), e1.getMessage());
 					logger.debug(
 							"Error while executing command {}, error while rolling back transaction for entry at index {}",
 							command.getClass().getName(), command.getIndex(), e1);
+					logger.warn(
+							"Error while executing command {}, error while rolling back transaction for entry at index {}: {} - {}",
+							command.getClass().getName(), command.getIndex(), e1.getClass().getName(), e1.getMessage());
 
 					caughtExceptions.put(command.getIndex(), e1);
 				}
@@ -242,10 +242,10 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while running post-execute of command {} for entry at index {}: {} - {}",
-						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
 				logger.debug("Error while running post-execute of command {} for entry at index {}",
 						command.getClass().getName(), command.getIndex(), e);
+				logger.warn("Error while running post-execute of command {} for entry at index {}: {} - {}",
+						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
 
 				caughtExceptions.put(command.getIndex(), e);
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
@@ -154,8 +154,11 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while running pre-execute of command {} for entry at index {}: {}",
-						command.getClass().getName(), command.getIndex(), e.getMessage());
+				logger.warn("Error while running pre-execute of command {} for entry at index {}: {} - {}",
+						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
+				logger.debug("Error while running pre-execute of command {} for entry at index {}",
+						command.getClass().getName(), command.getIndex(), e);
+
 				caughtExceptions.put(command.getIndex(), e);
 			}
 		};
@@ -187,8 +190,11 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while executing command {}, rolling back transaction for entry at index {}: {}",
-						command.getClass().getName(), command.getIndex(), e.getMessage());
+				logger.warn("Error while executing command {}, rolling back transaction for entry at index {}: {} - {}",
+						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
+				logger.debug("Error while executing command {}, rolling back transaction for entry at index {}",
+						command.getClass().getName(), command.getIndex(), e);
+
 				caughtExceptions.put(command.getIndex(), e);
 
 				try
@@ -199,8 +205,12 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 				catch (SQLException e1)
 				{
 					logger.warn(
-							"Error while executing command {}, error while rolling back transaction for entry at index {}: {}",
-							command.getClass().getName(), command.getIndex(), e1.getMessage());
+							"Error while executing command {}, error while rolling back transaction for entry at index {}: {} - {}",
+							command.getClass().getName(), command.getIndex(), e1.getClass().getName(), e1.getMessage());
+					logger.debug(
+							"Error while executing command {}, error while rolling back transaction for entry at index {}",
+							command.getClass().getName(), command.getIndex(), e1);
+
 					caughtExceptions.put(command.getIndex(), e1);
 				}
 			}
@@ -232,8 +242,11 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while running post-execute of command {} for entry at index {}: {}",
-						command.getClass().getName(), command.getIndex(), e.getMessage());
+				logger.warn("Error while running post-execute of command {} for entry at index {}: {} - {}",
+						command.getClass().getName(), command.getIndex(), e.getClass().getName(), e.getMessage());
+				logger.debug("Error while running post-execute of command {} for entry at index {}",
+						command.getClass().getName(), command.getIndex(), e);
+
 				caughtExceptions.put(command.getIndex(), e);
 			}
 		};

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CheckReferencesCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CheckReferencesCommand.java
@@ -60,9 +60,8 @@ public class CheckReferencesCommand<R extends Resource, D extends ResourceDao<R>
 	// See also AbstractResourceServiceImpl#checkReferenceAfterCreate
 	private boolean checkReferenceAfterUpdate(ResourceReference ref)
 	{
-		if (resource instanceof Task && HTTPVerb.PUT.equals(verb))
+		if (resource instanceof Task task && HTTPVerb.PUT.equals(verb))
 		{
-			Task task = (Task) resource;
 			if (EnumSet.of(TaskStatus.COMPLETED, TaskStatus.FAILED).contains(task.getStatus()))
 			{
 				ReferenceType refType = ref.getType(serverBase);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CommandFactoryImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CommandFactoryImpl.java
@@ -127,11 +127,11 @@ public class CommandFactoryImpl implements InitializingBean, CommandFactory
 			Optional<? extends ResourceDao<R>> dao = (Optional<? extends ResourceDao<R>>) daoProvider
 					.getDao(resource.getClass());
 
-			if (resource instanceof StructureDefinition)
+			if (resource instanceof StructureDefinition s)
 				return new CreateStructureDefinitionCommand(index, identity, returnType, bundle, entry, serverBase,
-						authorizationHelper, (StructureDefinition) resource, (StructureDefinitionDao) dao.get(),
-						exceptionHandler, parameterConverter, responseGenerator, referenceExtractor, referenceResolver,
-						referenceCleaner, eventGenerator, daoProvider.getStructureDefinitionSnapshotDao());
+						authorizationHelper, s, (StructureDefinitionDao) dao.get(), exceptionHandler,
+						parameterConverter, responseGenerator, referenceExtractor, referenceResolver, referenceCleaner,
+						eventGenerator, daoProvider.getStructureDefinitionSnapshotDao());
 			else
 				return dao.map(d -> new CreateCommand<R, ResourceDao<R>>(index, identity, returnType, bundle, entry,
 						serverBase, authorizationHelper, resource, d, exceptionHandler, parameterConverter,
@@ -155,11 +155,11 @@ public class CommandFactoryImpl implements InitializingBean, CommandFactory
 			Optional<? extends ResourceDao<R>> dao = (Optional<? extends ResourceDao<R>>) daoProvider
 					.getDao(resource.getClass());
 
-			if (resource instanceof StructureDefinition)
+			if (resource instanceof StructureDefinition s)
 				return new UpdateStructureDefinitionCommand(index, identity, returnType, bundle, entry, serverBase,
-						authorizationHelper, (StructureDefinition) resource, (StructureDefinitionDao) dao.get(),
-						exceptionHandler, parameterConverter, responseGenerator, referenceExtractor, referenceResolver,
-						referenceCleaner, eventGenerator, daoProvider.getStructureDefinitionSnapshotDao());
+						authorizationHelper, s, (StructureDefinitionDao) dao.get(), exceptionHandler,
+						parameterConverter, responseGenerator, referenceExtractor, referenceResolver, referenceCleaner,
+						eventGenerator, daoProvider.getStructureDefinitionSnapshotDao());
 			else
 				return dao.map(d -> new UpdateCommand<R, ResourceDao<R>>(index, identity, returnType, bundle, entry,
 						serverBase, authorizationHelper, resource, d, exceptionHandler, parameterConverter,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CreateCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CreateCommand.java
@@ -232,7 +232,9 @@ public class CreateCommand<R extends Resource, D extends ResourceDao<R>> extends
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while handling resource created event", e);
+				logger.debug("Error while handling resource created event", e);
+				logger.warn("Error while handling resource created event: {} - {}", e.getClass().getName(),
+						e.getMessage());
 			}
 
 			IdType location = createdResourceWithResolvedReferences.getIdElement().withServerBase(serverBase,
@@ -290,7 +292,9 @@ public class CreateCommand<R extends Resource, D extends ResourceDao<R>> extends
 		}
 		catch (ResourceNotFoundException | SQLException | ResourceDeletedException e)
 		{
-			logger.warn("Error while reading resource from db", e);
+			logger.debug("Error while reading resource from db", e);
+			logger.warn("Error while reading resource from db: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CreateStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CreateStructureDefinitionCommand.java
@@ -89,7 +89,10 @@ public class CreateStructureDefinitionCommand extends CreateCommand<StructureDef
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Error while creating StructureDefinition snapshot: " + e.getMessage(), e);
+				logger.warn("Error while creating StructureDefinition snapshot: {} - {}", e.getClass().getName(),
+						e.getMessage());
+				logger.debug("Error while creating StructureDefinition snapshot", e);
+
 				throw e;
 			}
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CreateStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CreateStructureDefinitionCommand.java
@@ -89,9 +89,9 @@ public class CreateStructureDefinitionCommand extends CreateCommand<StructureDef
 			}
 			catch (SQLException e)
 			{
+				logger.debug("Error while creating StructureDefinition snapshot", e);
 				logger.warn("Error while creating StructureDefinition snapshot: {} - {}", e.getClass().getName(),
 						e.getMessage());
-				logger.debug("Error while creating StructureDefinition snapshot", e);
 
 				throw e;
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteCommand.java
@@ -211,7 +211,8 @@ public class DeleteCommand extends AbstractCommand implements ModifyingCommand
 		}
 		catch (Exception e)
 		{
-			logger.warn("Error while handling resource deleted event", e);
+			logger.debug("Error while handling resource deleted event", e);
+			logger.warn("Error while handling resource deleted event: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 
 		BundleEntryComponent resultEntry = new BundleEntryComponent();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteStructureDefinitionCommand.java
@@ -49,8 +49,11 @@ public class DeleteStructureDefinitionCommand extends DeleteCommand
 		}
 		catch (SQLException | ResourceNotFoundException e)
 		{
-			logger.warn("Error while deleting StructureDefinition snaphost for id " + uuid.toString()
-					+ ", exception will be ignored", e);
+			logger.warn(
+					"Error while deleting StructureDefinition snaphost for id {}, exception will be ignored: {} - {}",
+					uuid.toString(), e.getClass().getName(), e.getMessage());
+			logger.debug("Error while deleting StructureDefinition snaphost for id {}, exception will be ignored",
+					uuid.toString(), e);
 		}
 
 		return deleted;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteStructureDefinitionCommand.java
@@ -49,11 +49,11 @@ public class DeleteStructureDefinitionCommand extends DeleteCommand
 		}
 		catch (SQLException | ResourceNotFoundException e)
 		{
+			logger.debug("Error while deleting StructureDefinition snaphost for id {}, exception will be ignored",
+					uuid.toString(), e);
 			logger.warn(
 					"Error while deleting StructureDefinition snaphost for id {}, exception will be ignored: {} - {}",
 					uuid.toString(), e.getClass().getName(), e.getMessage());
-			logger.debug("Error while deleting StructureDefinition snaphost for id {}, exception will be ignored",
-					uuid.toString(), e);
 		}
 
 		return deleted;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/ReferencesHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/ReferencesHelperImpl.java
@@ -210,7 +210,7 @@ public final class ReferencesHelperImpl<R extends Resource> implements Reference
 		referenceExtractor.getReferences(resource).filter(checkReference)
 				.filter(ref -> referenceResolver.referenceCanBeChecked(ref, connection)).forEach(ref ->
 				{
-					Optional<OperationOutcome> outcome = checkReference(idTranslationTable, connection, ref);
+					Optional<OperationOutcome> outcome = checkReference(ref, connection);
 					if (outcome.isPresent())
 					{
 						Response response = Response.status(Status.FORBIDDEN).entity(outcome.get()).build();
@@ -219,8 +219,8 @@ public final class ReferencesHelperImpl<R extends Resource> implements Reference
 				});
 	}
 
-	private Optional<OperationOutcome> checkReference(Map<String, IdType> idTranslationTable, Connection connection,
-			ResourceReference reference) throws WebApplicationException
+	private Optional<OperationOutcome> checkReference(ResourceReference reference, Connection connection)
+			throws WebApplicationException
 	{
 		ReferenceType type = reference.getType(serverBase);
 		switch (type)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/TransactionCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/TransactionCommandList.java
@@ -74,8 +74,12 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 					}
 					catch (Exception e)
 					{
-						logger.warn("Error while running pre-execute of command " + c.getClass().getSimpleName()
-								+ " for entry at index " + c.getIndex() + ", abborting transaction", e);
+						logger.warn(
+								"Error while running pre-execute of command {} for entry at index {}, abborting transaction: {} - {}",
+								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
+						logger.debug(
+								"Error while running pre-execute of command {} for entry at index {}, abborting transaction",
+								c.getClass().getSimpleName(), c.getIndex(), e);
 
 						try
 						{
@@ -84,7 +88,9 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 						}
 						catch (Exception e1)
 						{
-							logger.warn("Error while writing to audit log", e1);
+							logger.warn("Error while writing to audit log: {} - {}", e1.getClass().getName(),
+									e1.getMessage());
+							logger.debug("Error while writing to audit log", e1);
 						}
 
 						throw e;
@@ -101,9 +107,11 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 					}
 					catch (Exception e)
 					{
-						logger.warn("Error while executing command " + c.getClass().getSimpleName()
-								+ " for entry at index " + c.getIndex() + ", rolling back transaction: {}",
-								e.getMessage());
+						logger.warn(
+								"Error while executing command {} for entry at index {}, rolling back transaction: {} - {}",
+								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
+						logger.debug("Error while executing command {} for entry at index {}, rolling back transaction",
+								c.getClass().getSimpleName(), c.getIndex(), e);
 
 						if (hasModifyingCommands)
 						{
@@ -118,7 +126,9 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 						}
 						catch (Exception e1)
 						{
-							logger.warn("Error while writing to audit log", e1);
+							logger.warn("Error while writing to audit log: {} - {}", e1.getClass().getName(),
+									e1.getMessage());
+							logger.debug("Error while writing to audit log", e1);
 						}
 
 						throw e;
@@ -136,8 +146,12 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 					}
 					catch (Exception e)
 					{
-						logger.warn("Error while running post-execute of command " + c.getClass().getSimpleName()
-								+ " for entry at index " + c.getIndex() + ", rolling back transaction", e);
+						logger.warn(
+								"Error while running post-execute of command {} for entry at index {}, rolling back transaction: {} - {}",
+								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
+						logger.debug(
+								"Error while running post-execute of command {} for entry at index {}, rolling back transaction",
+								c.getClass().getSimpleName(), c.getIndex(), e);
 
 						if (hasModifyingCommands)
 						{
@@ -152,7 +166,9 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 						}
 						catch (Exception e1)
 						{
-							logger.warn("Error while writing to audit log", e1);
+							logger.warn("Error while writing to audit log: {} - {}", e1.getClass().getName(),
+									e1.getMessage());
+							logger.debug("Error while writing to audit log", e1);
 						}
 
 						throw e;
@@ -173,7 +189,8 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while handling events", e);
+				logger.warn("Error while handling events: {} - {}", e.getClass().getName(), e.getMessage());
+				logger.debug("Error while handling events", e);
 			}
 
 			try
@@ -187,7 +204,8 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while writing to audit log", e);
+				logger.warn("Error while writing to audit log: {} - {}", e.getClass().getName(), e.getMessage());
+				logger.debug("Error while writing to audit log", e);
 			}
 
 			Bundle result = new Bundle();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/TransactionCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/TransactionCommandList.java
@@ -45,7 +45,7 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 	@Override
 	public Bundle execute() throws WebApplicationException
 	{
-		Map<Integer, BundleEntryComponent> results = new HashMap<>((int) ((commands.size() / 0.75) + 1));
+		Map<Integer, BundleEntryComponent> results = new HashMap<>((int) (commands.size() / 0.75) + 1);
 		try
 		{
 			TransactionEventHandler transactionEventHandler;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/TransactionCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/TransactionCommandList.java
@@ -74,12 +74,12 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 					}
 					catch (Exception e)
 					{
-						logger.warn(
-								"Error while running pre-execute of command {} for entry at index {}, abborting transaction: {} - {}",
-								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
 						logger.debug(
 								"Error while running pre-execute of command {} for entry at index {}, abborting transaction",
 								c.getClass().getSimpleName(), c.getIndex(), e);
+						logger.warn(
+								"Error while running pre-execute of command {} for entry at index {}, abborting transaction: {} - {}",
+								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
 
 						try
 						{
@@ -88,9 +88,9 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 						}
 						catch (Exception e1)
 						{
+							logger.debug("Error while writing to audit log", e1);
 							logger.warn("Error while writing to audit log: {} - {}", e1.getClass().getName(),
 									e1.getMessage());
-							logger.debug("Error while writing to audit log", e1);
 						}
 
 						throw e;
@@ -107,11 +107,11 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 					}
 					catch (Exception e)
 					{
+						logger.debug("Error while executing command {} for entry at index {}, rolling back transaction",
+								c.getClass().getSimpleName(), c.getIndex(), e);
 						logger.warn(
 								"Error while executing command {} for entry at index {}, rolling back transaction: {} - {}",
 								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
-						logger.debug("Error while executing command {} for entry at index {}, rolling back transaction",
-								c.getClass().getSimpleName(), c.getIndex(), e);
 
 						if (hasModifyingCommands)
 						{
@@ -126,9 +126,9 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 						}
 						catch (Exception e1)
 						{
+							logger.debug("Error while writing to audit log", e1);
 							logger.warn("Error while writing to audit log: {} - {}", e1.getClass().getName(),
 									e1.getMessage());
-							logger.debug("Error while writing to audit log", e1);
 						}
 
 						throw e;
@@ -146,12 +146,12 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 					}
 					catch (Exception e)
 					{
-						logger.warn(
-								"Error while running post-execute of command {} for entry at index {}, rolling back transaction: {} - {}",
-								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
 						logger.debug(
 								"Error while running post-execute of command {} for entry at index {}, rolling back transaction",
 								c.getClass().getSimpleName(), c.getIndex(), e);
+						logger.warn(
+								"Error while running post-execute of command {} for entry at index {}, rolling back transaction: {} - {}",
+								c.getClass().getSimpleName(), c.getIndex(), e.getClass().getName(), e.getMessage());
 
 						if (hasModifyingCommands)
 						{
@@ -166,9 +166,9 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 						}
 						catch (Exception e1)
 						{
+							logger.debug("Error while writing to audit log", e1);
 							logger.warn("Error while writing to audit log: {} - {}", e1.getClass().getName(),
 									e1.getMessage());
-							logger.debug("Error while writing to audit log", e1);
 						}
 
 						throw e;
@@ -189,8 +189,8 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while handling events: {} - {}", e.getClass().getName(), e.getMessage());
 				logger.debug("Error while handling events", e);
+				logger.warn("Error while handling events: {} - {}", e.getClass().getName(), e.getMessage());
 			}
 
 			try
@@ -204,8 +204,8 @@ public class TransactionCommandList extends AbstractCommandList implements Comma
 			}
 			catch (Exception e)
 			{
-				logger.warn("Error while writing to audit log: {} - {}", e.getClass().getName(), e.getMessage());
 				logger.debug("Error while writing to audit log", e);
+				logger.warn("Error while writing to audit log: {} - {}", e.getClass().getName(), e.getMessage());
 			}
 
 			Bundle result = new Bundle();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateCommand.java
@@ -372,7 +372,8 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 		}
 		catch (Exception e)
 		{
-			logger.warn("Error while handling resource updated event", e);
+			logger.debug("Error while handling resource updated event", e);
+			logger.warn("Error while handling resource updated event: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 
 		IdType location = updatedResourceWithResolvedReferences.getIdElement().withServerBase(serverBase,
@@ -413,7 +414,9 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 		}
 		catch (ResourceNotFoundException | SQLException | ResourceDeletedException e)
 		{
-			logger.warn("Error while reading resource from db", e);
+			logger.debug("Error while reading resource from db", e);
+			logger.warn("Error while reading resource from db: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateCommand.java
@@ -203,7 +203,7 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 							|| serverBase.equals(resource.getIdElement().getBaseUrl()))
 					&& (!resource.getIdElement().hasResourceType()
 							|| resourceTypeName.equals(resource.getIdElement().getResourceType()))
-					&& (dbResourceId.getIdPart().equals(resource.getIdElement().getIdPart())))
+					&& dbResourceId.getIdPart().equals(resource.getIdElement().getIdPart()))
 			{
 				idTranslationTable.put(entry.getFullUrl(),
 						new IdType(resource.getResourceType().toString(), dbResource.getIdElement().getIdPart()));
@@ -236,8 +236,7 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 			updateById(idTranslationTable, connection, validationHelper, componentes.getPathSegments().get(0),
 					componentes.getPathSegments().get(1));
 		else if (componentes.getPathSegments().size() == 1 && !componentes.getQueryParams().isEmpty())
-			updateByCondition(idTranslationTable, connection, validationHelper, componentes.getPathSegments().get(0),
-					parameterConverter.urlDecodeQueryParameters(componentes.getQueryParams()));
+			updateByCondition(idTranslationTable, connection, validationHelper, componentes.getPathSegments().get(0));
 		else
 			throw new WebApplicationException(
 					responseGenerator.badUpdateRequestUrl(index, entry.getRequest().getUrl()));
@@ -305,8 +304,7 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 	}
 
 	private void updateByCondition(Map<String, IdType> idTranslationTable, Connection connection,
-			ValidationHelper validationHelper, String resourceTypeName, Map<String, List<String>> queryParameters)
-			throws SQLException
+			ValidationHelper validationHelper, String resourceTypeName) throws SQLException
 	{
 
 		boolean foundByCondition = addMissingIdToTranslationTableAndCheckConditionFindsResource(idTranslationTable,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateStructureDefinitionCommand.java
@@ -92,9 +92,9 @@ public class UpdateStructureDefinitionCommand extends UpdateCommand<StructureDef
 			}
 			catch (SQLException e)
 			{
+				logger.debug("Error while creating StructureDefinition snapshot", e);
 				logger.warn("Error while creating StructureDefinition snapshot: {} - {}", e.getClass().getName(),
 						e.getMessage());
-				logger.debug("Error while creating StructureDefinition snapshot", e);
 
 				throw e;
 			}
@@ -120,9 +120,9 @@ public class UpdateStructureDefinitionCommand extends UpdateCommand<StructureDef
 			}
 			catch (SQLException | ResourceNotFoundException | ResourceVersionNoMatchException e)
 			{
+				logger.debug("Error while updating StructureDefinition snapshot", e);
 				logger.warn("Error while updating StructureDefinition snapshot: {} - {}", e.getClass().getName(),
 						e.getMessage());
-				logger.debug("Error while updating StructureDefinition snapshot", e);
 
 				throw e;
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/UpdateStructureDefinitionCommand.java
@@ -92,7 +92,10 @@ public class UpdateStructureDefinitionCommand extends UpdateCommand<StructureDef
 			}
 			catch (SQLException e)
 			{
-				logger.warn("Error while creating StructureDefinition snapshot: " + e.getMessage(), e);
+				logger.warn("Error while creating StructureDefinition snapshot: {} - {}", e.getClass().getName(),
+						e.getMessage());
+				logger.debug("Error while creating StructureDefinition snapshot", e);
+
 				throw e;
 			}
 		}
@@ -117,7 +120,10 @@ public class UpdateStructureDefinitionCommand extends UpdateCommand<StructureDef
 			}
 			catch (SQLException | ResourceNotFoundException | ResourceVersionNoMatchException e)
 			{
-				logger.warn("Error while updating StructureDefinition snapshot: " + e.getMessage(), e);
+				logger.warn("Error while updating StructureDefinition snapshot: {} - {}", e.getClass().getName(),
+						e.getMessage());
+				logger.debug("Error while updating StructureDefinition snapshot", e);
+
 				throw e;
 			}
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/BadBundleException.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/BadBundleException.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.dao.exception;
 
-public class BadBundleException extends RuntimeException
+public final class BadBundleException extends RuntimeException
 {
 	private static final long serialVersionUID = 1L;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceDeletedException.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceDeletedException.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 import org.hl7.fhir.r4.model.IdType;
 
-public class ResourceDeletedException extends Exception
+public final class ResourceDeletedException extends Exception
 {
 	private static final long serialVersionUID = 1L;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceNotFoundException.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceNotFoundException.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.dao.exception;
 
-public class ResourceNotFoundException extends Exception
+public final class ResourceNotFoundException extends Exception
 {
 	private static final long serialVersionUID = 1L;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceNotMarkedDeletedException.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceNotMarkedDeletedException.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.dao.exception;
 
-public class ResourceNotMarkedDeletedException extends Exception
+public final class ResourceNotMarkedDeletedException extends Exception
 {
 	private static final long serialVersionUID = 1L;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceVersionNoMatchException.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/exception/ResourceVersionNoMatchException.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.dao.exception;
 
-public class ResourceVersionNoMatchException extends Exception
+public final class ResourceVersionNoMatchException extends Exception
 {
 	private static final long serialVersionUID = 1L;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
@@ -202,11 +202,11 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 			this.searchRevIncludeParameterFactories.addAll(searchRevIncludeParameterFactories);
 
 		resourceIdFactory = new SearchQueryParameterFactory<>(ResourceId.PARAMETER_NAME,
-				() -> new ResourceId<>(resourceIdColumn), null, null, null);
+				() -> new ResourceId<>(resourceIdColumn));
 		resourceLastUpdatedFactory = new SearchQueryParameterFactory<>(ResourceLastUpdated.PARAMETER_NAME,
-				() -> new ResourceLastUpdated<>(resourceColumn), null, null, null);
+				() -> new ResourceLastUpdated<>(resourceColumn));
 		resourceProfileFactory = new SearchQueryParameterFactory<>(ResourceProfile.PARAMETER_NAME,
-				() -> new ResourceProfile<>(resourceColumn), ResourceProfile.getNameModifiers(), null, null);
+				() -> new ResourceProfile<>(resourceColumn), ResourceProfile.getNameModifiers());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
@@ -895,10 +895,10 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 		{
 			JsonElement jsonElement = it.next();
 			IBaseResource resource = preparedStatementFactory.getJsonParser().parseResource(jsonElement.toString());
-			if (resource instanceof Resource)
+			if (resource instanceof Resource r)
 			{
-				query.modifyIncludeResource((Resource) resource, columnIndex, connection);
-				includeResources.add((Resource) resource);
+				query.modifyIncludeResource(r, columnIndex, connection);
+				includeResources.add(r);
 			}
 			else
 				logger.warn("parsed resouce of type {} not instance of {}, ignoring include resource",

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
@@ -69,10 +69,10 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 
 	private static final class ResourceDistinctById
 	{
-		private final IdType id;
-		private final Resource resource;
+		final IdType id;
+		final Resource resource;
 
-		public ResourceDistinctById(IdType id, Resource resource)
+		ResourceDistinctById(IdType id, Resource resource)
 		{
 			this.id = id;
 			this.resource = resource;
@@ -170,14 +170,14 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 			List<SearchQueryParameterFactory<R>> searchParameterFactories,
 			List<SearchQueryRevIncludeParameterFactory> searchRevIncludeParameterFactories)
 	{
-		this(dataSource, permanentDeleteDataSource, fhirContext, resourceType, resourceTable, resourceColumn,
-				resourceIdColumn, new PreparedStatementFactoryDefault<>(fhirContext, resourceType, resourceTable,
-						resourceIdColumn, resourceColumn),
+		this(dataSource, permanentDeleteDataSource, resourceType, resourceTable, resourceColumn, resourceIdColumn,
+				new PreparedStatementFactoryDefault<>(fhirContext, resourceType, resourceTable, resourceIdColumn,
+						resourceColumn),
 				userFilter, searchParameterFactories, searchRevIncludeParameterFactories);
 	}
 
-	AbstractResourceDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource, FhirContext fhirContext,
-			Class<R> resourceType, String resourceTable, String resourceColumn, String resourceIdColumn,
+	AbstractResourceDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource, Class<R> resourceType,
+			String resourceTable, String resourceColumn, String resourceIdColumn,
 			PreparedStatementFactory<R> preparedStatementFactory,
 			Function<Identity, SearchQueryIdentityFilter> userFilter,
 			List<SearchQueryParameterFactory<R>> searchParameterFactories,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractStructureDefinitionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractStructureDefinitionDaoJdbc.java
@@ -42,7 +42,7 @@ abstract class AbstractStructureDefinitionDaoJdbc extends AbstractResourceDaoJdb
 
 	private final ReadByUrlDaoJdbc<StructureDefinition> readByUrl;
 
-	public AbstractStructureDefinitionDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource,
+	protected AbstractStructureDefinitionDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource,
 			FhirContext fhirContext, String resourceTable, String resourceColumn, String resourceIdColumn,
 			Function<Identity, SearchQueryIdentityFilter> userFilter)
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BinaryDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BinaryDaoJdbc.java
@@ -22,7 +22,7 @@ public class BinaryDaoJdbc extends AbstractResourceDaoJdbc<Binary> implements Bi
 {
 	public BinaryDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource, FhirContext fhirContext)
 	{
-		super(dataSource, permanentDeleteDataSource, fhirContext, Binary.class, "binaries", "binary_json", "binary_id",
+		super(dataSource, permanentDeleteDataSource, Binary.class, "binaries", "binary_json", "binary_id",
 				new PreparedStatementFactoryBinary(fhirContext), BinaryIdentityFilter::new,
 				Arrays.asList(factory(BinaryContentType.PARAMETER_NAME, BinaryContentType::new,
 						BinaryContentType.getNameModifiers())),

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HistroyDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HistroyDaoJdbc.java
@@ -156,8 +156,8 @@ public class HistroyDaoJdbc implements HistoryDao, InitializingBean
 
 	private void modifyResource(Resource resource, Connection connection) throws SQLException
 	{
-		if (resource instanceof Binary)
-			binaryDao.modifySearchResultResource((Binary) resource, connection);
+		if (resource instanceof Binary b)
+			binaryDao.modifySearchResultResource(b, connection);
 	}
 
 	private PGobject uuidToPgObject(UUID uuid)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/SubscriptionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/SubscriptionDaoJdbc.java
@@ -50,8 +50,7 @@ public class SubscriptionDaoJdbc extends AbstractResourceDaoJdbc<Subscription> i
 	}
 
 	@Override
-	public List<Subscription> readByStatus(org.hl7.fhir.r4.model.Subscription.SubscriptionStatus status)
-			throws SQLException
+	public List<Subscription> readByStatus(Subscription.SubscriptionStatus status) throws SQLException
 	{
 		if (status == null)
 			return Collections.emptyList();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/event/EventManagerImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/event/EventManagerImpl.java
@@ -38,8 +38,10 @@ public class EventManagerImpl implements EventManager
 			}
 			catch (Exception ex)
 			{
-				logger.warn("Error while handling {} with {}", event.getClass().getSimpleName(),
-						e.getClass().getName());
+				logger.debug("Error while handling {} with {}", event.getClass().getSimpleName(),
+						e.getClass().getName(), ex);
+				logger.warn("Error while handling {} with {}: {} - {}", event.getClass().getSimpleName(),
+						e.getClass().getName(), ex.getClass().getName(), ex.getMessage());
 			}
 		};
 	}
@@ -61,8 +63,11 @@ public class EventManagerImpl implements EventManager
 			}
 			catch (Exception ex)
 			{
-				logger.warn("Error while handling {} event{} with {}", events.size(), events.size() != 1 ? "s" : "",
-						e.getClass().getName());
+				logger.debug("Error while handling {} event{} with {}", events.size(), events.size() != 1 ? "s" : "",
+						e.getClass().getName(), ex);
+				logger.warn("Error while handling {} event{} with {}: {} - {}", events.size(),
+						events.size() != 1 ? "s" : "", e.getClass().getName(), ex.getClass().getName(),
+						ex.getMessage());
 			}
 		};
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ExceptionHandler.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ExceptionHandler.java
@@ -103,7 +103,7 @@ public class ExceptionHandler
 		logger.debug("Error while executing transaction bundle", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
-				"Error while executing transaction");
+				"Error while executing transaction bundle");
 		return new WebApplicationException(Response.status(Status.INTERNAL_SERVER_ERROR).entity(outcome).build());
 	}
 
@@ -113,7 +113,7 @@ public class ExceptionHandler
 		logger.debug("Error while executing batch bundle element", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
-				"Error while executing batch element");
+				"Error while executing batch bundle element");
 		return new WebApplicationException(Response.status(Status.INTERNAL_SERVER_ERROR).entity(outcome).build());
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ExceptionHandler.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ExceptionHandler.java
@@ -69,7 +69,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerError(SQLException e)
 	{
-		logger.error("Error while accessing DB", e);
+		logger.error("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+		logger.debug("Error while accessing DB", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while accessing DB");
@@ -78,7 +79,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerError(ResourceDeletedException e)
 	{
-		logger.error("Error while accessing DB", e);
+		logger.error("Error while accessing DB, resource deleted: {} - {}", e.getClass().getName(), e.getMessage());
+		logger.debug("Error while accessing DB, resource deleted", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while accessing DB");
@@ -87,7 +89,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerError(ResourceNotFoundException e)
 	{
-		logger.error("Error while accessing DB", e);
+		logger.error("Error while accessing DB, resource not found: {} - {}", e.getClass().getName(), e.getMessage());
+		logger.debug("Error while accessing DB, resource not found", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while accessing DB");
@@ -96,7 +99,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerErrorBundleTransaction(Exception e)
 	{
-		logger.error("Error while executing transaction", e);
+		logger.error("Error while executing transaction bundle: {} - {}", e.getClass().getName(), e.getMessage());
+		logger.debug("Error while executing transaction bundle", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while executing transaction");
@@ -105,7 +109,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerErrorBundleBatch(Exception e)
 	{
-		logger.error("Error while executing batch element", e);
+		logger.error("Error while executing batch bundle element: {} - {}", e.getClass().getName(), e.getMessage());
+		logger.debug("Error while executing batch bundle element", e);
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while executing batch element");
@@ -259,7 +264,9 @@ public class ExceptionHandler
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+			logger.debug("Error while accessing DB", e);
+
 			return onSqlException.get();
 		}
 	}
@@ -273,12 +280,16 @@ public class ExceptionHandler
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+			logger.debug("Error while accessing DB", e);
+
 			return onSqlException.get();
 		}
 		catch (ResourceDeletedException e)
 		{
-			logger.warn("Resource with id " + e.getId() + " marked as deleted.", e);
+			logger.warn("Resource with id {} marked as deleted", e.getId());
+			logger.debug("Resource with id {} marked as deleted", e.getId(), e);
+
 			return onResourceDeletedException.get();
 		}
 	}
@@ -291,7 +302,8 @@ public class ExceptionHandler
 		}
 		catch (SQLException e)
 		{
-			logger.error("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+			logger.debug("Error while accessing DB", e);
 		}
 	}
 
@@ -304,11 +316,13 @@ public class ExceptionHandler
 		}
 		catch (ResourceNotFoundException e)
 		{
-			logger.error(resourceTypeName + " with id " + e.getId() + " not found", e);
+			logger.warn("{} with id {} not found", resourceTypeName, e.getId());
+			logger.debug("{} with id {} not found", resourceTypeName, e.getId(), e);
 		}
 		catch (SQLException e)
 		{
-			logger.error("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+			logger.debug("Error while accessing DB", e);
 		}
 	}
 
@@ -322,12 +336,16 @@ public class ExceptionHandler
 		}
 		catch (ResourceNotFoundException e)
 		{
-			logger.warn(resourceTypeName + " with id " + e.getId() + " not found", e);
+			logger.warn("{} with id {} not found", resourceTypeName, e.getId());
+			logger.debug("{} with id {} not found", resourceTypeName, e.getId(), e);
+
 			return onResourceNotFoundException.get();
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+			logger.debug("Error while accessing DB", e);
+
 			return onSqlException.get();
 		}
 	}
@@ -341,6 +359,8 @@ public class ExceptionHandler
 		catch (BadBundleException e)
 		{
 			logger.warn("Error while creating command list for bundle: {}", e.getMessage());
+			logger.debug("Error while creating command list for bundle", e);
+
 			throw new WebApplicationException(responseGenerator.badBundleRequest(e.getMessage()));
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ExceptionHandler.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ExceptionHandler.java
@@ -69,8 +69,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerError(SQLException e)
 	{
-		logger.error("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 		logger.debug("Error while accessing DB", e);
+		logger.error("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while accessing DB");
@@ -79,8 +79,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerError(ResourceDeletedException e)
 	{
-		logger.error("Error while accessing DB, resource deleted: {} - {}", e.getClass().getName(), e.getMessage());
 		logger.debug("Error while accessing DB, resource deleted", e);
+		logger.error("Error while accessing DB, resource deleted: {} - {}", e.getClass().getName(), e.getMessage());
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while accessing DB");
@@ -89,8 +89,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerError(ResourceNotFoundException e)
 	{
-		logger.error("Error while accessing DB, resource not found: {} - {}", e.getClass().getName(), e.getMessage());
 		logger.debug("Error while accessing DB, resource not found", e);
+		logger.error("Error while accessing DB, resource not found: {} - {}", e.getClass().getName(), e.getMessage());
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while accessing DB");
@@ -99,8 +99,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerErrorBundleTransaction(Exception e)
 	{
-		logger.error("Error while executing transaction bundle: {} - {}", e.getClass().getName(), e.getMessage());
 		logger.debug("Error while executing transaction bundle", e);
+		logger.error("Error while executing transaction bundle: {} - {}", e.getClass().getName(), e.getMessage());
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while executing transaction bundle");
@@ -109,8 +109,8 @@ public class ExceptionHandler
 
 	public WebApplicationException internalServerErrorBundleBatch(Exception e)
 	{
-		logger.error("Error while executing batch bundle element: {} - {}", e.getClass().getName(), e.getMessage());
 		logger.debug("Error while executing batch bundle element", e);
+		logger.error("Error while executing batch bundle element: {} - {}", e.getClass().getName(), e.getMessage());
 
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.EXCEPTION,
 				"Error while executing batch bundle element");
@@ -264,8 +264,8 @@ public class ExceptionHandler
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 
 			return onSqlException.get();
 		}
@@ -280,15 +280,15 @@ public class ExceptionHandler
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 
 			return onSqlException.get();
 		}
 		catch (ResourceDeletedException e)
 		{
-			logger.warn("Resource with id {} marked as deleted", e.getId());
 			logger.debug("Resource with id {} marked as deleted", e.getId(), e);
+			logger.warn("Resource with id {} marked as deleted", e.getId());
 
 			return onResourceDeletedException.get();
 		}
@@ -302,8 +302,8 @@ public class ExceptionHandler
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 	}
 
@@ -316,13 +316,13 @@ public class ExceptionHandler
 		}
 		catch (ResourceNotFoundException e)
 		{
-			logger.warn("{} with id {} not found", resourceTypeName, e.getId());
 			logger.debug("{} with id {} not found", resourceTypeName, e.getId(), e);
+			logger.warn("{} with id {} not found", resourceTypeName, e.getId());
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 	}
 
@@ -336,15 +336,15 @@ public class ExceptionHandler
 		}
 		catch (ResourceNotFoundException e)
 		{
-			logger.warn("{} with id {} not found", resourceTypeName, e.getId());
 			logger.debug("{} with id {} not found", resourceTypeName, e.getId(), e);
+			logger.warn("{} with id {} not found", resourceTypeName, e.getId());
 
 			return onResourceNotFoundException.get();
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 
 			return onSqlException.get();
 		}
@@ -358,8 +358,8 @@ public class ExceptionHandler
 		}
 		catch (BadBundleException e)
 		{
-			logger.warn("Error while creating command list for bundle: {}", e.getMessage());
 			logger.debug("Error while creating command list for bundle", e);
+			logger.warn("Error while creating command list for bundle: {}", e.getMessage());
 
 			throw new WebApplicationException(responseGenerator.badBundleRequest(e.getMessage()));
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ParameterConverter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ParameterConverter.java
@@ -233,12 +233,15 @@ public class ParameterConverter
 			else
 			{
 				logger.warn("{} not a weak ETag", eTag.getValue());
+
 				return Optional.empty();
 			}
 		}
 		catch (IllegalArgumentException e)
 		{
-			logger.warn("Unable to parse ETag value", e);
+			logger.debug("Unable to parse ETag value", e);
+			logger.warn("Unable to parse ETag value: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return Optional.empty();
 		}
 	}
@@ -274,7 +277,9 @@ public class ParameterConverter
 		}
 		catch (NumberFormatException e)
 		{
-			logger.warn("Version not a Long value", e);
+			logger.debug("Version not a Long value", e);
+			logger.warn("Version not a Long value: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ParameterConverter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ParameterConverter.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.help;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -34,10 +33,10 @@ public class ParameterConverter
 
 	public static final String HTML_FORMAT = "html";
 	public static final String JSON_FORMAT = "json";
-	public static final List<String> JSON_FORMATS = Arrays.asList(Constants.CT_FHIR_JSON, Constants.CT_FHIR_JSON_NEW,
+	public static final List<String> JSON_FORMATS = List.of(Constants.CT_FHIR_JSON, Constants.CT_FHIR_JSON_NEW,
 			MediaType.APPLICATION_JSON);
 	public static final String XML_FORMAT = "xml";
-	public static final List<String> XML_FORMATS = Arrays.asList(Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW,
+	public static final List<String> XML_FORMATS = List.of(Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW,
 			MediaType.APPLICATION_XML, MediaType.TEXT_XML);
 
 	private final ExceptionHandler exceptionHandler;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ResponseGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ResponseGenerator.java
@@ -920,19 +920,23 @@ public class ResponseGenerator
 	public Response unableToGenerateSnapshot(StructureDefinition resource, Integer bundleIndex,
 			List<ValidationMessage> messages)
 	{
+		String messagesLogString = messages == null ? ""
+				: messages.stream().map(ValidationMessage::getDisplay).collect(Collectors.joining(", ", ": [", "]"));
+
 		if (bundleIndex == null)
 			logger.warn(
-					"Unable to generate StructureDefinition snapshot for profile with url {}, version {} and id {}: {}",
-					resource.getUrl(), resource.getVersion(), resource.getId());
+					"Unable to generate StructureDefinition snapshot for profile with url {}, version {} and id {}{}",
+					resource.getUrl(), resource.getVersion(), resource.getId(), messagesLogString);
 		else
 			logger.warn(
-					"Unable to generate StructureDefinition snapshot for profile with url {}, version {} and id {} at bundle index {}: {}",
-					resource.getUrl(), resource.getVersion(), resource.getId(), bundleIndex);
+					"Unable to generate StructureDefinition snapshot for profile with url {}, version {} and id {} at bundle index {}{}",
+					resource.getUrl(), resource.getVersion(), resource.getId(), bundleIndex, messagesLogString);
 
 		OperationOutcome outcome = new OperationOutcome();
 
-		messages.forEach(m -> outcome.addIssue().setSeverity(convert(m.getLevel())).setCode(convert(m.getType()))
-				.setDiagnostics(m.summary()));
+		if (messages != null)
+			messages.forEach(m -> outcome.addIssue().setSeverity(convert(m.getLevel())).setCode(convert(m.getType()))
+					.setDiagnostics(m.summary()));
 
 		return Response.status(Status.BAD_REQUEST).entity(outcome).build();
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ResponseGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ResponseGenerator.java
@@ -941,7 +941,7 @@ public class ResponseGenerator
 		return Response.status(Status.BAD_REQUEST).entity(outcome).build();
 	}
 
-	private IssueSeverity convert(org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity severity)
+	private IssueSeverity convert(ValidationMessage.IssueSeverity severity)
 	{
 		switch (severity)
 		{
@@ -960,7 +960,7 @@ public class ResponseGenerator
 		}
 	}
 
-	private IssueType convert(org.hl7.fhir.utilities.validation.ValidationMessage.IssueType type)
+	private IssueType convert(ValidationMessage.IssueType type)
 	{
 		switch (type)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/HistoryServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/HistoryServiceImpl.java
@@ -91,7 +91,7 @@ public class HistoryServiceImpl implements HistoryService, InitializingBean
 		int effectivePage = page == null ? 1 : page;
 
 		Integer count = parameterConverter.getFirstInt(queryParameters, SearchQuery.PARAMETER_COUNT);
-		int effectiveCount = (count == null || count < 0) ? defaultPageCount : count;
+		int effectiveCount = count == null || count < 0 ? defaultPageCount : count;
 
 		PageAndCount pageAndCount = new PageAndCount(effectivePage, effectiveCount);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/IncludeParts.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/IncludeParts.java
@@ -36,7 +36,7 @@ public class IncludeParts
 	public String toBundleUriQueryParameterValue()
 	{
 		return getSourceResourceTypeName() + ":" + getSearchParameterName()
-				+ (getTargetResourceTypeName() != null ? (":" + getTargetResourceTypeName()) : "");
+				+ (getTargetResourceTypeName() != null ? ":" + getTargetResourceTypeName() : "");
 	}
 
 	public String getSourceResourceTypeName()

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/PageAndCount.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/PageAndCount.java
@@ -13,7 +13,7 @@ public class PageAndCount
 
 	public String getSql()
 	{
-		return " LIMIT " + count + (page > 1 ? (" OFFSET " + ((page - 1) * count)) : "");
+		return " LIMIT " + count + (page > 1 ? " OFFSET " + ((page - 1) * count) : "");
 	}
 
 	public boolean isCountOnly(int total)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuery.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuery.java
@@ -442,7 +442,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while modifying prepared statement '{}': {}", statement.toString(), e.getMessage());
+			logger.debug("Error while modifying prepared statement '{}'", statement.toString(), e);
 			throw e;
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuery.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuery.java
@@ -42,7 +42,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 	public static final String[] STANDARD_PARAMETERS = { PARAMETER_SORT, PARAMETER_INCLUDE, PARAMETER_REVINCLUDE,
 			PARAMETER_PAGE, PARAMETER_COUNT, PARAMETER_FORMAT, PARAMETER_PRETTY, PARAMETER_SUMMARY };
 
-	public static final String[] SINGLE_VALUE_PARAMETERS = { PARAMETER_SORT, PARAMETER_PAGE, PARAMETER_COUNT,
+	private static final String[] SINGLE_VALUE_PARAMETERS = { PARAMETER_SORT, PARAMETER_PAGE, PARAMETER_COUNT,
 			PARAMETER_FORMAT, PARAMETER_PRETTY, PARAMETER_SUMMARY };
 
 	public static class SearchQueryBuilder<R extends Resource>
@@ -404,7 +404,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 	{
 		String countQueryMain = "SELECT count(*) FROM current_" + resourceTable;
 
-		return countQueryMain + (!filterQuery.isEmpty() ? (" WHERE " + filterQuery) : "");
+		return countQueryMain + (!filterQuery.isEmpty() ? " WHERE " + filterQuery : "");
 	}
 
 	@Override
@@ -413,7 +413,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 		String searchQueryMain = "SELECT " + resourceColumn + includeSql + revIncludeSql + " FROM current_"
 				+ resourceTable;
 
-		return searchQueryMain + (!filterQuery.isEmpty() ? (" WHERE " + filterQuery) : "") + sortSql
+		return searchQueryMain + (!filterQuery.isEmpty() ? " WHERE " + filterQuery : "") + sortSql
 				+ pageAndCount.getSql();
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQueryParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQueryParameter.java
@@ -21,7 +21,7 @@ public interface SearchQueryParameter<R extends Resource> extends MatcherParamet
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
-	public @interface SearchParameterDefinition
+	@interface SearchParameterDefinition
 	{
 		String name();
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQueryParameterError.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQueryParameterError.java
@@ -2,7 +2,7 @@ package dev.dsf.fhir.search;
 
 public class SearchQueryParameterError
 {
-	public static enum SearchQueryParameterErrorType
+	public enum SearchQueryParameterErrorType
 	{
 		UNSUPPORTED_PARAMETER, UNSUPPORTED_NUMBER_OF_VALUES, UNPARSABLE_VALUE
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQueryParameterFactory.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQueryParameterFactory.java
@@ -26,7 +26,21 @@ public final class SearchQueryParameterFactory<R extends Resource>
 	 */
 	public SearchQueryParameterFactory(String name, Supplier<SearchQueryParameter<R>> supplier)
 	{
-		this(name, supplier, null, null, null);
+		this(name, supplier, null);
+	}
+
+	/**
+	 * @param name
+	 *            not <code>null</code>
+	 * @param supplier
+	 *            not <code>null</code>
+	 * @param nameModifiers
+	 *            may be <code>null</code>
+	 */
+	public SearchQueryParameterFactory(String name, Supplier<SearchQueryParameter<R>> supplier,
+			List<String> nameModifiers)
+	{
+		this(name, supplier, nameModifiers, null, null);
 	}
 
 	/**

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuerySortParameterConfiguration.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuerySortParameterConfiguration.java
@@ -2,14 +2,14 @@ package dev.dsf.fhir.search;
 
 public class SearchQuerySortParameterConfiguration
 {
-	public static enum SortDirection
+	public enum SortDirection
 	{
 		ASC("", ""), DESC(" DESC", "-");
 
 		private final String sqlModifier;
 		private final String urlModifier;
 
-		private SortDirection(String sqlModifier, String urlModifier)
+		SortDirection(String sqlModifier, String urlModifier)
 		{
 			this.sqlModifier = sqlModifier;
 			this.urlModifier = urlModifier;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/filter/AbstractIdentityFilter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/filter/AbstractIdentityFilter.java
@@ -9,7 +9,7 @@ abstract class AbstractIdentityFilter implements SearchQueryIdentityFilter
 	protected final String resourceTable;
 	protected final String resourceIdColumn;
 
-	public AbstractIdentityFilter(Identity identity, String resourceTable, String resourceIdColumn)
+	AbstractIdentityFilter(Identity identity, String resourceTable, String resourceIdColumn)
 	{
 		this.identity = identity;
 		this.resourceTable = resourceTable;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/filter/AbstractMetaTagAuthorizationRoleIdentityFilter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/filter/AbstractMetaTagAuthorizationRoleIdentityFilter.java
@@ -10,8 +10,7 @@ import dev.dsf.fhir.authentication.FhirServerRole;
 
 abstract class AbstractMetaTagAuthorizationRoleIdentityFilter extends AbstractIdentityFilter
 {
-	public AbstractMetaTagAuthorizationRoleIdentityFilter(Identity identity, String resourceTable,
-			String resourceIdColumn)
+	AbstractMetaTagAuthorizationRoleIdentityFilter(Identity identity, String resourceTable, String resourceIdColumn)
 	{
 		super(identity, resourceTable, resourceIdColumn);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the activity definition")
 public class ActivityDefinitionIdentifier extends AbstractIdentifierParameter<ActivityDefinition>
 {
-	public static final String RESOURCE_COLUMN = "activity_definition";
+	private static final String RESOURCE_COLUMN = "activity_definition";
 
 	public ActivityDefinitionIdentifier()
 	{
@@ -20,9 +20,6 @@ public class ActivityDefinitionIdentifier extends AbstractIdentifierParameter<Ac
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof ActivityDefinition))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionName.java
@@ -65,9 +65,6 @@ public class ActivityDefinitionName extends AbstractStringParameter<ActivityDefi
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof ActivityDefinition))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-status", type = SearchParamType.TOKEN, documentation = "The current status of the activity definition")
 public class ActivityDefinitionStatus extends AbstractStatusParameter<ActivityDefinition>
 {
-	public static final String RESOURCE_COLUMN = "activity_definition";
+	private static final String RESOURCE_COLUMN = "activity_definition";
 
 	public ActivityDefinitionStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.Resource;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = ActivityDefinitionUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-url", type = SearchParamType.URI, documentation = "The uri that identifies the activity definition")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-url", type = SearchParamType.URI, documentation = "The uri that identifies the activity definition")
 public class ActivityDefinitionUrl extends AbstractUrlAndVersionParameter<ActivityDefinition>
 {
-	public static final String RESOURCE_COLUMN = "activity_definition";
+	private static final String RESOURCE_COLUMN = "activity_definition";
 
 	public ActivityDefinitionUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-version", type = SearchParamType.TOKEN, documentation = "The business version of the activity definition")
 public class ActivityDefinitionVersion extends AbstractVersionParameter<ActivityDefinition>
 {
-	public static final String RESOURCE_COLUMN = "activity_definition";
+	private static final String RESOURCE_COLUMN = "activity_definition";
 
 	public ActivityDefinitionVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BinaryContentType.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BinaryContentType.java
@@ -20,7 +20,7 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class BinaryContentType extends AbstractTokenParameter<Binary>
 {
 	public static final String PARAMETER_NAME = "contentType";
-	public static final String RESOURCE_COLUMN = "binary_json";
+	private static final String RESOURCE_COLUMN = "binary_json";
 
 	private CodeType contentType;
 
@@ -81,9 +81,6 @@ public class BinaryContentType extends AbstractTokenParameter<Binary>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Binary))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BundleIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BundleIdentifier.java
@@ -18,7 +18,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
 public class BundleIdentifier extends AbstractTokenParameter<Bundle>
 {
 	public static final String PARAMETER_NAME = "identifier";
-	public static final String RESOURCE_COLUMN = "bundle";
+	private static final String RESOURCE_COLUMN = "bundle";
 
 	public BundleIdentifier()
 	{
@@ -92,9 +92,6 @@ public class BundleIdentifier extends AbstractTokenParameter<Bundle>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Bundle))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the code system")
 public class CodeSystemIdentifier extends AbstractIdentifierParameter<CodeSystem>
 {
-	public static final String RESOURCE_COLUMN = "code_system";
+	private static final String RESOURCE_COLUMN = "code_system";
 
 	public CodeSystemIdentifier()
 	{
@@ -20,9 +20,6 @@ public class CodeSystemIdentifier extends AbstractIdentifierParameter<CodeSystem
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof CodeSystem))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-status", type = SearchParamType.TOKEN, documentation = "The current status of the code system")
 public class CodeSystemStatus extends AbstractStatusParameter<CodeSystem>
 {
-	public static final String RESOURCE_COLUMN = "code_system";
+	private static final String RESOURCE_COLUMN = "code_system";
 
 	public CodeSystemStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.Resource;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = CodeSystemUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-url", type = SearchParamType.URI, documentation = "The uri that identifies the code system")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-url", type = SearchParamType.URI, documentation = "The uri that identifies the code system")
 public class CodeSystemUrl extends AbstractUrlAndVersionParameter<CodeSystem>
 {
-	public static final String RESOURCE_COLUMN = "code_system";
+	private static final String RESOURCE_COLUMN = "code_system";
 
 	public CodeSystemUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-version", type = SearchParamType.TOKEN, documentation = "The business version of the code system")
 public class CodeSystemVersion extends AbstractVersionParameter<CodeSystem>
 {
-	public static final String RESOURCE_COLUMN = "code_system";
+	private static final String RESOURCE_COLUMN = "code_system";
 
 	public CodeSystemVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/DocumentReferenceIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/DocumentReferenceIdentifier.java
@@ -13,15 +13,14 @@ import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
 import dev.dsf.fhir.search.parameters.basic.TokenValueAndSearchType;
 
-@SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/clinical-identifier", type = SearchParamType.TOKEN, documentation = "Identifies this document reference across multiple systems")
+@SearchParameterDefinition(name = DocumentReferenceIdentifier.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/clinical-identifier", type = SearchParamType.TOKEN, documentation = "Identifies this document reference across multiple systems")
 public class DocumentReferenceIdentifier extends AbstractTokenParameter<DocumentReference>
 {
 	public static final String PARAMETER_NAME = "identifier";
-	public static final String RESOURCE_COLUMN = "document_reference";
+	private static final String RESOURCE_COLUMN = "document_reference";
 
 	public DocumentReferenceIdentifier()
 	{
@@ -126,9 +125,6 @@ public class DocumentReferenceIdentifier extends AbstractTokenParameter<Document
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof DocumentReference))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointAddress.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointAddress.java
@@ -63,9 +63,6 @@ public class EndpointAddress extends AbstractCanonicalUrlParameter<Endpoint>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Endpoint))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Endpoint-identifier", type = SearchParamType.TOKEN, documentation = "Identifies this endpoint across multiple systems")
 public class EndpointIdentifier extends AbstractIdentifierParameter<Endpoint>
 {
-	public static final String RESOURCE_COLUMN = "endpoint";
+	private static final String RESOURCE_COLUMN = "endpoint";
 
 	public EndpointIdentifier()
 	{
@@ -20,9 +20,6 @@ public class EndpointIdentifier extends AbstractIdentifierParameter<Endpoint>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Endpoint))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointName.java
@@ -65,9 +65,6 @@ public class EndpointName extends AbstractStringParameter<Endpoint>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Endpoint))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointOrganization.java
@@ -154,9 +154,8 @@ public class EndpointOrganization extends AbstractReferenceParameter<Endpoint>
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (e.getManagingOrganization().getResource() instanceof Organization)
+			if (e.getManagingOrganization().getResource() instanceof Organization o)
 			{
-				Organization o = (Organization) e.getManagingOrganization().getResource();
 				return o.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointOrganization.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = EndpointOrganization.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Endpoint-organization", type = SearchParamType.REFERENCE, documentation = "The organization that is managing the endpoint")
 public class EndpointOrganization extends AbstractReferenceParameter<Endpoint>
 {
-	public static final String RESOURCE_TYPE_NAME = "Endpoint";
+	private static final String RESOURCE_TYPE_NAME = "Endpoint";
 	public static final String PARAMETER_NAME = "organization";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -144,9 +144,6 @@ public class EndpointOrganization extends AbstractReferenceParameter<Endpoint>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Endpoint))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointStatus.java
@@ -22,9 +22,9 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class EndpointStatus extends AbstractTokenParameter<Endpoint>
 {
 	public static final String PARAMETER_NAME = "status";
-	public static final String RESOURCE_COLUMN = "endpoint";
+	private static final String RESOURCE_COLUMN = "endpoint";
 
-	private org.hl7.fhir.r4.model.Endpoint.EndpointStatus status;
+	private Endpoint.EndpointStatus status;
 
 	public EndpointStatus()
 	{
@@ -41,15 +41,15 @@ public class EndpointStatus extends AbstractTokenParameter<Endpoint>
 			status = toStatus(errors, valueAndType.codeValue, queryParameterValue);
 	}
 
-	private org.hl7.fhir.r4.model.Endpoint.EndpointStatus toStatus(List<? super SearchQueryParameterError> errors,
-			String status, String queryParameterValue)
+	private Endpoint.EndpointStatus toStatus(List<? super SearchQueryParameterError> errors, String status,
+			String queryParameterValue)
 	{
 		if (status == null || status.isBlank())
 			return null;
 
 		try
 		{
-			return org.hl7.fhir.r4.model.Endpoint.EndpointStatus.fromCode(status);
+			return Endpoint.EndpointStatus.fromCode(status);
 		}
 		catch (FHIRException e)
 		{
@@ -93,9 +93,6 @@ public class EndpointStatus extends AbstractTokenParameter<Endpoint>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Endpoint))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/GroupIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/GroupIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Group-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the group")
 public class GroupIdentifier extends AbstractIdentifierParameter<Group>
 {
-	public static final String RESOURCE_COLUMN = "group_json";
+	private static final String RESOURCE_COLUMN = "group_json";
 
 	public GroupIdentifier()
 	{
@@ -20,9 +20,6 @@ public class GroupIdentifier extends AbstractIdentifierParameter<Group>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Group))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceActive.java
@@ -44,9 +44,6 @@ public class HealthcareServiceActive extends AbstractBooleanParameter<Healthcare
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof HealthcareService))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/HealthcareService-identifier", type = SearchParamType.TOKEN, documentation = "External identifiers for this item")
 public class HealthcareServiceIdentifier extends AbstractIdentifierParameter<HealthcareService>
 {
-	public static final String RESOURCE_COLUMN = "healthcare_service";
+	private static final String RESOURCE_COLUMN = "healthcare_service";
 
 	public HealthcareServiceIdentifier()
 	{
@@ -20,9 +20,6 @@ public class HealthcareServiceIdentifier extends AbstractIdentifierParameter<Hea
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof HealthcareService))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the library")
 public class LibraryIdentifier extends AbstractIdentifierParameter<Library>
 {
-	public static final String RESOURCE_COLUMN = "library";
+	private static final String RESOURCE_COLUMN = "library";
 
 	public LibraryIdentifier()
 	{
@@ -20,9 +20,6 @@ public class LibraryIdentifier extends AbstractIdentifierParameter<Library>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Library))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-status", type = SearchParamType.TOKEN, documentation = "The current status of the library")
 public class LibraryStatus extends AbstractStatusParameter<Library>
 {
-	public static final String RESOURCE_COLUMN = "library";
+	private static final String RESOURCE_COLUMN = "library";
 
 	public LibraryStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.Resource;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = LibraryUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-url", type = SearchParamType.URI, documentation = "The uri that identifies the library")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-url", type = SearchParamType.URI, documentation = "The uri that identifies the library")
 public class LibraryUrl extends AbstractUrlAndVersionParameter<Library>
 {
-	public static final String RESOURCE_COLUMN = "library";
+	private static final String RESOURCE_COLUMN = "library";
 
 	public LibraryUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-version", type = SearchParamType.TOKEN, documentation = "The business version of the library")
 public class LibraryVersion extends AbstractVersionParameter<Library>
 {
-	public static final String RESOURCE_COLUMN = "library";
+	private static final String RESOURCE_COLUMN = "library";
 
 	public LibraryVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LocationIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LocationIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Location-identifier", type = SearchParamType.TOKEN, documentation = "An identifier for the location")
 public class LocationIdentifier extends AbstractIdentifierParameter<Location>
 {
-	public static final String RESOURCE_COLUMN = "location";
+	private static final String RESOURCE_COLUMN = "location";
 
 	public LocationIdentifier()
 	{
@@ -20,9 +20,6 @@ public class LocationIdentifier extends AbstractIdentifierParameter<Location>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Location))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureDependsOn.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureDependsOn.java
@@ -22,9 +22,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractCanonicalReferenceParameter;
 @SearchParameterDefinition(name = MeasureDependsOn.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-depends-on", type = SearchParamType.REFERENCE, documentation = "What resource is being referenced")
 public class MeasureDependsOn extends AbstractCanonicalReferenceParameter<Measure>
 {
-	public static final String RESOURCE_TYPE_NAME = "Measure";
+	private static final String RESOURCE_TYPE_NAME = "Measure";
 	public static final String PARAMETER_NAME = "depends-on";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Library";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Library";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -81,9 +81,6 @@ public class MeasureDependsOn extends AbstractCanonicalReferenceParameter<Measur
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Measure))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the measure")
 public class MeasureIdentifier extends AbstractIdentifierParameter<Measure>
 {
-	public static final String RESOURCE_COLUMN = "measure";
+	private static final String RESOURCE_COLUMN = "measure";
 
 	public MeasureIdentifier()
 	{
@@ -20,9 +20,6 @@ public class MeasureIdentifier extends AbstractIdentifierParameter<Measure>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Measure))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureReportIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureReportIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/MeasureReport-identifier", type = SearchParamType.TOKEN, documentation = "External identifier of the measure report to be returned")
 public class MeasureReportIdentifier extends AbstractIdentifierParameter<MeasureReport>
 {
-	public static final String RESOURCE_COLUMN = "measure_report";
+	private static final String RESOURCE_COLUMN = "measure_report";
 
 	public MeasureReportIdentifier()
 	{
@@ -20,9 +20,6 @@ public class MeasureReportIdentifier extends AbstractIdentifierParameter<Measure
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof MeasureReport))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-status", type = SearchParamType.TOKEN, documentation = "The current status of the measure")
 public class MeasureStatus extends AbstractStatusParameter<Measure>
 {
-	public static final String RESOURCE_COLUMN = "measure";
+	private static final String RESOURCE_COLUMN = "measure";
 
 	public MeasureStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.Resource;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = MeasureUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-url", type = SearchParamType.URI, documentation = "The uri that identifies the measure")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-url", type = SearchParamType.URI, documentation = "The uri that identifies the measure")
 public class MeasureUrl extends AbstractUrlAndVersionParameter<Measure>
 {
-	public static final String RESOURCE_COLUMN = "measure";
+	private static final String RESOURCE_COLUMN = "measure";
 
 	public MeasureUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-version", type = SearchParamType.TOKEN, documentation = "The business version of the measure")
 public class MeasureVersion extends AbstractVersionParameter<Measure>
 {
-	public static final String RESOURCE_COLUMN = "measure";
+	private static final String RESOURCE_COLUMN = "measure";
 
 	public MeasureVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemName.java
@@ -66,9 +66,6 @@ public class NamingSystemName extends AbstractStringParameter<NamingSystem>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Endpoint))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemName.java
@@ -5,7 +5,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.NamingSystem;
 import org.hl7.fhir.r4.model.Resource;
@@ -66,19 +65,19 @@ public class NamingSystemName extends AbstractStringParameter<NamingSystem>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!(resource instanceof Endpoint))
+		if (!(resource instanceof NamingSystem))
 			return false;
 
-		Endpoint e = (Endpoint) resource;
+		NamingSystem n = (NamingSystem) resource;
 
 		switch (valueAndType.type)
 		{
 			case STARTS_WITH:
-				return e.getName() != null && e.getName().toLowerCase().startsWith(valueAndType.value.toLowerCase());
+				return n.getName() != null && n.getName().toLowerCase().startsWith(valueAndType.value.toLowerCase());
 			case CONTAINS:
-				return e.getName() != null && e.getName().toLowerCase().contains(valueAndType.value.toLowerCase());
+				return n.getName() != null && n.getName().toLowerCase().contains(valueAndType.value.toLowerCase());
 			case EXACT:
-				return Objects.equals(e.getName(), valueAndType.value);
+				return Objects.equals(n.getName(), valueAndType.value);
 			default:
 				throw notDefined();
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/NamingSystem-status", type = SearchParamType.TOKEN, documentation = "The current status of the naming system")
 public class NamingSystemStatus extends AbstractStatusParameter<NamingSystem>
 {
-	public static final String RESOURCE_COLUMN = "naming_system";
+	private static final String RESOURCE_COLUMN = "naming_system";
 
 	public NamingSystemStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationActive.java
@@ -44,9 +44,6 @@ public class OrganizationActive extends AbstractBooleanParameter<Organization>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Organization))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationActive.java
@@ -44,9 +44,6 @@ public class OrganizationAffiliationActive extends AbstractBooleanParameter<Orga
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof OrganizationAffiliation))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationEndpoint.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationEndpoint.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = OrganizationAffiliationEndpoint.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-endpoint", type = SearchParamType.REFERENCE, documentation = "Technical endpoints providing access to services operated for this role")
 public class OrganizationAffiliationEndpoint extends AbstractReferenceParameter<OrganizationAffiliation>
 {
-	public static final String RESOURCE_TYPE_NAME = "OrganizationAffiliation";
+	private static final String RESOURCE_TYPE_NAME = "OrganizationAffiliation";
 	public static final String PARAMETER_NAME = "endpoint";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Endpoint";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Endpoint";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -147,9 +147,6 @@ public class OrganizationAffiliationEndpoint extends AbstractReferenceParameter<
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof OrganizationAffiliation))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-identifier", type = SearchParamType.TOKEN, documentation = "An organization affiliation's Identifier")
 public class OrganizationAffiliationIdentifier extends AbstractIdentifierParameter<OrganizationAffiliation>
 {
-	public static final String RESOURCE_COLUMN = "organization_affiliation";
+	private static final String RESOURCE_COLUMN = "organization_affiliation";
 
 	public OrganizationAffiliationIdentifier()
 	{
@@ -20,9 +20,6 @@ public class OrganizationAffiliationIdentifier extends AbstractIdentifierParamet
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof OrganizationAffiliation))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationParticipatingOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationParticipatingOrganization.java
@@ -29,9 +29,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 public class OrganizationAffiliationParticipatingOrganization
 		extends AbstractReferenceParameter<OrganizationAffiliation>
 {
-	public static final String RESOURCE_TYPE_NAME = "OrganizationAffiliation";
+	private static final String RESOURCE_TYPE_NAME = "OrganizationAffiliation";
 	public static final String PARAMETER_NAME = "participating-organization";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -146,9 +146,6 @@ public class OrganizationAffiliationParticipatingOrganization
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof OrganizationAffiliation))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationParticipatingOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationParticipatingOrganization.java
@@ -156,9 +156,8 @@ public class OrganizationAffiliationParticipatingOrganization
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (oA.getParticipatingOrganization().getResource() instanceof Organization)
+			if (oA.getParticipatingOrganization().getResource() instanceof Organization o)
 			{
-				Organization o = (Organization) oA.getParticipatingOrganization().getResource();
 				return o.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationPrimaryOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationPrimaryOrganization.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = OrganizationAffiliationPrimaryOrganization.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-primary-organization", type = SearchParamType.REFERENCE, documentation = "The organization that receives the services from the participating organization")
 public class OrganizationAffiliationPrimaryOrganization extends AbstractReferenceParameter<OrganizationAffiliation>
 {
-	public static final String RESOURCE_TYPE_NAME = "OrganizationAffiliation";
+	private static final String RESOURCE_TYPE_NAME = "OrganizationAffiliation";
 	public static final String PARAMETER_NAME = "primary-organization";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -145,9 +145,6 @@ public class OrganizationAffiliationPrimaryOrganization extends AbstractReferenc
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof OrganizationAffiliation))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationPrimaryOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationPrimaryOrganization.java
@@ -155,9 +155,8 @@ public class OrganizationAffiliationPrimaryOrganization extends AbstractReferenc
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (oA.getOrganization().getResource() instanceof Organization)
+			if (oA.getOrganization().getResource() instanceof Organization o)
 			{
-				Organization o = (Organization) oA.getOrganization().getResource();
 				return o.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationRole.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationRole.java
@@ -1,7 +1,5 @@
 package dev.dsf.fhir.search.parameters;
 
-import static dev.dsf.fhir.search.parameters.OrganizationAffiliationRole.PARAMETER_NAME;
-
 import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -14,11 +12,11 @@ import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
 
-@SearchParameterDefinition(name = PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-role", type = SearchParamType.TOKEN, documentation = "Definition of the role the participatingOrganization plays")
+@SearchParameterDefinition(name = OrganizationAffiliationRole.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-role", type = SearchParamType.TOKEN, documentation = "Definition of the role the participatingOrganization plays")
 public class OrganizationAffiliationRole extends AbstractTokenParameter<OrganizationAffiliation>
 {
 	public static final String PARAMETER_NAME = "role";
-	public static final String RESOURCE_COLUMN = "organization_affiliation";
+	private static final String RESOURCE_COLUMN = "organization_affiliation";
 
 	public OrganizationAffiliationRole()
 	{
@@ -91,9 +89,6 @@ public class OrganizationAffiliationRole extends AbstractTokenParameter<Organiza
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof OrganizationAffiliation))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationEndpoint.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationEndpoint.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = OrganizationEndpoint.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-endpoint", type = SearchParamType.REFERENCE, documentation = "Technical endpoints providing access to services operated for the organization")
 public class OrganizationEndpoint extends AbstractReferenceParameter<Organization>
 {
-	public static final String RESOURCE_TYPE_NAME = "Organization";
+	private static final String RESOURCE_TYPE_NAME = "Organization";
 	public static final String PARAMETER_NAME = "endpoint";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Endpoint";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Endpoint";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -146,9 +146,6 @@ public class OrganizationEndpoint extends AbstractReferenceParameter<Organizatio
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Organization))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-identifier", type = SearchParamType.TOKEN, documentation = "Any identifier for the organization (not the accreditation issuer's identifier)")
 public class OrganizationIdentifier extends AbstractIdentifierParameter<Organization>
 {
-	public static final String RESOURCE_COLUMN = "organization";
+	private static final String RESOURCE_COLUMN = "organization";
 
 	public OrganizationIdentifier()
 	{
@@ -20,9 +20,6 @@ public class OrganizationIdentifier extends AbstractIdentifierParameter<Organiza
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Organization))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationName.java
@@ -69,9 +69,6 @@ public class OrganizationName extends AbstractStringParameter<Organization>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Organization))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationType.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationType.java
@@ -1,7 +1,5 @@
 package dev.dsf.fhir.search.parameters;
 
-import static dev.dsf.fhir.search.parameters.OrganizationType.PARAMETER_NAME;
-
 import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -14,11 +12,11 @@ import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
 
-@SearchParameterDefinition(name = PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-type", type = SearchParamType.TOKEN, documentation = "A code for the type of organization")
+@SearchParameterDefinition(name = OrganizationType.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-type", type = SearchParamType.TOKEN, documentation = "A code for the type of organization")
 public class OrganizationType extends AbstractTokenParameter<Organization>
 {
 	public static final String PARAMETER_NAME = "type";
-	public static final String RESOURCE_COLUMN = "organization";
+	private static final String RESOURCE_COLUMN = "organization";
 
 	public OrganizationType()
 	{
@@ -91,9 +89,6 @@ public class OrganizationType extends AbstractTokenParameter<Organization>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Organization))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientActive.java
@@ -44,9 +44,6 @@ public class PatientActive extends AbstractBooleanParameter<Patient>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Patient))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Patient-identifier", type = SearchParamType.TOKEN, documentation = "A patient identifier")
 public class PatientIdentifier extends AbstractIdentifierParameter<Patient>
 {
-	public static final String RESOURCE_COLUMN = "patient";
+	private static final String RESOURCE_COLUMN = "patient";
 
 	public PatientIdentifier()
 	{
@@ -20,9 +20,6 @@ public class PatientIdentifier extends AbstractIdentifierParameter<Patient>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Patient))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerActive.java
@@ -44,9 +44,6 @@ public class PractitionerActive extends AbstractBooleanParameter<Practitioner>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Practitioner))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Practitioner-identifier", type = SearchParamType.TOKEN, documentation = "A practitioner's Identifier")
 public class PractitionerIdentifier extends AbstractIdentifierParameter<Practitioner>
 {
-	public static final String RESOURCE_COLUMN = "practitioner";
+	private static final String RESOURCE_COLUMN = "practitioner";
 
 	public PractitionerIdentifier()
 	{
@@ -20,9 +20,6 @@ public class PractitionerIdentifier extends AbstractIdentifierParameter<Practiti
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Practitioner))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleActive.java
@@ -12,7 +12,7 @@ import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
 
-@SearchParameterDefinition(name = PractitionerActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-active", type = SearchParamType.TOKEN, documentation = "Whether this practitioner role record is in active use [true|false]")
+@SearchParameterDefinition(name = PractitionerRoleActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-active", type = SearchParamType.TOKEN, documentation = "Whether this practitioner role record is in active use [true|false]")
 public class PractitionerRoleActive extends AbstractBooleanParameter<PractitionerRole>
 {
 	public static final String PARAMETER_NAME = "active";
@@ -44,9 +44,6 @@ public class PractitionerRoleActive extends AbstractBooleanParameter<Practitione
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof PractitionerRole))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-identifier", type = SearchParamType.TOKEN, documentation = "A practitioner's Identifier")
 public class PractitionerRoleIdentifier extends AbstractIdentifierParameter<PractitionerRole>
 {
-	public static final String RESOURCE_COLUMN = "practitioner_role";
+	private static final String RESOURCE_COLUMN = "practitioner_role";
 
 	public PractitionerRoleIdentifier()
 	{
@@ -20,9 +20,6 @@ public class PractitionerRoleIdentifier extends AbstractIdentifierParameter<Prac
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof PractitionerRole))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleOrganization.java
@@ -155,9 +155,8 @@ public class PractitionerRoleOrganization extends AbstractReferenceParameter<Pra
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (pR.getOrganization().getResource() instanceof Organization)
+			if (pR.getOrganization().getResource() instanceof Organization o)
 			{
-				Organization o = (Organization) pR.getOrganization().getResource();
 				return o.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleOrganization.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = PractitionerRoleOrganization.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-organization", type = SearchParamType.REFERENCE, documentation = "The identity of the organization the practitioner represents / acts on behalf of")
 public class PractitionerRoleOrganization extends AbstractReferenceParameter<PractitionerRole>
 {
-	public static final String RESOURCE_TYPE_NAME = "PractitionerRole";
+	private static final String RESOURCE_TYPE_NAME = "PractitionerRole";
 	public static final String PARAMETER_NAME = "organization";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Organization";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -145,9 +145,6 @@ public class PractitionerRoleOrganization extends AbstractReferenceParameter<Pra
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof PractitionerRole))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRolePractitioner.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRolePractitioner.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = PractitionerRolePractitioner.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner", type = SearchParamType.REFERENCE, documentation = "Practitioner that is able to provide the defined services for the organization")
 public class PractitionerRolePractitioner extends AbstractReferenceParameter<PractitionerRole>
 {
-	public static final String RESOURCE_TYPE_NAME = "PractitionerRole";
+	private static final String RESOURCE_TYPE_NAME = "PractitionerRole";
 	public static final String PARAMETER_NAME = "practitioner";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Practitioner";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Practitioner";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -145,9 +145,6 @@ public class PractitionerRolePractitioner extends AbstractReferenceParameter<Pra
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof PractitionerRole))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRolePractitioner.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRolePractitioner.java
@@ -155,9 +155,8 @@ public class PractitionerRolePractitioner extends AbstractReferenceParameter<Pra
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (pR.getPractitioner().getResource() instanceof Practitioner)
+			if (pR.getPractitioner().getResource() instanceof Practitioner p)
 			{
-				Practitioner p = (Practitioner) pR.getPractitioner().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the questionnaire")
 public class QuestionnaireIdentifier extends AbstractIdentifierParameter<Questionnaire>
 {
-	public static final String RESOURCE_COLUMN = "questionnaire";
+	private static final String RESOURCE_COLUMN = "questionnaire";
 
 	public QuestionnaireIdentifier()
 	{
@@ -20,9 +20,6 @@ public class QuestionnaireIdentifier extends AbstractIdentifierParameter<Questio
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Questionnaire))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseIdentifier.java
@@ -16,7 +16,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/QuestionnaireResponse-identifier", type = SearchParamType.TOKEN, documentation = "The unique identifier for the questionnaire response")
 public class QuestionnaireResponseIdentifier extends AbstractIdentifierParameter<QuestionnaireResponse>
 {
-	public static final String RESOURCE_COLUMN = "questionnaire_response";
+	private static final String RESOURCE_COLUMN = "questionnaire_response";
 
 	public QuestionnaireResponseIdentifier()
 	{
@@ -88,9 +88,6 @@ public class QuestionnaireResponseIdentifier extends AbstractIdentifierParameter
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof QuestionnaireResponse))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseQuestionnaire.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseQuestionnaire.java
@@ -22,9 +22,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractCanonicalReferenceParameter;
 @SearchParameterDefinition(name = QuestionnaireResponseQuestionnaire.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/QuestionnaireResponse-questionnaire", type = SearchParamType.REFERENCE, documentation = "The questionnaire the answers are provided for")
 public class QuestionnaireResponseQuestionnaire extends AbstractCanonicalReferenceParameter<QuestionnaireResponse>
 {
-	public static final String RESOURCE_TYPE_NAME = "QuestionnaireResponse";
+	private static final String RESOURCE_TYPE_NAME = "QuestionnaireResponse";
 	public static final String PARAMETER_NAME = "questionnaire";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Questionnaire";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Questionnaire";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -46,10 +46,7 @@ public class QuestionnaireResponseQuestionnaire extends AbstractCanonicalReferen
 	@Override
 	public String getFilterQuery()
 	{
-		if (ReferenceSearchType.URL.equals(valueAndType.type))
-			return "(questionnaire_response->>'questionnaire' LIKE (? || '%'))";
-
-		return "";
+		return "(questionnaire_response->>'questionnaire' LIKE (? || '%'))";
 	}
 
 	@Override
@@ -62,11 +59,7 @@ public class QuestionnaireResponseQuestionnaire extends AbstractCanonicalReferen
 	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
 			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
 	{
-		if (ReferenceSearchType.URL.equals(valueAndType.type))
-		{
-			if (subqueryParameterIndex == 1)
-				statement.setString(parameterIndex, valueAndType.url);
-		}
+		statement.setString(parameterIndex, valueAndType.url);
 	}
 
 	@Override
@@ -79,9 +72,6 @@ public class QuestionnaireResponseQuestionnaire extends AbstractCanonicalReferen
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof QuestionnaireResponse))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseStatus.java
@@ -22,7 +22,7 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class QuestionnaireResponseStatus extends AbstractTokenParameter<QuestionnaireResponse>
 {
 	public static final String PARAMETER_NAME = "status";
-	public static final String RESOURCE_COLUMN = "questionnaire_response";
+	private static final String RESOURCE_COLUMN = "questionnaire_response";
 
 	private QuestionnaireResponse.QuestionnaireResponseStatus status;
 
@@ -94,9 +94,6 @@ public class QuestionnaireResponseStatus extends AbstractTokenParameter<Question
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof QuestionnaireResponse))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseSubject.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseSubject.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.hl7.fhir.instance.model.api.IIdType;
-import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Practitioner;
@@ -33,7 +32,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = QuestionnaireResponseSubject.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/QuestionnaireResponse-subject", type = SearchParamType.REFERENCE, documentation = "The subject of the questionnaire response")
 public class QuestionnaireResponseSubject extends AbstractReferenceParameter<QuestionnaireResponse>
 {
-	public static final String RESOURCE_TYPE_NAME = "QuestionnaireResponse";
+	private static final String RESOURCE_TYPE_NAME = "QuestionnaireResponse";
 	public static final String PARAMETER_NAME = "subject";
 
 	// TODO if needed, modify for Reference(Any), see also doResolveReferencesForMatching, matches, getIncludeSql
@@ -174,10 +173,7 @@ public class QuestionnaireResponseSubject extends AbstractReferenceParameter<Que
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
-		if (!(resource instanceof Endpoint))
+		if (!(resource instanceof QuestionnaireResponse))
 			return false;
 
 		QuestionnaireResponse qr = (QuestionnaireResponse) resource;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseSubject.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseSubject.java
@@ -184,21 +184,18 @@ public class QuestionnaireResponseSubject extends AbstractReferenceParameter<Que
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (qr.getSubject().getResource() instanceof Organization)
+			if (qr.getSubject().getResource() instanceof Organization o)
 			{
-				Organization o = (Organization) qr.getSubject().getResource();
 				return o.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}
-			else if (qr.getSubject().getResource() instanceof Practitioner)
+			else if (qr.getSubject().getResource() instanceof Practitioner p)
 			{
-				Practitioner p = (Practitioner) qr.getSubject().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}
-			else if (qr.getSubject().getResource() instanceof PractitionerRole)
+			else if (qr.getSubject().getResource() instanceof PractitionerRole p)
 			{
-				PractitionerRole p = (PractitionerRole) qr.getSubject().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-status", type = SearchParamType.TOKEN, documentation = "The current status of the questionnaire")
 public class QuestionnaireStatus extends AbstractStatusParameter<Questionnaire>
 {
-	public static final String RESOURCE_COLUMN = "questionnaire";
+	private static final String RESOURCE_COLUMN = "questionnaire";
 
 	public QuestionnaireStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.Resource;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = QuestionnaireUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-url", type = SearchParamType.URI, documentation = "The uri that identifies the questionnaire")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-url", type = SearchParamType.URI, documentation = "The uri that identifies the questionnaire")
 public class QuestionnaireUrl extends AbstractUrlAndVersionParameter<Questionnaire>
 {
-	public static final String RESOURCE_COLUMN = "questionnaire";
+	private static final String RESOURCE_COLUMN = "questionnaire";
 
 	public QuestionnaireUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-version", type = SearchParamType.TOKEN, documentation = "The business version of the questionnaire")
 public class QuestionnaireVersion extends AbstractVersionParameter<Questionnaire>
 {
-	public static final String RESOURCE_COLUMN = "questionnaire";
+	private static final String RESOURCE_COLUMN = "questionnaire";
 
 	public QuestionnaireVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyEnrollment.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyEnrollment.java
@@ -28,9 +28,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = ResearchStudyEnrollment.PARAMETER_NAME, definition = "http://dsf.dev/fhir/SearchParameter/ResearchStudy-enrollment", type = SearchParamType.REFERENCE, documentation = "Search by research study enrollment")
 public class ResearchStudyEnrollment extends AbstractReferenceParameter<ResearchStudy>
 {
-	public static final String RESOURCE_TYPE_NAME = "ResearchStudy";
+	private static final String RESOURCE_TYPE_NAME = "ResearchStudy";
 	public static final String PARAMETER_NAME = "enrollment";
-	public static final String TARGET_RESOURCE_TYPE_NAME = "Group";
+	private static final String TARGET_RESOURCE_TYPE_NAME = "Group";
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -146,9 +146,6 @@ public class ResearchStudyEnrollment extends AbstractReferenceParameter<Research
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof ResearchStudy))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ResearchStudy-identifier", type = SearchParamType.TOKEN, documentation = "Business Identifier for study")
 public class ResearchStudyIdentifier extends AbstractIdentifierParameter<ResearchStudy>
 {
-	public static final String RESOURCE_COLUMN = "research_study";
+	private static final String RESOURCE_COLUMN = "research_study";
 
 	public ResearchStudyIdentifier()
 	{
@@ -20,9 +20,6 @@ public class ResearchStudyIdentifier extends AbstractIdentifierParameter<Researc
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof ResearchStudy))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyPrincipalInvestigator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyPrincipalInvestigator.java
@@ -174,15 +174,13 @@ public class ResearchStudyPrincipalInvestigator extends AbstractReferenceParamet
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (r.getPrincipalInvestigator().getResource() instanceof Practitioner)
+			if (r.getPrincipalInvestigator().getResource() instanceof Practitioner p)
 			{
-				Practitioner p = (Practitioner) r.getPrincipalInvestigator().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}
-			else if (r.getPrincipalInvestigator().getResource() instanceof PractitionerRole)
+			else if (r.getPrincipalInvestigator().getResource() instanceof PractitionerRole p)
 			{
-				PractitionerRole p = (PractitionerRole) r.getPrincipalInvestigator().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyPrincipalInvestigator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyPrincipalInvestigator.java
@@ -31,9 +31,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = ResearchStudyPrincipalInvestigator.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ResearchStudy-principalinvestigator", type = SearchParamType.REFERENCE, documentation = "Researcher who oversees multiple aspects of the study")
 public class ResearchStudyPrincipalInvestigator extends AbstractReferenceParameter<ResearchStudy>
 {
-	public static final String RESOURCE_TYPE_NAME = "ResearchStudy";
+	private static final String RESOURCE_TYPE_NAME = "ResearchStudy";
 	public static final String PARAMETER_NAME = "principalinvestigator";
-	public static final String[] TARGET_RESOURCE_TYPE_NAMES = { "Practitioner", "PractitionerRole" };
+	private static final String[] TARGET_RESOURCE_TYPE_NAMES = { "Practitioner", "PractitionerRole" };
 
 	public static List<String> getIncludeParameterValues()
 	{
@@ -164,9 +164,6 @@ public class ResearchStudyPrincipalInvestigator extends AbstractReferenceParamet
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof ResearchStudy))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceId.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceId.java
@@ -119,10 +119,7 @@ public class ResourceId<R extends Resource> extends AbstractSearchParameter<R>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (isDefined())
-			return Objects.equals(resource.getId(), id.toString());
-		else
-			throw notDefined();
+		return Objects.equals(resource.getId(), id.toString());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceProfile.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceProfile.java
@@ -64,9 +64,6 @@ public class ResourceProfile<R extends Resource> extends AbstractCanonicalUrlPar
 	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
 			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		switch (valueAndType.type)
 		{
 			case PRECISE:
@@ -94,9 +91,6 @@ public class ResourceProfile<R extends Resource> extends AbstractCanonicalUrlPar
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		switch (valueAndType.type)
 		{
 			case PRECISE:

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the structure definition")
 public class StructureDefinitionIdentifier extends AbstractIdentifierParameter<StructureDefinition>
 {
-	public static final String RESOURCE_COLUMN = "structure_definition";
+	private static final String RESOURCE_COLUMN = "structure_definition";
 
 	public StructureDefinitionIdentifier()
 	{
@@ -25,9 +25,6 @@ public class StructureDefinitionIdentifier extends AbstractIdentifierParameter<S
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof StructureDefinition))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-status", type = SearchParamType.TOKEN, documentation = "The current status of the structure definition")
 public class StructureDefinitionStatus extends AbstractStatusParameter<StructureDefinition>
 {
-	public static final String RESOURCE_COLUMN = "structure_definition";
+	private static final String RESOURCE_COLUMN = "structure_definition";
 
 	public StructureDefinitionStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.StructureDefinition;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = StructureDefinitionUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-url", type = SearchParamType.URI, documentation = "The uri that identifies the structure definition")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-url", type = SearchParamType.URI, documentation = "The uri that identifies the structure definition")
 public class StructureDefinitionUrl extends AbstractUrlAndVersionParameter<StructureDefinition>
 {
-	public static final String RESOURCE_COLUMN = "structure_definition";
+	private static final String RESOURCE_COLUMN = "structure_definition";
 
 	public StructureDefinitionUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-version", type = SearchParamType.TOKEN, documentation = "The business version of the structure definition")
 public class StructureDefinitionVersion extends AbstractVersionParameter<StructureDefinition>
 {
-	public static final String RESOURCE_COLUMN = "structure_definition";
+	private static final String RESOURCE_COLUMN = "structure_definition";
 
 	public StructureDefinitionVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionCriteria.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionCriteria.java
@@ -45,9 +45,6 @@ public class SubscriptionCriteria extends AbstractStringParameter<Subscription>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Subscription))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionPayload.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionPayload.java
@@ -20,7 +20,7 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class SubscriptionPayload extends AbstractTokenParameter<Subscription>
 {
 	public static final String PARAMETER_NAME = "payload";
-	public static final String RESOURCE_COLUMN = "subscription";
+	private static final String RESOURCE_COLUMN = "subscription";
 
 	private String payloadMimeType;
 
@@ -73,9 +73,6 @@ public class SubscriptionPayload extends AbstractTokenParameter<Subscription>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Subscription))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionStatus.java
@@ -22,9 +22,9 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class SubscriptionStatus extends AbstractTokenParameter<Subscription>
 {
 	public static final String PARAMETER_NAME = "status";
-	public static final String RESOURCE_COLUMN = "subscription";
+	private static final String RESOURCE_COLUMN = "subscription";
 
-	private org.hl7.fhir.r4.model.Subscription.SubscriptionStatus status;
+	private Subscription.SubscriptionStatus status;
 
 	public SubscriptionStatus()
 	{
@@ -41,15 +41,15 @@ public class SubscriptionStatus extends AbstractTokenParameter<Subscription>
 			status = toStatus(errors, valueAndType.codeValue, queryParameterValue);
 	}
 
-	private org.hl7.fhir.r4.model.Subscription.SubscriptionStatus toStatus(
-			List<? super SearchQueryParameterError> errors, String status, String queryParameterValue)
+	private Subscription.SubscriptionStatus toStatus(List<? super SearchQueryParameterError> errors, String status,
+			String queryParameterValue)
 	{
 		if (status == null || status.isBlank())
 			return null;
 
 		try
 		{
-			return org.hl7.fhir.r4.model.Subscription.SubscriptionStatus.fromCode(status);
+			return Subscription.SubscriptionStatus.fromCode(status);
 		}
 		catch (FHIRException e)
 		{
@@ -93,9 +93,6 @@ public class SubscriptionStatus extends AbstractTokenParameter<Subscription>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Subscription))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionType.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionType.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Subscription;
+import org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -22,9 +23,9 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class SubscriptionType extends AbstractTokenParameter<Subscription>
 {
 	public static final String PARAMETER_NAME = "type";
-	public static final String RESOURCE_COLUMN = "subscription";
+	private static final String RESOURCE_COLUMN = "subscription";
 
-	private org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType channelType;
+	private SubscriptionChannelType channelType;
 
 	public SubscriptionType()
 	{
@@ -41,15 +42,15 @@ public class SubscriptionType extends AbstractTokenParameter<Subscription>
 			channelType = toChannelType(errors, valueAndType.codeValue, queryParameterValue);
 	}
 
-	private org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType toChannelType(
-			List<? super SearchQueryParameterError> errors, String status, String queryParameterValue)
+	private SubscriptionChannelType toChannelType(List<? super SearchQueryParameterError> errors, String status,
+			String queryParameterValue)
 	{
 		if (status == null || status.isBlank())
 			return null;
 
 		try
 		{
-			return org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType.fromCode(status);
+			return SubscriptionChannelType.fromCode(status);
 		}
 		catch (FHIRException e)
 		{
@@ -93,9 +94,6 @@ public class SubscriptionType extends AbstractTokenParameter<Subscription>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Subscription))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Task-identifier", type = SearchParamType.TOKEN, documentation = "Search for a task instance by its business identifier")
 public class TaskIdentifier extends AbstractIdentifierParameter<Task>
 {
-	public static final String RESOURCE_COLUMN = "task";
+	private static final String RESOURCE_COLUMN = "task";
 
 	public TaskIdentifier()
 	{
@@ -20,9 +20,6 @@ public class TaskIdentifier extends AbstractIdentifierParameter<Task>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Task))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskRequester.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskRequester.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.hl7.fhir.instance.model.api.IIdType;
-import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
@@ -34,9 +33,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractReferenceParameter;
 @SearchParameterDefinition(name = TaskRequester.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Task-requester", type = SearchParamType.REFERENCE, documentation = "Search by task requester")
 public class TaskRequester extends AbstractReferenceParameter<Task>
 {
-	public static final String RESOURCE_TYPE_NAME = "Task";
+	private static final String RESOURCE_TYPE_NAME = "Task";
 	public static final String PARAMETER_NAME = "requester";
-	public static final String[] TARGET_RESOURCE_TYPE_NAMES = { "Practitioner", "Organization", "Patient",
+	private static final String[] TARGET_RESOURCE_TYPE_NAMES = { "Practitioner", "Organization", "Patient",
 			"PractitionerRole" };
 	// TODO add Device, RelatedPerson if supported, see also doResolveReferencesForMatching, matches, getIncludeSql
 
@@ -178,10 +177,7 @@ public class TaskRequester extends AbstractReferenceParameter<Task>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
-		if (!(resource instanceof Endpoint))
+		if (!(resource instanceof Task))
 			return false;
 
 		Task t = (Task) resource;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskRequester.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskRequester.java
@@ -188,27 +188,23 @@ public class TaskRequester extends AbstractReferenceParameter<Task>
 
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (t.getRequester().getResource() instanceof Practitioner)
+			if (t.getRequester().getResource() instanceof Practitioner p)
 			{
-				Practitioner p = (Practitioner) t.getRequester().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}
-			else if (t.getRequester().getResource() instanceof Organization)
+			else if (t.getRequester().getResource() instanceof Organization o)
 			{
-				Organization o = (Organization) t.getRequester().getResource();
 				return o.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}
-			else if (t.getRequester().getResource() instanceof Patient)
+			else if (t.getRequester().getResource() instanceof Patient p)
 			{
-				Patient p = (Patient) t.getRequester().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}
-			else if (t.getRequester().getResource() instanceof PractitionerRole)
+			else if (t.getRequester().getResource() instanceof PractitionerRole p)
 			{
-				PractitionerRole p = (PractitionerRole) t.getRequester().getResource();
 				return p.getIdentifier().stream()
 						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskStatus.java
@@ -22,9 +22,9 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class TaskStatus extends AbstractTokenParameter<Task>
 {
 	public static final String PARAMETER_NAME = "status";
-	public static final String RESOURCE_COLUMN = "task";
+	private static final String RESOURCE_COLUMN = "task";
 
-	private org.hl7.fhir.r4.model.Task.TaskStatus status;
+	private Task.TaskStatus status;
 
 	public TaskStatus()
 	{
@@ -41,15 +41,15 @@ public class TaskStatus extends AbstractTokenParameter<Task>
 			status = toStatus(errors, valueAndType.codeValue, queryParameterValue);
 	}
 
-	private org.hl7.fhir.r4.model.Task.TaskStatus toStatus(List<? super SearchQueryParameterError> errors,
-			String status, String queryParameterValue)
+	private Task.TaskStatus toStatus(List<? super SearchQueryParameterError> errors, String status,
+			String queryParameterValue)
 	{
 		if (status == null || status.isBlank())
 			return null;
 
 		try
 		{
-			return org.hl7.fhir.r4.model.Task.TaskStatus.fromCode(status);
+			return Task.TaskStatus.fromCode(status);
 		}
 		catch (FHIRException e)
 		{
@@ -93,9 +93,6 @@ public class TaskStatus extends AbstractTokenParameter<Task>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof Task))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetIdentifier.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the value set")
 public class ValueSetIdentifier extends AbstractIdentifierParameter<ValueSet>
 {
-	public static final String RESOURCE_COLUMN = "value_set";
+	private static final String RESOURCE_COLUMN = "value_set";
 
 	public ValueSetIdentifier()
 	{
@@ -20,9 +20,6 @@ public class ValueSetIdentifier extends AbstractIdentifierParameter<ValueSet>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!(resource instanceof ValueSet))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetStatus.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-status", type = SearchParamType.TOKEN, documentation = "The current status of the value set")
 public class ValueSetStatus extends AbstractStatusParameter<ValueSet>
 {
-	public static final String RESOURCE_COLUMN = "value_set";
+	private static final String RESOURCE_COLUMN = "value_set";
 
 	public ValueSetStatus()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetUrl.java
@@ -7,10 +7,10 @@ import org.hl7.fhir.r4.model.ValueSet;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 
-@SearchParameterDefinition(name = ValueSetUrl.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-url", type = SearchParamType.URI, documentation = "The uri that identifies the value set")
+@SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-url", type = SearchParamType.URI, documentation = "The uri that identifies the value set")
 public class ValueSetUrl extends AbstractUrlAndVersionParameter<ValueSet>
 {
-	public static final String RESOURCE_COLUMN = "value_set";
+	private static final String RESOURCE_COLUMN = "value_set";
 
 	public ValueSetUrl()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetVersion.java
@@ -10,7 +10,7 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-version", type = SearchParamType.TOKEN, documentation = "The business version of the value set")
 public class ValueSetVersion extends AbstractVersionParameter<ValueSet>
 {
-	public static final String RESOURCE_COLUMN = "value_set";
+	private static final String RESOURCE_COLUMN = "value_set";
 
 	public ValueSetVersion()
 	{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractCanonicalUrlParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractCanonicalUrlParameter.java
@@ -9,13 +9,13 @@ import dev.dsf.fhir.search.SearchQueryParameterError;
 
 public abstract class AbstractCanonicalUrlParameter<R extends Resource> extends AbstractSearchParameter<R>
 {
-	public static enum UriSearchType
+	protected enum UriSearchType
 	{
 		PRECISE(""), BELOW(":below"); // TODO, ABOVE(":above");
 
 		public final String modifier;
 
-		private UriSearchType(String modifier)
+		UriSearchType(String modifier)
 		{
 			this.modifier = modifier;
 		}
@@ -94,6 +94,6 @@ public abstract class AbstractCanonicalUrlParameter<R extends Resource> extends 
 	@Override
 	public String getBundleUriQueryParameterValue()
 	{
-		return valueAndType.url + (hasVersion() ? ("|" + valueAndType.version) : "");
+		return valueAndType.url + (hasVersion() ? "|" + valueAndType.version : "");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractDateTimeParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractDateTimeParameter.java
@@ -23,21 +23,21 @@ import dev.dsf.fhir.search.SearchQueryParameterError.SearchQueryParameterErrorTy
 
 public abstract class AbstractDateTimeParameter<R extends Resource> extends AbstractSearchParameter<R>
 {
-	public static enum DateTimeSearchType
+	protected enum DateTimeSearchType
 	{
 		EQ("eq", "="), NE("ne", "<>"), GT("gt", ">"), LT("lt", "<"), GE("ge", ">="), LE("le", "<=");
 
 		public final String prefix;
 		public final String operator;
 
-		private DateTimeSearchType(String prefix, String operator)
+		DateTimeSearchType(String prefix, String operator)
 		{
 			this.prefix = prefix;
 			this.operator = operator;
 		}
 	}
 
-	protected static enum DateTimeType
+	protected enum DateTimeType
 	{
 		ZONED_DATE_TIME, LOCAL_DATE, YEAR_PERIOD, YEAR_MONTH_PERIOD;
 	}
@@ -282,9 +282,6 @@ public abstract class AbstractDateTimeParameter<R extends Resource> extends Abst
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		ZonedDateTime lastUpdated = toZonedDateTime(resource.getMeta().getLastUpdated());
 		return lastUpdated != null && matches(lastUpdated, valueAndType);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractReferenceParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractReferenceParameter.java
@@ -21,14 +21,14 @@ import dev.dsf.fhir.search.SearchQueryParameterError.SearchQueryParameterErrorTy
 public abstract class AbstractReferenceParameter<R extends DomainResource> extends AbstractSearchParameter<R>
 		implements SearchQueryIncludeParameter<R>
 {
-	public static final String PARAMETER_NAME_IDENTIFIER_MODIFIER = ":identifier";
+	private static final String PARAMETER_NAME_IDENTIFIER_MODIFIER = ":identifier";
 
 	public static List<String> getNameModifiers()
 	{
 		return Collections.singletonList(PARAMETER_NAME_IDENTIFIER_MODIFIER);
 	}
 
-	protected static enum ReferenceSearchType
+	protected enum ReferenceSearchType
 	{
 		ID, TYPE_AND_ID, RESOURCE_NAME_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID, URL, IDENTIFIER
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStatusParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStatusParameter.java
@@ -94,9 +94,6 @@ public class AbstractStatusParameter<R extends MetadataResource> extends Abstrac
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!resourceType.isInstance(resource))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStringParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStringParameter.java
@@ -8,13 +8,13 @@ import dev.dsf.fhir.search.SearchQueryParameterError;
 
 public abstract class AbstractStringParameter<R extends DomainResource> extends AbstractSearchParameter<R>
 {
-	public static enum StringSearchType
+	protected enum StringSearchType
 	{
 		STARTS_WITH(""), EXACT(":exact"), CONTAINS(":contains");
 
 		public final String modifier;
 
-		private StringSearchType(String modifier)
+		StringSearchType(String modifier)
 		{
 			this.modifier = modifier;
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractUrlAndVersionParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractUrlAndVersionParameter.java
@@ -71,9 +71,6 @@ public abstract class AbstractUrlAndVersionParameter<R extends MetadataResource>
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!instanceOf(resource))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractVersionParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractVersionParameter.java
@@ -71,9 +71,6 @@ public abstract class AbstractVersionParameter<R extends MetadataResource> exten
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (!isDefined())
-			throw notDefined();
-
 		if (!instanceOf(resource))
 			return false;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/InitialDataLoaderImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/InitialDataLoaderImpl.java
@@ -68,6 +68,6 @@ public class InitialDataLoaderImpl implements InitialDataLoader, InitializingBea
 
 	private void logResult(BundleEntryComponent entry)
 	{
-		logger.info("{} {}", entry.getResponse().getLocation(), entry.getResponse().getStatus());
+		logger.info("Result: {} {}", entry.getResponse().getLocation(), entry.getResponse().getStatus());
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/InitialDataMigratorImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/InitialDataMigratorImpl.java
@@ -32,11 +32,12 @@ public class InitialDataMigratorImpl implements InitialDataMigrator
 				logger.debug("Executing initial data migration job: {}", job.getClass().getName());
 				job.execute();
 			}
-			catch (Exception exception)
+			catch (Exception e)
 			{
-				logger.warn("Initial data migration job '{}' failed with error: {}", job.getClass().getName(),
-						exception.getMessage());
-				throw new RuntimeException(exception);
+				logger.debug("Initial data migration job '{}' failed with error: {}", job.getClass().getName(), e);
+				logger.warn("Initial data migration job '{}' failed with error: {} - {}", job.getClass().getName(),
+						e.getClass().getName(), e.getMessage());
+				throw new RuntimeException(e);
 			}
 		}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ReferenceResolverImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ReferenceResolverImpl.java
@@ -238,12 +238,12 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			}
 			catch (Exception e)
 			{
-				logger.error("Literal external reference {} could not be resolved on remote server {}: {}",
-						reference.getReference().getReference(), remoteServerBase, e.getMessage());
+				logger.error("Literal external reference {} could not be resolved on remote server {}: {} - {}",
+						reference.getReference().getReference(), remoteServerBase, e.getClass().getName(),
+						e.getMessage());
+				logger.debug("Literal external reference {} could not be resolved on remote server {}",
+						reference.getReference().getReference(), remoteServerBase, e);
 
-				if (logger.isDebugEnabled())
-					logger.debug("Literal external reference " + reference.getReference().getReference()
-							+ " could not be resolved on remote server " + remoteServerBase, e);
 				return Optional.empty();
 			}
 		}
@@ -372,6 +372,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 						UriComponentsBuilder.newInstance().path(referenceTargetDao.getResourceTypeName())
 								.replaceQueryParams(CollectionUtils.toMultiValueMap(queryParameters)).toUriString(),
 						resourceReference.getLocation());
+
 			return Optional.empty();
 		}
 		else if (result.getTotal() == 1)
@@ -488,12 +489,10 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			}
 			catch (Exception e)
 			{
-				logger.error("Literal external reference {} could not be resolved on remote server {}: {}",
-						referenceValue, remoteServerBase, e.getMessage());
-
-				if (logger.isDebugEnabled())
-					logger.debug("Literal external reference " + referenceValue
-							+ " could not be resolved on remote server " + remoteServerBase, e);
+				logger.error("Literal external reference {} could not be resolved on remote server {}: {} - {}",
+						referenceValue, remoteServerBase, e.getClass().getName(), e.getMessage());
+				logger.debug("Literal external reference {} could not be resolved on remote server {}", referenceValue,
+						remoteServerBase, e);
 
 				return Optional.of(responseGenerator.referenceTargetCouldNotBeResolvedOnRemote(bundleIndex, resource,
 						reference, remoteServerBase));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ReferenceResolverImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ReferenceResolverImpl.java
@@ -238,11 +238,11 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			}
 			catch (Exception e)
 			{
+				logger.debug("Literal external reference {} could not be resolved on remote server {}",
+						reference.getReference().getReference(), remoteServerBase, e);
 				logger.error("Literal external reference {} could not be resolved on remote server {}: {} - {}",
 						reference.getReference().getReference(), remoteServerBase, e.getClass().getName(),
 						e.getMessage());
-				logger.debug("Literal external reference {} could not be resolved on remote server {}",
-						reference.getReference().getReference(), remoteServerBase, e);
 
 				return Optional.empty();
 			}
@@ -489,10 +489,10 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			}
 			catch (Exception e)
 			{
-				logger.error("Literal external reference {} could not be resolved on remote server {}: {} - {}",
-						referenceValue, remoteServerBase, e.getClass().getName(), e.getMessage());
 				logger.debug("Literal external reference {} could not be resolved on remote server {}", referenceValue,
 						remoteServerBase, e);
+				logger.error("Literal external reference {} could not be resolved on remote server {}: {} - {}",
+						referenceValue, remoteServerBase, e.getClass().getName(), e.getMessage());
 
 				return Optional.of(responseGenerator.referenceTargetCouldNotBeResolvedOnRemote(bundleIndex, resource,
 						reference, remoteServerBase));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
@@ -34,12 +34,12 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 {
 	private static final Logger logger = LoggerFactory.getLogger(ValidationSupportWithCache.class);
 
-	private final class CacheEntry<R extends Resource>
+	private static final class CacheEntry<R extends Resource>
 	{
-		private final Supplier<R> resourceSupplier;
-		private SoftReference<R> ref;
+		final Supplier<R> resourceSupplier;
+		SoftReference<R> ref;
 
-		public CacheEntry(R resource, Supplier<R> resourceSupplier)
+		CacheEntry(R resource, Supplier<R> resourceSupplier)
 		{
 			this.ref = new SoftReference<>(resource);
 			this.resourceSupplier = resourceSupplier;
@@ -53,9 +53,7 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 		public R get()
 		{
 			if (ref == null || ref.get() == null)
-			{
 				ref = read();
-			}
 
 			return ref.get();
 		}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
@@ -130,16 +130,14 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 
 	private void add(Resource resource)
 	{
-		if (resource instanceof CodeSystem)
-			doAdd((CodeSystem) resource, codeSystems, CodeSystem::getUrl, CodeSystem::getVersion,
+		if (resource instanceof CodeSystem c)
+			doAdd(c, codeSystems, CodeSystem::getUrl, CodeSystem::getVersion,
 					url -> (CodeSystem) delegate.fetchCodeSystem(url));
-		else if (resource instanceof StructureDefinition)
-			doAdd((StructureDefinition) resource, structureDefinitions, StructureDefinition::getUrl,
-					StructureDefinition::getVersion,
+		else if (resource instanceof StructureDefinition s)
+			doAdd(s, structureDefinitions, StructureDefinition::getUrl, StructureDefinition::getVersion,
 					url -> (StructureDefinition) delegate.fetchStructureDefinition(url));
-		else if (resource instanceof ValueSet)
-			doAdd((ValueSet) resource, valueSets, ValueSet::getUrl, ValueSet::getVersion,
-					url -> (ValueSet) delegate.fetchValueSet(url));
+		else if (resource instanceof ValueSet v)
+			doAdd(v, valueSets, ValueSet::getUrl, ValueSet::getVersion, url -> (ValueSet) delegate.fetchValueSet(url));
 	}
 
 	private <R extends Resource> void doAdd(R resource, ConcurrentMap<String, CacheEntry<R>> cache,
@@ -169,13 +167,12 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 
 	private void remove(Resource resource)
 	{
-		if (resource instanceof CodeSystem)
-			doRemove((CodeSystem) resource, codeSystems, CodeSystem::getUrl, CodeSystem::getVersion);
-		else if (resource instanceof StructureDefinition)
-			doRemove((StructureDefinition) resource, structureDefinitions, StructureDefinition::getUrl,
-					StructureDefinition::getVersion);
-		else if (resource instanceof ValueSet)
-			doRemove((ValueSet) resource, valueSets, ValueSet::getUrl, ValueSet::getVersion);
+		if (resource instanceof CodeSystem c)
+			doRemove(c, codeSystems, CodeSystem::getUrl, CodeSystem::getVersion);
+		else if (resource instanceof StructureDefinition s)
+			doRemove(s, structureDefinitions, StructureDefinition::getUrl, StructureDefinition::getVersion);
+		else if (resource instanceof ValueSet v)
+			doRemove(v, valueSets, ValueSet::getUrl, ValueSet::getVersion);
 	}
 
 	private <R extends Resource> void doRemove(R resource, ConcurrentMap<String, CacheEntry<R>> cache,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithFetchFromDb.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithFetchFromDb.java
@@ -128,7 +128,9 @@ public class ValidationSupportWithFetchFromDb implements IValidationSupport, Ini
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB", e);
+			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithFetchFromDbWithTransaction.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithFetchFromDbWithTransaction.java
@@ -116,7 +116,9 @@ public class ValidationSupportWithFetchFromDbWithTransaction implements IValidat
 		}
 		catch (SQLException e)
 		{
-			logger.warn("Error while accessing DB", e);
+			logger.debug("Error while accessing DB", e);
+			logger.warn("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
+
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/AuthorizationConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/AuthorizationConfig.java
@@ -86,6 +86,9 @@ public class AuthorizationConfig
 	@Autowired
 	private ReferenceConfig referenceConfig;
 
+	@Autowired
+	private FhirConfig fhirConfig;
+
 	@Bean
 	public ReadAccessHelper readAccessHelper()
 	{
@@ -306,7 +309,7 @@ public class AuthorizationConfig
 	{
 		return new TaskAuthorizationRule(daoConfig.daoProvider(), propertiesConfig.getServerBaseUrl(),
 				referenceConfig.referenceResolver(), authenticationConfig.organizationProvider(), readAccessHelper(),
-				helperConfig.parameterConverter(), processAuthorizationHelper());
+				helperConfig.parameterConverter(), processAuthorizationHelper(), fhirConfig.fhirContext());
 	}
 
 	@Bean

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/CommandConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/CommandConfig.java
@@ -75,7 +75,7 @@ public class CommandConfig
 		SnapshotGenerator snapshotGenerator = new SnapshotGeneratorImpl(fhirConfig.fhirContext(), validationSupport);
 
 		TransactionEventHandler transactionEventHandler = new TransactionEventHandler(eventConfig.eventManager(),
-				validationSupport instanceof EventHandler ? (EventHandler) validationSupport : null);
+				validationSupport instanceof EventHandler h ? h : null);
 
 		return new TransactionResources(validationHelper, snapshotGenerator, transactionEventHandler);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/ValidationConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/ValidationConfig.java
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import dev.dsf.fhir.dao.command.ValidationHelper;
@@ -45,7 +44,7 @@ public class ValidationConfig
 
 	private ValidationSupportChain validationSupportChain(IValidationSupport dbSupport)
 	{
-		DefaultProfileValidationSupport dpvs = new DefaultProfileValidationSupport(FhirContext.forR4());
+		DefaultProfileValidationSupport dpvs = new DefaultProfileValidationSupport(fhirConfig.fhirContext());
 		dpvs.fetchCodeSystem(""); // FIXME HAPI bug workaround, to initialize
 		dpvs.fetchAllStructureDefinitions(); // FIXME HAPI bug workaround, to initialize
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/subscription/WebSocketSubscriptionManagerImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/subscription/WebSocketSubscriptionManagerImpl.java
@@ -186,7 +186,8 @@ public class WebSocketSubscriptionManagerImpl
 		}
 		catch (SQLException e)
 		{
-			logger.error("Error while accessing DB", e);
+			logger.debug("Error while accessing DB", e);
+			logger.error("Error while accessing DB: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 	}
 
@@ -350,7 +351,10 @@ public class WebSocketSubscriptionManagerImpl
 		}
 		catch (Exception e)
 		{
-			logger.warn("Error while sending event to remote with session id {}", sessionAndRemote.sessionId);
+			logger.debug("Error while sending event to remote with session id {}: {} - {}", sessionAndRemote.sessionId,
+					e);
+			logger.warn("Error while sending event to remote with session id {}: {} - {}", sessionAndRemote.sessionId,
+					e.getClass().getName(), e.getMessage());
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
@@ -422,7 +422,9 @@ public abstract class AbstractResourceServiceImpl<D extends ResourceDao<R>, R ex
 		}
 		catch (DateTimeParseException e)
 		{
-			logger.warn("Not a RFC-1123 date", e);
+			logger.debug("Not a RFC-1123 date", e);
+			logger.warn("Not a RFC-1123 date: {} - {}", e.getClass().getName(), e.getMessage());
+
 			return Optional.empty();
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/AbstractResourceServiceImpl.java
@@ -11,7 +11,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -25,20 +24,9 @@ import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.CanonicalType;
-import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
-import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
-import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
-import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.Type;
-import org.hl7.fhir.r4.model.UriType;
-import org.hl7.fhir.r4.model.UrlType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -47,9 +35,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import ca.uhn.fhir.rest.api.Constants;
-import ca.uhn.fhir.validation.ResultSeverityEnum;
-import ca.uhn.fhir.validation.SingleValidationMessage;
-import ca.uhn.fhir.validation.ValidationResult;
 import dev.dsf.fhir.authorization.AuthorizationRule;
 import dev.dsf.fhir.authorization.AuthorizationRuleProvider;
 import dev.dsf.fhir.dao.ResourceDao;
@@ -706,169 +691,6 @@ public abstract class AbstractResourceServiceImpl<D extends ResourceDao<R>, R ex
 							include.getIdElement().getValue());
 					return false;
 				});
-	}
-
-	private Optional<Resource> getResource(Parameters parameters, String parameterName)
-	{
-		return parameters.getParameter().stream().filter(p -> parameterName.equals(p.getName())).findFirst()
-				.map(ParametersParameterComponent::getResource);
-	}
-
-	private OperationOutcome createValidationOutcomeError(List<SingleValidationMessage> messages)
-	{
-		OperationOutcome outcome = new OperationOutcome();
-		List<OperationOutcomeIssueComponent> issues = messages.stream().map(vm -> new OperationOutcomeIssueComponent()
-				.setSeverity(toSeverity(vm.getSeverity())).setCode(IssueType.STRUCTURE).setDiagnostics(vm.getMessage()))
-				.collect(Collectors.toList());
-		outcome.setIssue(issues);
-		return outcome;
-	}
-
-	private IssueSeverity toSeverity(ResultSeverityEnum resultSeverity)
-	{
-		switch (resultSeverity)
-		{
-			case ERROR:
-				return IssueSeverity.ERROR;
-			case FATAL:
-				return IssueSeverity.FATAL;
-			case INFORMATION:
-				return IssueSeverity.INFORMATION;
-			case WARNING:
-				return IssueSeverity.WARNING;
-			default:
-				return IssueSeverity.NULL;
-		}
-	}
-
-	private OperationOutcome createValidationOutcomeOk(List<SingleValidationMessage> messages, List<String> profiles)
-	{
-		OperationOutcome outcome = new OperationOutcome();
-
-		List<OperationOutcomeIssueComponent> issues = messages.stream().map(vm -> new OperationOutcomeIssueComponent()
-				.setSeverity(toSeverity(vm.getSeverity())).setCode(IssueType.STRUCTURE).setDiagnostics(vm.getMessage()))
-				.collect(Collectors.toList());
-		outcome.setIssue(issues);
-
-		OperationOutcomeIssueComponent ok = new OperationOutcomeIssueComponent().setSeverity(IssueSeverity.INFORMATION)
-				.setCode(IssueType.INFORMATIONAL)
-				.setDiagnostics("Resource validated" + (profiles.isEmpty() ? ""
-						: " with profile" + (profiles.size() > 1 ? "s " : " ")
-								+ profiles.stream().collect(Collectors.joining(", "))));
-		outcome.addIssue(ok);
-
-		return outcome;
-	}
-
-	@Override
-	public Response postValidateNew(String validate, Parameters parameters, UriInfo uri, HttpHeaders headers)
-	{
-		Optional<Resource> resource = getResource(parameters, "resource");
-		if (resource.isEmpty())
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome, hint post with id url?
-
-		Type mode = parameters.getParameter("mode");
-		if (!(mode instanceof CodeType))
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-
-		Type profile = parameters.getParameter("profile");
-		if (!(profile instanceof UriType))
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-
-		// TODO handle mode and profile parameters
-
-		// ValidationResult validationResult = validator.validate(resource.get());
-
-		// TODO create return values
-
-		return Response.ok().build();
-	}
-
-	@Override
-	public Response getValidateNew(String validate, UriInfo uri, HttpHeaders headers)
-	{
-		// MultivaluedMap<String, String> queryParameters = uri.getQueryParameters();
-		//
-		// String mode = queryParameters.getFirst("mode");
-		// String profile = queryParameters.getFirst("profile");
-
-		// mode = create
-
-		// TODO Auto-generated method stub
-		return Response.ok().build();
-	}
-
-	@Override
-	public Response postValidateExisting(String validate, String id, Parameters parameters, UriInfo uri,
-			HttpHeaders headers)
-	{
-		if (getResource(parameters, "resource").isPresent())
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-
-		Type mode = parameters.getParameter("mode");
-		if (!(mode instanceof CodeType) || !(mode instanceof StringType))
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-		if (!"profile".equals(((StringType) mode).getValue()))
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-
-		Type profile = parameters.getParameter("profile");
-		if (!(profile instanceof UriType) || !(mode instanceof UrlType) || !(mode instanceof CanonicalType))
-			return Response.status(Status.BAD_REQUEST).build(); // TODO return OperationOutcome
-
-		UriType profileUri = (UriType) profile;
-
-		Optional<R> read = exceptionHandler.handleSqlAndResourceDeletedException(serverBase, resourceTypeName,
-				() -> dao.read(parameterConverter.toUuid(resourceTypeName, id)));
-
-		R resource = read.get();
-		resource.getMeta().setProfile(Collections.singletonList(new CanonicalType(profileUri.getValue())));
-
-		ValidationResult result = validator.validate(resource);
-
-		if (result.isSuccessful())
-			return responseGenerator.response(Status.OK,
-					createValidationOutcomeOk(result.getMessages(), Collections.singletonList(profileUri.getValue())),
-					parameterConverter.getMediaTypeThrowIfNotSupported(uri, headers)).build();
-		else
-			return responseGenerator.response(Status.OK, createValidationOutcomeError(result.getMessages()),
-					parameterConverter.getMediaTypeThrowIfNotSupported(uri, headers)).build();
-	}
-
-	@Override
-	public Response getValidateExisting(String validate, String id, UriInfo uri, HttpHeaders headers)
-	{
-		MultivaluedMap<String, String> queryParameters = uri.getQueryParameters();
-
-		String mode = queryParameters.getFirst("mode");
-		if (mode == null)
-			mode = "profile";
-		String profile = queryParameters.getFirst("profile");
-
-		if ("profile".equals(mode))
-		{
-			Optional<R> read = exceptionHandler.handleSqlAndResourceDeletedException(serverBase, resourceTypeName,
-					() -> dao.read(parameterConverter.toUuid(resourceTypeName, id)));
-
-			R resource = read.get();
-			if (profile != null)
-				resource.getMeta().setProfile(Collections.singletonList(new CanonicalType(profile)));
-
-			ValidationResult result = validator.validate(resource);
-
-			if (result.isSuccessful())
-				return responseGenerator.response(Status.OK,
-						createValidationOutcomeOk(result.getMessages(),
-								resource.getMeta().getProfile().stream().map(t -> t.getValue())
-										.collect(Collectors.toList())),
-						parameterConverter.getMediaTypeThrowIfNotSupported(uri, headers)).build();
-			else
-				return responseGenerator.response(Status.OK, createValidationOutcomeError(result.getMessages()),
-						parameterConverter.getMediaTypeThrowIfNotSupported(uri, headers)).build();
-		}
-		else if ("delete".equals(mode))
-			return Response.status(Status.METHOD_NOT_ALLOWED).build(); // TODO mode = delete
-		else
-			return Response.status(Status.METHOD_NOT_ALLOWED).build(); // TODO return OperationOutcome
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/BinaryServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/BinaryServiceImpl.java
@@ -56,7 +56,7 @@ public class BinaryServiceImpl extends AbstractResourceServiceImpl<BinaryDao, Bi
 		if (uri.getQueryParameters().containsKey(Constants.PARAM_FORMAT))
 			return super.getMediaTypeForRead(uri, headers);
 		else
-			return getMediaType(uri, headers);
+			return getMediaType(headers);
 	}
 
 	@Override
@@ -65,10 +65,10 @@ public class BinaryServiceImpl extends AbstractResourceServiceImpl<BinaryDao, Bi
 		if (uri.getQueryParameters().containsKey(Constants.PARAM_FORMAT))
 			return super.getMediaTypeForVRead(uri, headers);
 		else
-			return getMediaType(uri, headers);
+			return getMediaType(headers);
 	}
 
-	private MediaType getMediaType(UriInfo uri, HttpHeaders headers)
+	private MediaType getMediaType(HttpHeaders headers)
 	{
 		List<MediaType> types = headers.getAcceptableMediaTypes();
 		return types == null ? null : types.get(0);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ConformanceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ConformanceServiceImpl.java
@@ -402,7 +402,6 @@ public class ConformanceServiceImpl extends AbstractBasicService implements Conf
 
 		var standardSortableSearchParameters = Arrays.asList(ResourceId.class, ResourceLastUpdated.class,
 				ResourceProfile.class);
-		var standardOperations = Arrays.asList(createValidateOperation());
 
 		Map<String, List<CanonicalType>> profileUrlsByResource = validationSupport.fetchAllStructureDefinitions()
 				.stream().filter(r -> r instanceof StructureDefinition).map(r -> (StructureDefinition) r)
@@ -479,7 +478,6 @@ public class ConformanceServiceImpl extends AbstractBasicService implements Conf
 			r.getSearchParam().sort(Comparator.comparing(CapabilityStatementRestResourceSearchParamComponent::getName));
 
 			operations.getOrDefault(resource, Collections.emptyList()).forEach(r::addOperation);
-			standardOperations.forEach(r::addOperation);
 
 			r.setSupportedProfile(
 					profileUrlsByResource.getOrDefault(resourceDefAnnotation.name(), Collections.emptyList()));
@@ -514,12 +512,6 @@ public class ConformanceServiceImpl extends AbstractBasicService implements Conf
 		return Arrays.stream(def.targetResourceTypes()).map(target -> target.getAnnotation(ResourceDef.class).name())
 				.map(target -> def.resourceType().getAnnotation(ResourceDef.class).name() + ":" + def.parameterName()
 						+ ":" + target);
-	}
-
-	private CapabilityStatementRestResourceOperationComponent createValidateOperation()
-	{
-		return createOperation("validate", "http://hl7.org/fhir/OperationDefinition/Resource-validate",
-				"The validate operation checks whether the attached content would be acceptable either generally, as a create, an update or as a delete to an existing resource. The action the server takes depends on the mode parameter");
 	}
 
 	private CapabilityStatementRestResourceSearchParamComponent createSortParameter(

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ConformanceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ConformanceServiceImpl.java
@@ -187,7 +187,7 @@ public class ConformanceServiceImpl extends AbstractBasicService implements Conf
 		final StructureDefinition structureDefinition;
 		final String url;
 
-		public StructureDefinitionDistinctByUrl(StructureDefinition structureDefinition)
+		StructureDefinitionDistinctByUrl(StructureDefinition structureDefinition)
 		{
 			this.structureDefinition = structureDefinition;
 			this.url = structureDefinition.getUrl();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
@@ -123,8 +123,10 @@ public class StructureDefinitionServiceImpl extends
 				}
 				catch (Exception e)
 				{
-					logger.warn("Error while generating snapshot for StructureDefinition with id "
-							+ postResource.getIdElement().getIdPart(), e);
+					logger.warn("Error while generating snapshot for StructureDefinition with id {}: {} - {}",
+							postResource.getIdElement().getIdPart(), e.getClass().getName(), e.getMessage());
+					logger.debug("Error while generating snapshot for StructureDefinition with id {}",
+							postResource.getIdElement().getIdPart(), e);
 				}
 			}
 		};
@@ -154,8 +156,10 @@ public class StructureDefinitionServiceImpl extends
 				}
 				catch (Exception e)
 				{
-					logger.warn("Error while generating snapshot for StructureDefinition with id "
-							+ postResource.getIdElement().getIdPart(), e);
+					logger.warn("Error while generating snapshot for StructureDefinition with id {}: {} - {}",
+							postResource.getIdElement().getIdPart(), e.getClass().getName(), e.getMessage());
+					logger.debug("Error while generating snapshot for StructureDefinition with id {}",
+							postResource.getIdElement().getIdPart(), e);
 				}
 			}
 		};

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
@@ -123,10 +123,10 @@ public class StructureDefinitionServiceImpl extends
 				}
 				catch (Exception e)
 				{
-					logger.warn("Error while generating snapshot for StructureDefinition with id {}: {} - {}",
-							postResource.getIdElement().getIdPart(), e.getClass().getName(), e.getMessage());
 					logger.debug("Error while generating snapshot for StructureDefinition with id {}",
 							postResource.getIdElement().getIdPart(), e);
+					logger.warn("Error while generating snapshot for StructureDefinition with id {}: {} - {}",
+							postResource.getIdElement().getIdPart(), e.getClass().getName(), e.getMessage());
 				}
 			}
 		};
@@ -156,10 +156,10 @@ public class StructureDefinitionServiceImpl extends
 				}
 				catch (Exception e)
 				{
-					logger.warn("Error while generating snapshot for StructureDefinition with id {}: {} - {}",
-							postResource.getIdElement().getIdPart(), e.getClass().getName(), e.getMessage());
 					logger.debug("Error while generating snapshot for StructureDefinition with id {}",
 							postResource.getIdElement().getIdPart(), e);
+					logger.warn("Error while generating snapshot for StructureDefinition with id {}: {} - {}",
+							postResource.getIdElement().getIdPart(), e.getClass().getName(), e.getMessage());
 				}
 			}
 		};

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/jaxrs/AbstractResourceServiceJaxrs.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/jaxrs/AbstractResourceServiceJaxrs.java
@@ -1,6 +1,5 @@
 package dev.dsf.fhir.webservice.jaxrs;
 
-import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,66 +156,6 @@ public abstract class AbstractResourceServiceJaxrs<R extends Resource, S extends
 		logger.trace("GET {}", uri.getRequestUri().toString());
 
 		return delegate.search(uri, headers);
-	}
-
-	@POST
-	@Path("/{validate : [$]validate(/)?}")
-	@Consumes({ Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML, Constants.CT_FHIR_JSON,
-			Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON })
-	@Produces({ Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML, Constants.CT_FHIR_JSON,
-			Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, MediaType.TEXT_HTML })
-	@Override
-	public Response postValidateNew(@PathParam("validate") String validate, Parameters parameters, @Context UriInfo uri,
-			@Context HttpHeaders headers)
-	{
-		logger.trace("POST {}", uri.getRequestUri().toString());
-
-		return delegate.postValidateNew(validate, parameters, uri, headers);
-	}
-
-	@GET
-	@Path("/{validate : [$]validate(/)?}")
-	@Consumes({ Constants.CT_FHIR_JSON, Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, Constants.CT_FHIR_XML,
-			Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML })
-	@Produces({ Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML, Constants.CT_FHIR_JSON,
-			Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, MediaType.TEXT_HTML })
-	@Override
-	public Response getValidateNew(@PathParam("validate") String validate, @Context UriInfo uri,
-			@Context HttpHeaders headers)
-	{
-		logger.trace("GET {}", uri.getRequestUri().toString());
-
-		return delegate.getValidateNew(validate, uri, headers);
-	}
-
-	@POST
-	@Path("/{id}/{validate : [$]validate(/)?}")
-	@Consumes({ Constants.CT_FHIR_JSON, Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, Constants.CT_FHIR_XML,
-			Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML })
-	@Produces({ Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML, Constants.CT_FHIR_JSON,
-			Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, MediaType.TEXT_HTML })
-	@Override
-	public Response postValidateExisting(@PathParam("validate") String validatePath, @PathParam("id") String id,
-			Parameters parameters, @Context UriInfo uri, @Context HttpHeaders headers)
-	{
-		logger.trace("POST {}", uri.getRequestUri().toString());
-
-		return delegate.postValidateExisting(validatePath, id, parameters, uri, headers);
-	}
-
-	@GET
-	@Path("/{id}/{validate : [$]validate(/)?}")
-	@Consumes({ Constants.CT_FHIR_JSON, Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, Constants.CT_FHIR_XML,
-			Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML })
-	@Produces({ Constants.CT_FHIR_XML, Constants.CT_FHIR_XML_NEW, MediaType.APPLICATION_XML, Constants.CT_FHIR_JSON,
-			Constants.CT_FHIR_JSON_NEW, MediaType.APPLICATION_JSON, MediaType.TEXT_HTML })
-	@Override
-	public Response getValidateExisting(@PathParam("validate") String validatePath, @PathParam("id") String id,
-			@Context UriInfo uri, @Context HttpHeaders headers)
-	{
-		logger.trace("GET {}", uri.getRequestUri().toString());
-
-		return delegate.getValidateExisting(validatePath, id, uri, headers);
 	}
 
 	@POST

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/jaxrs/AbstractServiceJaxrs.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/jaxrs/AbstractServiceJaxrs.java
@@ -30,8 +30,8 @@ public abstract class AbstractServiceJaxrs<S extends BasicService> extends Abstr
 		Principal principal = httpRequest.getUserPrincipal();
 		if (principal != null)
 		{
-			if (principal instanceof Identity)
-				return (Identity) principal;
+			if (principal instanceof Identity identity)
+				return identity;
 			else
 			{
 				logger.warn("Unknown current user principal of type {}", principal.getClass().getName());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/jaxrs/BinaryServiceJaxrs.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/jaxrs/BinaryServiceJaxrs.java
@@ -152,9 +152,8 @@ public class BinaryServiceJaxrs extends AbstractResourceServiceJaxrs<Binary, Bin
 	{
 		Response read = super.read(id, uri, headers);
 
-		if (read.getEntity() instanceof Binary && !isValidFhirRequest(uri, headers))
+		if (read.getEntity() instanceof Binary binary && !isValidFhirRequest(uri, headers))
 		{
-			Binary binary = (Binary) read.getEntity();
 			if (mediaTypeMatches(headers, binary))
 				return toStream(binary);
 			else
@@ -206,9 +205,8 @@ public class BinaryServiceJaxrs extends AbstractResourceServiceJaxrs<Binary, Bin
 	{
 		Response read = super.vread(id, version, uri, headers);
 
-		if (read.getEntity() instanceof Binary && !isValidFhirRequest(uri, headers))
+		if (read.getEntity() instanceof Binary binary && !isValidFhirRequest(uri, headers))
 		{
-			Binary binary = (Binary) read.getEntity();
 			if (mediaTypeMatches(headers, binary))
 				return toStream(binary);
 			else

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -171,7 +171,8 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 					logger.warn("Create returned with entity of type {}", created.getEntity().getClass().getName());
 				else if (!created.hasEntity()
 						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
-					logger.warn("Create returned with status {}, but no entity", created.getStatus());
+					logger.warn("Create returned with status {} {}, but no entity",
+							created.getStatusInfo().getStatusCode(), created.getStatusInfo().getReasonPhrase());
 
 				return created;
 			});
@@ -263,9 +264,10 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		else
 		{
 			audit.info("Read of {} for identity '{}' returned without entity, status {} {}", resourceTypeName,
-					getCurrentIdentity().getName(), read.getStatus());
+					getCurrentIdentity().getName(), read.getStatusInfo().getStatusCode(),
+					read.getStatusInfo().getReasonPhrase());
 
-			logger.info("Returning with status {}, but no entity", read.getStatusInfo().getStatusCode(),
+			logger.info("Returning with status {} {}, but no entity", read.getStatusInfo().getStatusCode(),
 					read.getStatusInfo().getReasonPhrase());
 			return read;
 		}
@@ -318,7 +320,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 					getCurrentIdentity().getName(), read.getStatusInfo().getStatusCode(),
 					read.getStatusInfo().getReasonPhrase());
 
-			logger.info("Returning with OperationOutcome, status {}", read.getStatusInfo().getStatusCode(),
+			logger.info("Returning with OperationOutcome, status {} {}", read.getStatusInfo().getStatusCode(),
 					read.getStatusInfo().getReasonPhrase());
 			return read;
 		}
@@ -356,9 +358,9 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 			audit.info("History of {} allowed for identity '{}', reason: {}", resourceTypeName,
 					getCurrentIdentity().getName(), reasonHistoryAllowed.get());
 			return logResultStatus(() -> delegate.history(uri, headers),
-					status -> audit.info("History of {} for identity '{}' successful: {}", resourceTypeName,
+					status -> audit.info("History of {} for identity '{}' successful: {} {}", resourceTypeName,
 							getCurrentIdentity().getName(), status.getStatusCode(), status.getReasonPhrase()),
-					status -> audit.info("History of {} for identity '{}' failed: {}", resourceTypeName,
+					status -> audit.info("History of {} for identity '{}' failed: {} {}", resourceTypeName,
 							getCurrentIdentity().getName(), status.getStatusCode(), status.getReasonPhrase()));
 		}
 	}
@@ -379,9 +381,9 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 			audit.info("History of {} allowed for identity '{}', reason: {}", resourceTypeName,
 					getCurrentIdentity().getName(), reasonHistoryAllowed.get());
 			return logResultStatus(() -> delegate.history(id, uri, headers),
-					status -> audit.info("History of {} for identity '{}' successful: {}", resourceTypeName,
+					status -> audit.info("History of {} for identity '{}' successful: {} {}", resourceTypeName,
 							getCurrentIdentity().getName(), status.getStatusCode(), status.getReasonPhrase()),
-					status -> audit.info("History of {} for identity '{}' failed: {}", resourceTypeName,
+					status -> audit.info("History of {} for identity '{}' failed: {} {}", resourceTypeName,
 							getCurrentIdentity().getName(), status.getStatusCode(), status.getReasonPhrase()));
 		}
 	}
@@ -441,7 +443,8 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 					logger.warn("Update returned with entity of type {}", updated.getEntity().getClass().getName());
 				else if (!updated.hasEntity()
 						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
-					logger.warn("Update returned with status {}, but no entity", updated.getStatus());
+					logger.warn("Update returned with status {} {}, but no entity",
+							updated.getStatusInfo().getStatusCode(), updated.getStatusInfo().getReasonPhrase());
 
 				return updated;
 			});
@@ -596,8 +599,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		}
 		else
 		{
-			audit.info("{} to delete not found for user '{}'", resourceTypeName, getCurrentIdentity().getName(),
-					getCurrentIdentity().getName());
+			audit.info("{} to delete not found for user '{}'", resourceTypeName, getCurrentIdentity().getName());
 			return responseGenerator.notFound(id, resourceTypeName);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -496,7 +496,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 							|| serverBase.equals(resource.getIdElement().getBaseUrl()))
 					&& (!resource.getIdElement().hasResourceType()
 							|| resourceTypeName.equals(resource.getIdElement().getResourceType()))
-					&& (dbResourceId.getIdPart().equals(resource.getIdElement().getIdPart())))
+					&& dbResourceId.getIdPart().equals(resource.getIdElement().getIdPart()))
 			{
 				// more security checks and audit log in update method
 				return update(resource.getIdElement().getIdPart(), resource, uri, headers, resource);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -690,39 +689,6 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 					status -> audit.info("Search of {} for identity '{}' failed, status: {} {}", resourceTypeName,
 							getCurrentIdentity().getName(), status.getStatusCode(), status.getReasonPhrase()));
 		}
-	}
-
-	@Override
-	public Response postValidateNew(String validate, Parameters parameters, UriInfo uri, HttpHeaders headers)
-	{
-		logCurrentIdentity();
-
-		return delegate.postValidateNew(validate, parameters, uri, headers);
-	}
-
-	@Override
-	public Response getValidateNew(String validate, UriInfo uri, HttpHeaders headers)
-	{
-		logCurrentIdentity();
-
-		return delegate.getValidateNew(validate, uri, headers);
-	}
-
-	@Override
-	public Response postValidateExisting(String validate, String id, Parameters parameters, UriInfo uri,
-			HttpHeaders headers)
-	{
-		logCurrentIdentity();
-
-		return delegate.postValidateExisting(validate, id, parameters, uri, headers);
-	}
-
-	@Override
-	public Response getValidateExisting(String validate, String id, UriInfo uri, HttpHeaders headers)
-	{
-		logCurrentIdentity();
-
-		return delegate.getValidateExisting(validate, id, uri, headers);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -787,10 +787,9 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		}
 		catch (Exception e)
 		{
-			StatusType status = e instanceof WebApplicationException
-					&& ((WebApplicationException) e).getResponse() != null
-							? ((WebApplicationException) e).getResponse().getStatusInfo()
-							: Status.INTERNAL_SERVER_ERROR;
+			StatusType status = e instanceof WebApplicationException w && w.getResponse() != null
+					? w.getResponse().getStatusInfo()
+					: Status.INTERNAL_SERVER_ERROR;
 
 			logErrorForStatusCode.accept(status);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractServiceSecure.java
@@ -59,11 +59,10 @@ public abstract class AbstractServiceSecure<S extends BasicService> extends Abst
 			logger.debug("Current organization identity '{}', dsf-roles '{}'", identity.getName(),
 					identity.getDsfRoles());
 		}
-		else if (identity instanceof PractitionerIdentity)
+		else if (identity instanceof PractitionerIdentity practitioner)
 		{
-			PractitionerIdentity practitionerIdentity = (PractitionerIdentity) identity;
 			logger.debug("Current practitioner identity '{}', dsf-roles '{}', practitioner-roles '{}'",
-					identity.getName(), identity.getDsfRoles(), practitionerIdentity.getPractionerRoles().stream()
+					identity.getName(), identity.getDsfRoles(), practitioner.getPractionerRoles().stream()
 							.map(c -> c.getSystem() + "|" + c.getCode()).collect(Collectors.joining(", ", "[", "]")));
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/RootServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/RootServiceSecure.java
@@ -19,7 +19,7 @@ import jakarta.ws.rs.core.UriInfo;
 
 public class RootServiceSecure extends AbstractServiceSecure<RootService> implements RootService
 {
-	private static final Logger logger = LoggerFactory.getLogger(AbstractResourceServiceSecure.class);
+	private static final Logger logger = LoggerFactory.getLogger(RootServiceSecure.class);
 
 	private final AuthorizationRule<Resource> authorizationRule;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/specification/BasicResourceService.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/specification/BasicResourceService.java
@@ -1,6 +1,5 @@
 package dev.dsf.fhir.webservice.specification;
 
-import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.webservice.base.BasicService;
@@ -125,15 +124,6 @@ public interface BasicResourceService<R extends Resource> extends BasicService
 	 *         <a href="https://www.hl7.org/fhir/http.html#search">https://www.hl7.org/fhir/http.html#search</a>
 	 */
 	Response search(UriInfo uri, HttpHeaders headers);
-
-	Response postValidateNew(String validatePath, Parameters parameters, UriInfo uri, HttpHeaders headers);
-
-	Response getValidateNew(String validatePath, UriInfo uri, HttpHeaders headers);
-
-	Response postValidateExisting(String validatePath, String id, Parameters parameters, UriInfo uri,
-			HttpHeaders headers);
-
-	Response getValidateExisting(String validatePath, String id, UriInfo uri, HttpHeaders headers);
 
 	Response deletePermanently(String deletePath, String id, UriInfo uri, HttpHeaders headers);
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/websocket/ServerEndpoint.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/websocket/ServerEndpoint.java
@@ -67,9 +67,9 @@ public class ServerEndpoint extends Endpoint implements InitializingBean, Dispos
 			}
 			catch (IOException e)
 			{
+				logger.debug("Error while closing websocket, session {}", session.getId(), e);
 				logger.warn("Error while closing websocket, session {}: {} - {}", session.getId(),
 						e.getClass().getName(), e.getMessage());
-				logger.debug("Error while closing websocket, session {}", session.getId(), e);
 			}
 
 			return;
@@ -129,9 +129,9 @@ public class ServerEndpoint extends Endpoint implements InitializingBean, Dispos
 		}
 		catch (IllegalArgumentException | IOException e)
 		{
+			logger.debug("Error while sending ping frame, session {}", session.getId(), e);
 			logger.warn("Error while sending ping frame, session {}: {} - {}", session.getId(), e.getClass().getName(),
 					e.getMessage());
-			logger.debug("Error while sending ping frame, session {}", session.getId(), e);
 		}
 	}
 
@@ -154,9 +154,9 @@ public class ServerEndpoint extends Endpoint implements InitializingBean, Dispos
 			logger.info("Websocket closed with error, session {}: unknown error", session.getId());
 		else
 		{
+			logger.debug("Websocket closed with error, session {}", session.getId(), throwable);
 			logger.info("Websocket closed with error, session {}: {} - {}", session.getId(),
 					throwable.getClass().getName(), getMessages(throwable));
-			logger.debug("Websocket closed with error, session {}", session.getId(), throwable);
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/AbstractIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/AbstractIntegrationTest.java
@@ -262,7 +262,7 @@ public abstract class AbstractIntegrationTest extends AbstractDbTest
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while reading bundle from " + bundleTemplateFile.toString(), e);
+			logger.error("Error while reading bundle from {}", bundleTemplateFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -276,7 +276,7 @@ public abstract class AbstractIntegrationTest extends AbstractDbTest
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while writing bundle to " + bundleFile.toString(), e);
+			logger.error("Error while writing bundle to {}", bundleFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/AbstractIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/AbstractIntegrationTest.java
@@ -246,7 +246,7 @@ public abstract class AbstractIntegrationTest extends AbstractDbTest
 		};
 
 		JettyServer server = new JettyServer(apiConnector, statusConnector, "dsf-fhir-server", CONTEXT_PATH,
-				servletContainerInitializers, initParameters, caCertificate, securityHandlerConfigurer);
+				servletContainerInitializers, initParameters, securityHandlerConfigurer);
 
 		server.start();
 

--- a/dsf-fhir/dsf-fhir-validation/src/main/java/dev/dsf/fhir/validation/SnapshotGenerator.java
+++ b/dsf-fhir/dsf-fhir-validation/src/main/java/dev/dsf/fhir/validation/SnapshotGenerator.java
@@ -9,7 +9,7 @@ import org.hl7.fhir.utilities.validation.ValidationMessage;
 
 public interface SnapshotGenerator
 {
-	public class SnapshotWithValidationMessages
+	class SnapshotWithValidationMessages
 	{
 		private final StructureDefinition snapshot;
 		private final List<ValidationMessage> messages = new ArrayList<>();

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
@@ -48,7 +48,8 @@ public abstract class AbstractFhirWebserviceClientJerseyWithRetry
 				{
 					if (tryNumber < nTimes || nTimes == RetryClient.RETRY_FOREVER)
 					{
-						logger.warn("Caught {}: {}; trying again in {} ms{}", e.getClass(), e.getMessage(), delayMillis,
+						logger.warn("Caught {} - {}; trying again in {} ms{}", e.getClass(), e.getMessage(),
+								delayMillis,
 								nTimes == RetryClient.RETRY_FOREVER ? " (retry " + (tryNumber + 1) + ")" : "");
 
 						try
@@ -61,7 +62,7 @@ public abstract class AbstractFhirWebserviceClientJerseyWithRetry
 					}
 					else
 					{
-						logger.warn("Caught {}: {}; not trying again", e.getClass(), e.getMessage(), delayMillis);
+						logger.warn("Caught {} - {}; not trying again", e.getClass(), e.getMessage());
 					}
 
 					if (caughtException != null)

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
@@ -79,9 +79,9 @@ public abstract class AbstractFhirWebserviceClientJerseyWithRetry
 
 	private boolean shouldRetry(RuntimeException e)
 	{
-		if (e instanceof WebApplicationException)
+		if (e instanceof WebApplicationException w)
 		{
-			return isRetryStatusCode((WebApplicationException) e);
+			return isRetryStatusCode(w);
 		}
 		else if (e instanceof ProcessingException)
 		{

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
@@ -98,13 +98,14 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 			OperationOutcome outcome = response.readEntity(OperationOutcome.class);
 			String message = toString(outcome);
 
-			logger.warn("OperationOutcome: {}", message);
+			logger.warn("Request failed, OperationOutcome: {}", message);
 			return new WebApplicationException(message, response.getStatus());
 		}
 		catch (ProcessingException e)
 		{
 			response.close();
-			logger.warn("{}: {}", e.getClass().getName(), e.getMessage());
+
+			logger.warn("Request failed: {} - {}", e.getClass().getName(), e.getMessage());
 			return new WebApplicationException(e, response.getStatus());
 		}
 	}

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/ClientEndpoint.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/ClientEndpoint.java
@@ -63,9 +63,9 @@ public class ClientEndpoint extends Endpoint
 					}
 					catch (Throwable e)
 					{
+						logger.debug("Error while handling message, session {}", session.getId(), e);
 						logger.error("Error while handling message, session {}: {} - {}", session.getId(),
 								e.getClass().getName(), e.getMessage());
-						logger.debug("Error while handling message, session {}", session.getId(), e);
 					}
 				}
 			}
@@ -94,9 +94,9 @@ public class ClientEndpoint extends Endpoint
 			logger.info("Websocket closed with error, session {}: unknown error", session.getId());
 		else
 		{
+			logger.debug("Websocket closed with error, session {}", session.getId(), throwable);
 			logger.warn("Websocket closed with error, session {}: {} - {}", session.getId(),
 					throwable.getClass().getName(), throwable.getMessage());
-			logger.debug("Websocket closed with error, session {}", session.getId(), throwable);
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
@@ -38,8 +38,15 @@ public class WebsocketClientTyrus implements WebsocketClient
 		@Override
 		public boolean onConnectFailure(Exception exception)
 		{
-			logger.warn("Websocket connection failed: {}", getMessages(exception));
-			logger.debug("onConnectFailure", exception);
+			if (exception == null)
+				logger.warn("Websocket connection failed: unknown error");
+			else
+			{
+				logger.warn("Websocket connection failed: {} - {}", exception.getClass().getName(),
+						getMessages(exception));
+				logger.debug("Websocket connection failed", exception);
+			}
+
 			return true;
 		}
 
@@ -69,7 +76,8 @@ public class WebsocketClientTyrus implements WebsocketClient
 		@Override
 		public boolean onDisconnect(CloseReason closeReason)
 		{
-			logger.debug("onDisconnect {}", closeReason.getReasonPhrase());
+			logger.debug("Websocket closed: {} - {}", closeReason.getCloseCode(), closeReason.getReasonPhrase());
+
 			return !closed;
 		}
 	};

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
@@ -172,7 +172,7 @@ public class WebsocketClientTyrus implements WebsocketClient
 
 		ClientEndpointConfig.Configurator configurator = new ClientEndpointConfig.Configurator()
 		{
-			public void beforeRequest(java.util.Map<String, java.util.List<String>> headers)
+			public void beforeRequest(Map<String, java.util.List<String>> headers)
 			{
 				headers.put(HttpHeaders.USER_AGENT, Collections.singletonList(userAgentValue));
 			}

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
@@ -151,16 +151,19 @@ public class WebsocketClientTyrus implements WebsocketClient
 		try
 		{
 			logger.debug("Connecting to websocket {} and waiting for connection", wsUri);
+
 			connection = manager.connectToServer(endpoint, config, wsUri);
 		}
 		catch (DeploymentException e)
 		{
-			logger.warn("Error while connecting to server", e);
+			logger.debug("Error while connecting to server", e);
+
 			throw new RuntimeException(e);
 		}
 		catch (IOException e)
 		{
-			logger.warn("Error while connecting to server", e);
+			logger.debug("Error while connecting to server", e);
+
 			throw new RuntimeException(e);
 		}
 	}
@@ -194,7 +197,8 @@ public class WebsocketClientTyrus implements WebsocketClient
 		}
 		catch (IOException e)
 		{
-			logger.warn("Error while closing websocket", e);
+			logger.debug("Error while closing websocket", e);
+			logger.warn("Error while closing websocket: {} - {}", e.getClass().getName(), e.getMessage());
 		}
 
 		manager.shutdown();

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
@@ -47,7 +47,7 @@ public class WebsocketClientTyrus implements WebsocketClient
 				logger.debug("Websocket connection failed", exception);
 			}
 
-			return true;
+			return !closed;
 		}
 
 		private String getMessages(Exception e)

--- a/dsf-tools/dsf-tools-build-info-reader/src/main/java/dev/dsf/tools/build/BuildInfoReaderImpl.java
+++ b/dsf-tools/dsf-tools-build-info-reader/src/main/java/dev/dsf/tools/build/BuildInfoReaderImpl.java
@@ -39,7 +39,9 @@ public class BuildInfoReaderImpl implements BuildInfoReader
 			}
 			catch (IOException e)
 			{
-				logger.warn("Error while reading version properties", e);
+				logger.debug("Error while reading version properties", e);
+				logger.warn("Error while reading version properties: {} - {}", e.getClass().getName(), e.getMessage());
+
 				throw new RuntimeException(e);
 			}
 		}

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleEntryFileVisitor.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleEntryFileVisitor.java
@@ -101,7 +101,7 @@ public class BundleEntryFileVisitor implements FileVisitor<Path>
 	@Override
 	public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException
 	{
-		logger.error("Error while reading file at " + file.toString(), exc);
+		logger.error("Error while reading file at {}", file.toString(), exc);
 		return FileVisitResult.TERMINATE;
 	}
 

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
@@ -202,6 +202,7 @@ public class BundleGenerator
 			if (e.getResource() == null)
 				return Integer.MIN_VALUE;
 			else
+			{
 				switch (e.getResource().getClass().getAnnotation(ResourceDef.class).name())
 				{
 					case "CodeSystem":
@@ -218,6 +219,7 @@ public class BundleGenerator
 					default:
 						return Integer.MAX_VALUE;
 				}
+			}
 		};
 	}
 

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
@@ -236,34 +236,18 @@ public class BundleGenerator
 	{
 		return (BundleEntryComponent e) ->
 		{
-
 			if (e.getResource() == null)
 				return "";
-			else if (e.getResource() instanceof CodeSystem)
-			{
-				CodeSystem cs = (CodeSystem) e.getResource();
-				return cs.getUrl() + "|" + cs.getVersion();
-			}
-			else if (e.getResource() instanceof NamingSystem)
-			{
-				NamingSystem ns = (NamingSystem) e.getResource();
-				return ns.getName();
-			}
-			else if (e.getResource() instanceof ValueSet)
-			{
-				ValueSet vs = (ValueSet) e.getResource();
-				return vs.getUrl() + "|" + vs.getVersion();
-			}
-			else if (e.getResource() instanceof StructureDefinition)
-			{
-				StructureDefinition sd = (StructureDefinition) e.getResource();
-				return sd.getUrl() + "|" + sd.getVersion();
-			}
-			else if (e.getResource() instanceof Subscription)
-			{
-				Subscription s = (Subscription) e.getResource();
+			else if (e.getResource() instanceof CodeSystem c)
+				return c.getUrl() + "|" + c.getVersion();
+			else if (e.getResource() instanceof NamingSystem n)
+				return n.getName();
+			else if (e.getResource() instanceof ValueSet v)
+				return v.getUrl() + "|" + v.getVersion();
+			else if (e.getResource() instanceof StructureDefinition s)
+				return s.getUrl() + "|" + s.getVersion();
+			else if (e.getResource() instanceof Subscription s)
 				return s.getReason();
-			}
 			else
 				return "";
 		};

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
@@ -304,7 +304,7 @@ public class BundleGenerator
 			Bundle bundle;
 			try
 			{
-				logger.info("Generating bundle at " + bundleGenerator.getBundleFilename() + " ...");
+				logger.info("Generating bundle at {} ...", bundleGenerator.getBundleFilename());
 				bundle = bundleGenerator.generateBundle();
 			}
 			catch (IOException e)
@@ -324,7 +324,7 @@ public class BundleGenerator
 			try
 			{
 				bundleGenerator.saveBundle(bundle);
-				logger.info("Bundle saved at " + bundleGenerator.getBundleFilename());
+				logger.info("Bundle saved at {}", bundleGenerator.getBundleFilename());
 			}
 			catch (IOException e)
 			{

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/ValidationSupportWithCustomResources.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/ValidationSupportWithCustomResources.java
@@ -29,27 +29,26 @@ public class ValidationSupportWithCustomResources implements IValidationSupport
 				.filter(r -> r instanceof StructureDefinition || r instanceof CodeSystem || r instanceof ValueSet)
 				.forEach(r ->
 				{
-					if (r instanceof StructureDefinition)
+					if (r instanceof StructureDefinition s)
 					{
-						StructureDefinition sd = (StructureDefinition) r;
+						structureDefinitionsByUrl.put(s.getUrl(), s);
 
-						structureDefinitionsByUrl.put(sd.getUrl(), sd);
-						if (sd.hasVersion())
-							structureDefinitionsByUrl.put(sd.getUrl() + "|" + sd.getVersion(), sd);
+						if (s.hasVersion())
+							structureDefinitionsByUrl.put(s.getUrl() + "|" + s.getVersion(), s);
 					}
-					else if (r instanceof CodeSystem)
+					else if (r instanceof CodeSystem c)
 					{
-						CodeSystem cs = (CodeSystem) r;
-						codeSystemsByUrl.put(cs.getUrl(), cs);
-						if (cs.hasVersion())
-							codeSystemsByUrl.put(cs.getUrl() + "|" + cs.getVersion(), cs);
+						codeSystemsByUrl.put(c.getUrl(), c);
+
+						if (c.hasVersion())
+							codeSystemsByUrl.put(c.getUrl() + "|" + c.getVersion(), c);
 					}
-					else if (r instanceof ValueSet)
+					else if (r instanceof ValueSet v)
 					{
-						ValueSet vs = (ValueSet) r;
-						valueSetsByUrl.put(vs.getUrl(), vs);
-						if (vs.hasVersion())
-							valueSetsByUrl.put(vs.getUrl() + "|" + vs.getVersion(), vs);
+						valueSetsByUrl.put(v.getUrl(), v);
+
+						if (v.hasVersion())
+							valueSetsByUrl.put(v.getUrl() + "|" + v.getVersion(), v);
 					}
 				});
 	}

--- a/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
+++ b/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
@@ -18,6 +18,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -54,27 +55,8 @@ public class DocumentationGenerator extends AbstractMojo
 	private static final String ENV_VARIABLE_PLACEHOLDER = "${env_variable}";
 	private static final String PROPERTY_NAME_PLACEHOLDER = " ${property_name}";
 
-	private static final class DocumentationEntry implements Comparable<DocumentationEntry>
+	private record DocumentationEntry(String propertyName, String value)
 	{
-		final String propertyName;
-		final String value;
-
-		DocumentationEntry(String propertyName, String value)
-		{
-			this.propertyName = propertyName;
-			this.value = value;
-		}
-
-		@Override
-		public int compareTo(DocumentationEntry o)
-		{
-			return propertyName.compareToIgnoreCase(o.propertyName);
-		}
-
-		String getValue()
-		{
-			return value;
-		}
 	}
 
 	@Parameter(defaultValue = "${project.build.directory}", readonly = true, required = true)
@@ -213,8 +195,9 @@ public class DocumentationGenerator extends AbstractMojo
 	private void writeFields(Collection<? extends Field> fields,
 			Function<Field, DocumentationEntry> documentationGenerator, Path file, String workingPackage)
 	{
-		Iterable<String> entries = fields.stream().map(documentationGenerator).sorted()
-				.map(DocumentationEntry::getValue)::iterator;
+		Iterable<String> entries = fields.stream().map(documentationGenerator)
+				.sorted(Comparator.comparing(DocumentationEntry::propertyName, String.CASE_INSENSITIVE_ORDER))
+				.map(DocumentationEntry::value)::iterator;
 		try
 		{
 			Files.write(file, entries, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
@@ -259,7 +242,7 @@ public class DocumentationGenerator extends AbstractMojo
 					: "";
 
 			return new DocumentationEntry(initialProperty,
-					String.format("### %s\n%s%s%s%s%s%s%s\n", environment, property, required, processes, description,
+					String.format("### %s%n%s%s%s%s%s%s%s%n", environment, property, required, processes, description,
 							recommendation, example, defaultValue).replace(ENV_VARIABLE_PLACEHOLDER, initialEnvironment)
 							.replace(PROPERTY_NAME_PLACEHOLDER, initialProperty));
 		};
@@ -293,7 +276,7 @@ public class DocumentationGenerator extends AbstractMojo
 					: "";
 
 			return new DocumentationEntry(initialProperty,
-					String.format("### %s\n%s%s%s%s%s%s\n", environment, property, required, description,
+					String.format("### %s%n%s%s%s%s%s%s%n", environment, property, required, description,
 							recommendation, example, defaultValue).replace(ENV_VARIABLE_PLACEHOLDER, initialEnvironment)
 							.replace(PROPERTY_NAME_PLACEHOLDER, initialProperty));
 		};
@@ -317,7 +300,7 @@ public class DocumentationGenerator extends AbstractMojo
 		if (title == null || title.isBlank() || value == null || value.isBlank())
 			return "";
 
-		return String.format("- **%s:** `%s`\n", title, value);
+		return String.format("- **%s:** `%s`%n", title, value);
 	}
 
 	private String getDocumentationString(String title, String value)
@@ -325,7 +308,7 @@ public class DocumentationGenerator extends AbstractMojo
 		if (title == null || title.isBlank() || value == null || value.isBlank())
 			return "";
 
-		return String.format("- **%s:** %s\n", title, value);
+		return String.format("- **%s:** %s%n", title, value);
 	}
 
 	private String getProcessNamesAsString(String[] documentationProcessNames, List<String> pluginProcessNames)

--- a/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
+++ b/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
@@ -253,7 +253,8 @@ public class DocumentationGenerator extends AbstractMojo
 			String recommendation = getDocumentationString("Recommendation", documentation.recommendation());
 			String example = getDocumentationStringMonospace("Example", documentation.example());
 
-			String defaultValue = (valueSplit.length > 1 && !"null".equals(valueSplit[1]))
+
+			String defaultValue = valueSplit.length > 1 && !"null".equals(valueSplit[1])
 					? getDocumentationStringMonospace("Default", valueSplit[1])
 					: "";
 
@@ -287,7 +288,7 @@ public class DocumentationGenerator extends AbstractMojo
 			String recommendation = getDocumentationString("Recommendation", documentation.recommendation());
 			String example = getDocumentationStringMonospace("Example", documentation.example());
 
-			String defaultValue = (valueSplit.length > 1 && !"null".equals(valueSplit[1]))
+			String defaultValue = valueSplit.length > 1 && !"null".equals(valueSplit[1])
 					? getDocumentationStringMonospace("Default", valueSplit[1])
 					: "";
 

--- a/dsf-tools/dsf-tools-proxy-test/src/main/java/dev/dsf/tools/proxy/ProxyTest.java
+++ b/dsf-tools/dsf-tools-proxy-test/src/main/java/dev/dsf/tools/proxy/ProxyTest.java
@@ -6,9 +6,13 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ProxyTest
+public final class ProxyTest
 {
 	private static final Logger logger = LoggerFactory.getLogger(ProxyTest.class);
+
+	private ProxyTest()
+	{
+	}
 
 	public static void main(String[] args)
 	{
@@ -22,7 +26,7 @@ public class ProxyTest
 					args.length > 2 ? args[2] : null, passwd);
 			client.testBaseUrl();
 
-			java.util.Arrays.fill(passwd, ' ');
+			Arrays.fill(passwd, ' ');
 		}
 		else
 			logger.info("null");

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,7 +54,7 @@ public class BundleGenerator
 	private void writeBundle(Path bundleFile, Bundle bundle)
 	{
 		try (OutputStream out = Files.newOutputStream(bundleFile);
-				OutputStreamWriter writer = new OutputStreamWriter(out))
+				OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8))
 		{
 			newXmlParser().encodeResourceToWriter(bundle, writer);
 		}

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
@@ -45,7 +45,7 @@ public class BundleGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while reading bundle from " + bundleTemplateFile.toString(), e);
+			logger.error("Error while reading bundle from {}", bundleTemplateFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -59,7 +59,7 @@ public class BundleGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while writing bundle to " + bundleFile.toString(), e);
+			logger.error("Error while writing bundle to {}", bundleFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
@@ -417,9 +417,8 @@ public class CertificateGenerator
 	{
 		logger.debug("Generating public-key from private-key [{}]", commonName);
 
-		if ("RSA".equals(privateKey.getAlgorithm()) && privateKey instanceof RSAPrivateCrtKey)
+		if ("RSA".equals(privateKey.getAlgorithm()) && privateKey instanceof RSAPrivateCrtKey rsaPrivateKey)
 		{
-			RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey) privateKey;
 			RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(rsaPrivateKey.getModulus(),
 					rsaPrivateKey.getPublicExponent());
 

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
@@ -67,7 +67,7 @@ public class CertificateGenerator
 
 	private static final BouncyCastleProvider PROVIDER = new BouncyCastleProvider();
 
-	private static enum CertificateType
+	private enum CertificateType
 	{
 		CLIENT, SERVER
 	}
@@ -81,7 +81,7 @@ public class CertificateGenerator
 
 		private final byte[] certificateSha512Thumbprint;
 
-		CertificateFiles(String commonName, KeyPair keyPair, Path keyPairPrivateKeyFile, X509Certificate certificate,
+		CertificateFiles(String commonName, KeyPair keyPair, X509Certificate certificate,
 				byte[] certificateSha512Thumbprint)
 		{
 			this.commonName = commonName;
@@ -266,16 +266,15 @@ public class CertificateGenerator
 				certificateType, keyPair, commonName, dnsNames);
 
 		Path certificatePemFile = createFolderIfNotExists(getCertPemPath(commonName));
-		X509Certificate certificate = signOrReadCertificate(certificatePemFile, certificateRequest,
-				keyPair.getPrivate(), commonName, certificateType);
+		X509Certificate certificate = signOrReadCertificate(certificatePemFile, certificateRequest, commonName,
+				certificateType);
 
-		return new CertificateFiles(commonName, keyPair, privateKeyFile, certificate,
+		return new CertificateFiles(commonName, keyPair, certificate,
 				calculateSha512CertificateThumbprint(certificate));
 	}
 
 	private X509Certificate signOrReadCertificate(Path certificateFile,
-			JcaPKCS10CertificationRequest certificateRequest, PrivateKey privateKey, String commonName,
-			CertificateType certificateType)
+			JcaPKCS10CertificationRequest certificateRequest, String commonName, CertificateType certificateType)
 	{
 		if (Files.isReadable(certificateFile))
 		{

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
@@ -177,7 +177,7 @@ public class CertificateGenerator
 		}
 		catch (IOException | OperatorCreationException e)
 		{
-			logger.error("Error while writing encrypted private-key to " + privateKeyFile.toString(), e);
+			logger.error("Error while writing encrypted private-key to {}", privateKeyFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -190,7 +190,7 @@ public class CertificateGenerator
 		}
 		catch (IOException | OperatorCreationException e)
 		{
-			logger.error("Error while writing not-encrypted private-key to " + privateKeyFile.toString(), e);
+			logger.error("Error while writing not-encrypted private-key to {}", privateKeyFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -203,7 +203,7 @@ public class CertificateGenerator
 		}
 		catch (CertificateEncodingException | IllegalStateException | IOException e)
 		{
-			logger.error("Error while writing certificate to " + certificateFile.toString(), e);
+			logger.error("Error while writing certificate to {}", certificateFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -216,7 +216,7 @@ public class CertificateGenerator
 		}
 		catch (IOException | PKCSException e)
 		{
-			logger.error("Error while reading private-key from " + privateKeyFile.toString(), e);
+			logger.error("Error while reading private-key from {}", privateKeyFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -229,7 +229,7 @@ public class CertificateGenerator
 		}
 		catch (CertificateException | IOException e)
 		{
-			logger.error("Error while reading certificate from " + certFile.toString(), e);
+			logger.error("Error while reading certificate from {}", certFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -251,7 +251,7 @@ public class CertificateGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while writing certificate thumbprints file to " + thumbprintsFile.toString(), e);
+			logger.error("Error while writing certificate thumbprints file to {}", thumbprintsFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -312,7 +312,7 @@ public class CertificateGenerator
 		catch (InvalidKeyException | NoSuchAlgorithmException | InvalidKeySpecException | OperatorCreationException
 				| CertificateException | IllegalStateException | IOException e)
 		{
-			logger.error("Error while signing " + certificateType.toString().toLowerCase() + " certificate", e);
+			logger.error("Error while signing {} certificate", certificateType.toString().toLowerCase(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -373,7 +373,7 @@ public class CertificateGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while reading certificate-request from " + certificateRequestFile.toString(), e);
+			logger.error("Error while reading certificate-request from {}", certificateRequestFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -386,7 +386,7 @@ public class CertificateGenerator
 		}
 		catch (NoSuchAlgorithmException | InvalidKeySpecException | IOException e)
 		{
-			logger.error("Error while reading certificate-request from " + certificateRequestFile.toString(), e);
+			logger.error("Error while reading certificate-request from {}", certificateRequestFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -460,7 +460,7 @@ public class CertificateGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while creating directories " + file.getParent().toString(), e);
+			logger.error("Error while creating directories {}", file.getParent().toString(), e);
 			throw new RuntimeException(e);
 		}
 
@@ -696,7 +696,7 @@ public class CertificateGenerator
 		}
 		catch (CertificateEncodingException | IllegalStateException | IOException e)
 		{
-			logger.error("Error while writing certificate to " + certificateFile.toString(), e);
+			logger.error("Error while writing certificate to {}", certificateFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -740,7 +740,7 @@ public class CertificateGenerator
 		}
 		catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e)
 		{
-			logger.error("Error while writing keystore file to " + file.toString(), e);
+			logger.error("Error while writing keystore file to {}", file.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/ConfigGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/ConfigGenerator.java
@@ -51,7 +51,7 @@ public class ConfigGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while reading properties from " + propertiesFile.toString(), e);
+			logger.error("Error while reading properties from {}", propertiesFile.toString(), e);
 			throw new RuntimeException(e);
 		}
 		return properties;
@@ -66,7 +66,7 @@ public class ConfigGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while writing properties to " + propertiesFiles.toString(), e);
+			logger.error("Error while writing properties to {}", propertiesFiles.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/ConfigGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/ConfigGenerator.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public class ConfigGenerator
 		{
 			// making sure entries are sorted when storing properties
 			@Override
-			public Set<java.util.Map.Entry<Object, Object>> entrySet()
+			public Set<Entry<Object, Object>> entrySet()
 			{
 				return Collections.synchronizedSet(
 						super.entrySet().stream().sorted(Comparator.comparing(e -> e.getKey().toString()))

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/EnvGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/EnvGenerator.java
@@ -106,7 +106,7 @@ public class EnvGenerator
 		}
 		catch (IOException e)
 		{
-			logger.error("Error while writing .env file to " + target.toString(), e);
+			logger.error("Error while writing .env file to {}", target.toString(), e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/TestDataGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/TestDataGenerator.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import de.rwh.utils.crypto.CertificateAuthority;
 import dev.dsf.tools.generator.CertificateGenerator.CertificateFiles;
 
-public class TestDataGenerator
+public final class TestDataGenerator
 {
 	private static final Logger logger = LoggerFactory.getLogger(TestDataGenerator.class);
 
@@ -21,6 +21,10 @@ public class TestDataGenerator
 	static
 	{
 		CertificateAuthority.registerBouncyCastleProvider();
+	}
+
+	private TestDataGenerator()
+	{
 	}
 
 	public static void main(String[] args)

--- a/pom.xml
+++ b/pom.xml
@@ -572,6 +572,26 @@
 					<artifactId>maven-enforcer-plugin</artifactId>
 					<version>3.4.1</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.12.1</version>
+				</plugin>
+				<plugin>
+					<groupId>com.github.spotbugs</groupId>
+					<artifactId>spotbugs-maven-plugin</artifactId>
+					<version>4.8.1.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-project-info-reports-plugin</artifactId>
+					<version>3.5.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-pmd-plugin</artifactId>
+					<version>3.21.2</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -683,6 +703,11 @@
 			<name>GitHub Packages</name>
 			<url>https://maven.pkg.github.com/datasharingframework/dsf</url>
 		</snapshotRepository>
+		<site>
+			<id>${project.artifactId}-site</id>
+			<!-- static non empty value to enable site:stage goal -->
+			<url>http://localhost</url>
+		</site>
 	</distributionManagement>
 
 	<profiles>
@@ -785,4 +810,30 @@
 			</build>
 		</profile>
 	</profiles>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<configuration>
+					<plugins>
+						<plugin>
+							<groupId>jp.skypencil.findbugs.slf4j</groupId>
+							<artifactId>bug-pattern</artifactId>
+							<version>1.5.0</version>
+						</plugin>
+					</plugins>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>


### PR DESCRIPTION
* Configures maven site and site:stage goals  
  Site reports enabled for pmd, cpd, spotbugs with slf4j bug patterns and javadoc.  
  Use `mvn site` to create independent reports per maven module. Run `mvn site site:stage` to create a combined (with working links) site report at `\target\staging`.
  closes #142
* Log message cleanup and SLF4J parameter vs. placeholder count fixes  
  fixes #137
* Codebase now uses `instanceof` pattern where possible
* Code cleanup: Removed implicit public, static, final modifiers; removed not needed method parameters or complete methods.
* Move date formatting code to new abstract base class  
  Switched from `java.text.SimpleDateFormat` to `java.time.format.DateTimeFormatter` since `SimpleDateFormat` is not thread safe.  
  `DateTimeFormatter` requires conversion from Date to `LocalDateTime`, but this is preferable to creating new `SimpleDateFormat` objects for every use.
* Changed websocket "on connect failure"  reconnect policy to "only if not closed". No need to try to reconnect, if the websocket client was commended do close during jvm shutdown.
* Modified `OperationOutcome` messages related to batch and transaction Bundle error handling to be more precise.
* Some minor changes: Record instead of inner class, switched \n to %n in String.format calls, added and used new convenience constructor, added missing not null check, output encoding explicitly set to UTF-8, switched from `Arrays.asList(...)` to `List.of(...) to create an un-modifiable list.
* New startup logging messages, improved websocket error log messages.
* Removed incomplete implemention of the `$validate` operation.