### PR TITLE
Code Cleanup, New "name" Query Parameters, OAuth in /metadata

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
@@ -153,11 +153,8 @@ public class SmtpMailService implements MailService, InitializingBean
 			super("SmtpMailService.Log4jAppender", ThresholdFilter.createFilter(null, null, null),
 					new Layout(debugLogLocation), false, null);
 
-			MailManagerFactory factory = (name, data) ->
+			MailManagerFactory factory = (name, data) -> new SmtpManager(name, session, message, data)
 			{
-				return new SmtpManager(name, session, message, data)
-				{
-				};
 			};
 			FactoryData data = new FactoryData(null, null, null, null, null, null, event -> subject, null, null, 0,
 					null, null, false, messageBufferSize, null, null);

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/AbstractProcessPlugin.java
@@ -803,23 +803,19 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 
 		// user tasks: task listeners
 		boolean userTasksTaskListenersOk = parent.getChildElementsByType(UserTask.class).stream()
-				.filter(Objects::nonNull).allMatch(t ->
-				{
-					return t.getChildElementsByType(ExtensionElements.class).stream().filter(Objects::nonNull)
-							.flatMap(e -> e.getChildElementsByType(CamundaTaskListener.class).stream())
-							.filter(Objects::nonNull).allMatch(l -> beanAvailable(process, t.getId(),
-									l.getCamundaClass(), TaskListener.class, applicationContext));
-				});
+				.filter(Objects::nonNull)
+				.allMatch(t -> t.getChildElementsByType(ExtensionElements.class).stream().filter(Objects::nonNull)
+						.flatMap(e -> e.getChildElementsByType(CamundaTaskListener.class).stream())
+						.filter(Objects::nonNull).allMatch(l -> beanAvailable(process, t.getId(), l.getCamundaClass(),
+								TaskListener.class, applicationContext)));
 
 		// all elements: execution listeners
 		boolean allElementsExecutionListenersOk = parent.getChildElementsByType(FlowNode.class).stream()
-				.filter(Objects::nonNull).allMatch(n ->
-				{
-					return n.getChildElementsByType(ExtensionElements.class).stream().filter(Objects::nonNull)
-							.flatMap(e -> e.getChildElementsByType(CamundaExecutionListener.class).stream())
-							.filter(Objects::nonNull).allMatch(l -> beanAvailable(process, n.getId(),
-									l.getCamundaClass(), ExecutionListener.class, applicationContext));
-				});
+				.filter(Objects::nonNull)
+				.allMatch(n -> n.getChildElementsByType(ExtensionElements.class).stream().filter(Objects::nonNull)
+						.flatMap(e -> e.getChildElementsByType(CamundaExecutionListener.class).stream())
+						.filter(Objects::nonNull).allMatch(l -> beanAvailable(process, n.getId(), l.getCamundaClass(),
+								ExecutionListener.class, applicationContext)));
 
 		// intermediate message throw events
 		boolean intermediateMessageThrowEventsOk = parent.getChildElementsByType(IntermediateThrowEvent.class).stream()
@@ -835,16 +831,12 @@ public abstract class AbstractProcessPlugin<D, A> implements ProcessPlugin<D, A>
 
 		// message end events
 		boolean endEventsOk = parent.getChildElementsByType(EndEvent.class).stream().filter(Objects::nonNull)
-				.allMatch(e ->
-				{
-					return e.getEventDefinitions().stream().filter(Objects::nonNull)
-							.filter(def -> def instanceof MessageEventDefinition)
-							.map(def -> (MessageEventDefinition) def)
-							.allMatch(def -> beanAvailable(process, def.getId(), def.getCamundaClass(),
-									JavaDelegate.class, applicationContext)
-									&& taskFieldsAvailable(process, "MessageEndEvent", e.getId(),
-											def.getExtensionElements()));
-				});
+				.allMatch(e -> e.getEventDefinitions().stream().filter(Objects::nonNull)
+						.filter(def -> def instanceof MessageEventDefinition).map(def -> (MessageEventDefinition) def)
+						.allMatch(def -> beanAvailable(process, def.getId(), def.getCamundaClass(), JavaDelegate.class,
+								applicationContext)
+								&& taskFieldsAvailable(process, "MessageEndEvent", e.getId(),
+										def.getExtensionElements())));
 
 		// sub processes
 		boolean subProcessesOk = parent.getChildElementsByType(SubProcess.class).stream().filter(Objects::nonNull)

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessIdAndVersion.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessIdAndVersion.java
@@ -67,11 +67,7 @@ public class ProcessIdAndVersion implements Comparable<ProcessIdAndVersion>
 	@Override
 	public int hashCode()
 	{
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result + ((version == null) ? 0 : version.hashCode());
-		return result;
+		return Objects.hash(id, version);
 	}
 
 	@Override
@@ -79,26 +75,10 @@ public class ProcessIdAndVersion implements Comparable<ProcessIdAndVersion>
 	{
 		if (this == obj)
 			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
+		if (obj == null || getClass() != obj.getClass())
 			return false;
 		ProcessIdAndVersion other = (ProcessIdAndVersion) obj;
-		if (id == null)
-		{
-			if (other.id != null)
-				return false;
-		}
-		else if (!id.equals(other.id))
-			return false;
-		if (version == null)
-		{
-			if (other.version != null)
-				return false;
-		}
-		else if (!version.equals(other.version))
-			return false;
-		return true;
+		return Objects.equals(id, other.id) && Objects.equals(version, other.version);
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessesResource.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessesResource.java
@@ -169,120 +169,93 @@ public final class ProcessesResource
 
 	public BundleEntryComponent toBundleEntry()
 	{
-		switch (getOldProcessState())
+		return switch (getOldProcessState())
 		{
-			case MISSING:
-				return fromMissing();
-			case NEW:
-				return fromNew();
-			case ACTIVE:
-				return fromActive();
-			case DRAFT:
-				return fromDraft();
-			case RETIRED:
-				return fromRetired();
-			case EXCLUDED:
-				return fromExcluded();
-			default:
-				throw new RuntimeException(
-						ProcessState.class.getSimpleName() + " " + getOldProcessState() + " not supported");
-		}
+			case MISSING -> fromMissing();
+			case NEW -> fromNew();
+			case ACTIVE -> fromActive();
+			case DRAFT -> fromDraft();
+			case RETIRED -> fromRetired();
+			case EXCLUDED -> fromExcluded();
+		};
 	}
 
 	private BundleEntryComponent fromMissing()
 	{
-		switch (getNewProcessState())
+		return switch (getNewProcessState())
 		{
-			case ACTIVE:
-				return createAsActive();
-			case RETIRED:
-				return createAsRetired();
-			default:
-				throw new RuntimeException(
-						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
-		}
+			case ACTIVE -> createAsActive();
+			case RETIRED -> createAsRetired();
+
+			default -> throw new RuntimeException(
+					"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+		};
 	}
 
 	private BundleEntryComponent fromNew()
 	{
-		switch (getNewProcessState())
+		return switch (getNewProcessState())
 		{
-			case ACTIVE:
-				return createAsActive();
-			case DRAFT:
-				return createAsDraft();
-			case RETIRED:
-				return createAsRetired();
-			default:
-				throw new RuntimeException(
-						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
-		}
+			case ACTIVE -> createAsActive();
+			case DRAFT -> createAsDraft();
+			case RETIRED -> createAsRetired();
+
+			default -> throw new RuntimeException(
+					"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+		};
 	}
 
 	private BundleEntryComponent fromActive()
 	{
-		switch (getNewProcessState())
+		return switch (getNewProcessState())
 		{
-			case DRAFT:
-				return updateToDraft();
-			case RETIRED:
-				return updateToRetired();
-			case EXCLUDED:
-				return delete();
-			default:
-				throw new RuntimeException(
-						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
-		}
+			case DRAFT -> updateToDraft();
+			case RETIRED -> updateToRetired();
+			case EXCLUDED -> delete();
+
+			default -> throw new RuntimeException(
+					"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+		};
 	}
 
 	private BundleEntryComponent fromDraft()
 	{
-		switch (getNewProcessState())
+		return switch (getNewProcessState())
 		{
-			case ACTIVE:
-				return updateToActive();
-			case DRAFT:
-				return updateToDraft();
-			case RETIRED:
-				return updateToRetired();
-			case EXCLUDED:
-				return delete();
-			default:
-				throw new RuntimeException(
-						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
-		}
+			case ACTIVE -> updateToActive();
+			case DRAFT -> updateToDraft();
+			case RETIRED -> updateToRetired();
+			case EXCLUDED -> delete();
+
+			default -> throw new RuntimeException(
+					"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+		};
 	}
 
 	private BundleEntryComponent fromRetired()
 	{
-		switch (getNewProcessState())
+		return switch (getNewProcessState())
 		{
-			case ACTIVE:
-				return updateToActive();
-			case DRAFT:
-				return updateToDraft();
-			case EXCLUDED:
-				return delete();
-			default:
-				throw new RuntimeException(
-						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
-		}
+			case ACTIVE -> updateToActive();
+			case DRAFT -> updateToDraft();
+			case EXCLUDED -> delete();
+
+			default -> throw new RuntimeException(
+					"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+		};
 	}
 
 	private BundleEntryComponent fromExcluded()
 	{
-		switch (getNewProcessState())
+		return switch (getNewProcessState())
 		{
-			case ACTIVE:
-				return createAsActive();
-			case DRAFT:
-				return createAsDraft();
-			case RETIRED:
-				return createAsRetired();
-			default:
-				throw new RuntimeException(
-						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
-		}
+			case ACTIVE -> createAsActive();
+			case DRAFT -> createAsDraft();
+			case RETIRED -> createAsRetired();
+
+			default -> throw new RuntimeException(
+					"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+		};
 	}
 
 	private BundleEntryComponent createAsActive()
@@ -373,108 +346,81 @@ public final class ProcessesResource
 
 	public List<String> getExpectedStatus()
 	{
-		switch (getOldProcessState())
+		return switch (getOldProcessState())
 		{
-			case MISSING:
-				switch (getNewProcessState())
-				{
-					case ACTIVE:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					case RETIRED:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					default:
-						throw new RuntimeException("State change " + getOldProcessState() + " -> "
-								+ getNewProcessState() + " not supported");
-				}
-			case NEW:
-				switch (getNewProcessState())
-				{
-					case ACTIVE:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					case DRAFT:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					case RETIRED:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					default:
-						throw new RuntimeException("State change " + getOldProcessState() + " -> "
-								+ getNewProcessState() + " not supported");
-				}
-			case ACTIVE:
-				switch (getNewProcessState())
-				{
-					case DRAFT:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case RETIRED:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case EXCLUDED:
-						// standard delete with resource id
-						return Arrays.asList("200", "204");
-					default:
-						throw new RuntimeException("State change " + getOldProcessState() + " -> "
-								+ getNewProcessState() + " not supported");
-				}
-			case DRAFT:
-				switch (getNewProcessState())
-				{
-					case ACTIVE:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case DRAFT:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case RETIRED:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case EXCLUDED:
-						// standard delete with resource id
-						return Arrays.asList("200", "204");
-					default:
-						throw new RuntimeException("State change " + getOldProcessState() + " -> "
-								+ getNewProcessState() + " not supported");
-				}
-			case RETIRED:
-				switch (getNewProcessState())
-				{
-					case ACTIVE:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case DRAFT:
-						// standard update with resource id
-						return Collections.singletonList("200");
-					case EXCLUDED:
-						// standard delete with resource id
-						return Arrays.asList("200", "204");
-					default:
-						throw new RuntimeException("State change " + getOldProcessState() + " -> "
-								+ getNewProcessState() + " not supported");
-				}
-			case EXCLUDED:
-				switch (getNewProcessState())
-				{
-					case ACTIVE:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					case DRAFT:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					case RETIRED:
-						// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
-						return Arrays.asList("200", "201");
-					default:
-						throw new RuntimeException("State change " + getOldProcessState() + " -> "
-								+ getNewProcessState() + " not supported");
-				}
-			default:
-				throw new RuntimeException(
-						ProcessState.class.getSimpleName() + " " + getOldProcessState() + " not supported");
-		}
+			case MISSING -> switch (getNewProcessState())
+			{
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case ACTIVE -> Arrays.asList("200", "201");
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case RETIRED -> Arrays.asList("200", "201");
+
+				default -> throw new RuntimeException(
+						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+			};
+			case NEW -> switch (getNewProcessState())
+			{
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case ACTIVE -> Arrays.asList("200", "201");
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case DRAFT -> Arrays.asList("200", "201");
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case RETIRED -> Arrays.asList("200", "201");
+
+				default -> throw new RuntimeException(
+						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+			};
+			case ACTIVE -> switch (getNewProcessState())
+			{
+				// standard update with resource id
+				case DRAFT -> Collections.singletonList("200");
+				// standard update with resource id
+				case RETIRED -> Collections.singletonList("200");
+				// standard delete with resource id
+				case EXCLUDED -> Arrays.asList("200", "204");
+
+				default -> throw new RuntimeException(
+						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+			};
+			case DRAFT -> switch (getNewProcessState())
+			{
+				// standard update with resource id
+				case ACTIVE -> Collections.singletonList("200");
+				// standard update with resource id
+				case DRAFT -> Collections.singletonList("200");
+				// standard update with resource id
+				case RETIRED -> Collections.singletonList("200");
+				// standard delete with resource id
+				case EXCLUDED -> Arrays.asList("200", "204");
+
+				default -> throw new RuntimeException(
+						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+			};
+			case RETIRED -> switch (getNewProcessState())
+			{
+				// standard update with resource id
+				case ACTIVE -> Collections.singletonList("200");
+				// standard update with resource id
+				case DRAFT -> Collections.singletonList("200");
+				// standard delete with resource id
+				case EXCLUDED -> Arrays.asList("200", "204");
+
+				default -> throw new RuntimeException(
+						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+			};
+			case EXCLUDED -> switch (getNewProcessState())
+			{
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case ACTIVE -> Arrays.asList("200", "201");
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case DRAFT -> Arrays.asList("200", "201");
+				// conditional create NamingSystem: name=..., Task: identifier=..., others: url=...&version=...
+				case RETIRED -> Arrays.asList("200", "201");
+
+				default -> throw new RuntimeException(
+						"State change " + getOldProcessState() + " -> " + getNewProcessState() + " not supported");
+			};
+		};
 	}
 
 	public BundleEntryComponent toSearchBundleEntryCount0()

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ResourceInfo.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ResourceInfo.java
@@ -100,9 +100,7 @@ public class ResourceInfo implements Comparable<ResourceInfo>
 	{
 		if (this == obj)
 			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
+		if (obj == null || getClass() != obj.getClass())
 			return false;
 		ResourceInfo other = (ResourceInfo) obj;
 		return Objects.equals(identifier, other.identifier) && Objects.equals(name, other.name)

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventResourceHandlerImpl.java
@@ -26,6 +26,7 @@ public class EventResourceHandlerImpl<R extends Resource> implements EventResour
 		this.resourceClass = resourceClass;
 	}
 
+	@Override
 	public void onResource(Resource resource)
 	{
 		logger.trace("Resource of type {} received", resource.getClass().getAnnotation(ResourceDef.class).name());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventType.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/EventType.java
@@ -13,21 +13,17 @@ public enum EventType
 
 	public static EventType fromString(String value)
 	{
-		switch (value.toLowerCase())
+		return switch (value.toLowerCase())
 		{
-			case "application/fhir+xml":
-			case "xml":
-				return XML;
-			case "application/fhir+json":
-			case "json":
-				return JSON;
-			case "ping":
-				return PING;
-			default:
-				throw new IllegalArgumentException("EvenType for " + value + " not implemented");
-		}
+			case "application/fhir+xml", "xml" -> XML;
+			case "application/fhir+json", "json" -> JSON;
+			case "ping" -> PING;
+
+			default -> throw new IllegalArgumentException("EvenType for " + value + " not implemented");
+		};
 	}
 
+	@Override
 	public String toString()
 	{
 		return value;

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/ExistingResourceLoaderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/ExistingResourceLoaderImpl.java
@@ -47,6 +47,7 @@ public class ExistingResourceLoaderImpl<R extends Resource> implements ExistingR
 		this.resourceClass = resourceClass;
 	}
 
+	@Override
 	public void readExistingResources(Map<String, List<String>> searchCriteriaQueryParameters)
 	{
 		// executing search until call results in no more found tasks

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/QuestionnaireResponseHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/QuestionnaireResponseHandler.java
@@ -36,6 +36,7 @@ public class QuestionnaireResponseHandler implements ResourceHandler<Questionnai
 		Objects.requireNonNull(userTaskService, "userTaskService");
 	}
 
+	@Override
 	public void onResource(QuestionnaireResponse questionnaireResponse)
 	{
 		try

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/TaskHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/TaskHandler.java
@@ -114,6 +114,7 @@ public class TaskHandler implements ResourceHandler<Task>, InitializingBean
 		Objects.requireNonNull(webserviceClient, "webserviceClient");
 	}
 
+	@Override
 	public void onResource(Task task)
 	{
 		Objects.requireNonNull(task, "task");

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/FhirWebserviceClientProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/FhirWebserviceClientProviderImpl.java
@@ -9,7 +9,7 @@ import dev.dsf.fhir.client.FhirWebserviceClient;
 
 public class FhirWebserviceClientProviderImpl implements FhirWebserviceClientProvider, InitializingBean
 {
-	private FhirClientProvider delegate;
+	private final FhirClientProvider delegate;
 
 	public FhirWebserviceClientProviderImpl(FhirClientProvider delegate)
 	{

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/MailServiceImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/MailServiceImpl.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 public class MailServiceImpl implements MailService, InitializingBean
 {
-	private MailService delegate;
+	private final MailService delegate;
 
 	public MailServiceImpl(MailService delegate)
 	{

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/QuestionnaireResponseHelperImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/v1/service/QuestionnaireResponseHelperImpl.java
@@ -20,7 +20,7 @@ import org.hl7.fhir.r4.model.UriType;
 
 public class QuestionnaireResponseHelperImpl implements QuestionnaireResponseHelper
 {
-	private String serverBaseUrl;
+	private final String serverBaseUrl;
 
 	/**
 	 * @param serverBaseUrl
@@ -79,31 +79,21 @@ public class QuestionnaireResponseHelperImpl implements QuestionnaireResponseHel
 	@Override
 	public Type transformQuestionTypeToAnswerType(Questionnaire.QuestionnaireItemComponent question)
 	{
-		switch (question.getType())
+		return switch (question.getType())
 		{
-			case STRING:
-			case TEXT:
-				return new StringType("Placeholder..");
-			case INTEGER:
-				return new IntegerType(0);
-			case DECIMAL:
-				return new DecimalType(0.00);
-			case BOOLEAN:
-				return new BooleanType(false);
-			case DATE:
-				return new DateType("1900-01-01");
-			case TIME:
-				return new TimeType("00:00:00");
-			case DATETIME:
-				return new DateTimeType("1900-01-01T00:00:00.000Z");
-			case URL:
-				return new UriType("http://example.org/foo");
-			case REFERENCE:
-				return new Reference("http://example.org/fhir/Placeholder/id");
-			default:
-				throw new RuntimeException("Type '" + question.getType().getDisplay()
-						+ "' in Questionnaire.item is not supported as answer type");
-		}
+			case STRING, TEXT -> new StringType("Placeholder..");
+			case INTEGER -> new IntegerType(0);
+			case DECIMAL -> new DecimalType(0.00);
+			case BOOLEAN -> new BooleanType(false);
+			case DATE -> new DateType("1900-01-01");
+			case TIME -> new TimeType("00:00:00");
+			case DATETIME -> new DateTimeType("1900-01-01T00:00:00.000Z");
+			case URL -> new UriType("http://example.org/foo");
+			case REFERENCE -> new Reference("http://example.org/fhir/Placeholder/id");
+
+			default -> throw new RuntimeException("Type '" + question.getType().getDisplay()
+					+ "' in Questionnaire.item is not supported as answer type");
+		};
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/dao/LastEventTimeDaoTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/dao/LastEventTimeDaoTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 public class LastEventTimeDaoTest extends AbstractDaoTest
 {
-	private LastEventTimeDao dao = new LastEventTimeDaoJdbc(defaultDataSource, "test_type");
+	private final LastEventTimeDao dao = new LastEventTimeDaoJdbc(defaultDataSource, "test_type");
 
 	@Test
 	public void testReadEmpty() throws Exception

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/v1/plugin/ProcessPluginImplTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/v1/plugin/ProcessPluginImplTest.java
@@ -136,22 +136,22 @@ public class ProcessPluginImplTest
 		}
 	}
 
-	private ProxyConfig proxyConfig = mock(ProxyConfig.class);
-	private EndpointProvider endpointProvider = mock(EndpointProvider.class);
-	private FhirContext fhirContext = FhirContext.forR4();
-	private FhirWebserviceClientProvider fhirWebserviceClientProvider = mock(FhirWebserviceClientProvider.class);
-	private MailService mailService = mock(MailService.class);
-	private ObjectMapper objectMapper = ObjectMapperFactory.createObjectMapper(fhirContext);
-	private OrganizationProvider organizationProvider = mock(OrganizationProvider.class);
-	private QuestionnaireResponseHelper questionnaireResponseHelper = mock(QuestionnaireResponseHelper.class);
-	private ProcessAuthorizationHelper processAuthorizationHelper = mock(ProcessAuthorizationHelper.class);
-	private ReadAccessHelper readAccessHelper = mock(ReadAccessHelper.class);
-	private TaskHelper taskHelper = mock(TaskHelper.class);
+	private final ProxyConfig proxyConfig = mock(ProxyConfig.class);
+	private final EndpointProvider endpointProvider = mock(EndpointProvider.class);
+	private final FhirContext fhirContext = FhirContext.forR4();
+	private final FhirWebserviceClientProvider fhirWebserviceClientProvider = mock(FhirWebserviceClientProvider.class);
+	private final MailService mailService = mock(MailService.class);
+	private final ObjectMapper objectMapper = ObjectMapperFactory.createObjectMapper(fhirContext);
+	private final OrganizationProvider organizationProvider = mock(OrganizationProvider.class);
+	private final QuestionnaireResponseHelper questionnaireResponseHelper = mock(QuestionnaireResponseHelper.class);
+	private final ProcessAuthorizationHelper processAuthorizationHelper = mock(ProcessAuthorizationHelper.class);
+	private final ReadAccessHelper readAccessHelper = mock(ReadAccessHelper.class);
+	private final TaskHelper taskHelper = mock(TaskHelper.class);
 
-	private ProcessPluginApi processPluginApi = new ProcessPluginApiImpl(proxyConfig, endpointProvider, fhirContext,
-			fhirWebserviceClientProvider, mailService, objectMapper, organizationProvider, processAuthorizationHelper,
-			questionnaireResponseHelper, readAccessHelper, taskHelper);
-	private ConfigurableEnvironment environment = new StandardEnvironment();
+	private final ProcessPluginApi processPluginApi = new ProcessPluginApiImpl(proxyConfig, endpointProvider,
+			fhirContext, fhirWebserviceClientProvider, mailService, objectMapper, organizationProvider,
+			processAuthorizationHelper, questionnaireResponseHelper, readAccessHelper, taskHelper);
+	private final ConfigurableEnvironment environment = new StandardEnvironment();
 
 	@Test
 	public void testInitializeAndValidateResourcesAllNull() throws Exception

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DelegatingAuthenticator.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DelegatingAuthenticator.java
@@ -65,6 +65,7 @@ public class DelegatingAuthenticator extends LoginAuthenticator implements Authe
 		{
 			AuthConfiguration openIdConfig = new WrappedAuthConfiguration(configuration)
 			{
+				@Override
 				public LoginService getLoginService()
 				{
 					return openIdLoginService;

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/auth/DsfOpenIdLoginService.java
@@ -42,7 +42,7 @@ public class DsfOpenIdLoginService extends OpenIdLoginService
 			return null;
 		}
 
-		return loginService.login(openIdCredentials.getUserId(), (OpenIdCredentials) credentials, req);
+		return loginService.login(openIdCredentials.getUserId(), credentials, req);
 	}
 
 	@Override
@@ -57,7 +57,7 @@ public class DsfOpenIdLoginService extends OpenIdLoginService
 			return false;
 		}
 
-		long expiry = (Long) identity.getCredentials().get().getLongClaim("exp");
+		long expiry = identity.getCredentials().get().getLongClaim("exp");
 		long currentTimeSeconds = (long) (System.currentTimeMillis() / 1000F);
 		if (currentTimeSeconds > expiry)
 		{

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
@@ -319,29 +319,22 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 	private Predicate<Coding> isValidReadAccessTag(Predicate<Identifier> organizationWithIdentifierExists,
 			Predicate<Coding> roleExists)
 	{
-		return coding ->
+		return coding -> switch (coding.getCode())
 		{
-			switch (coding.getCode())
-			{
-				case READ_ACCESS_TAG_VALUE_LOCAL:
-					return true;
-				case READ_ACCESS_TAG_VALUE_ORGANIZATION:
-					return isValidOrganizationReadAccessTag(coding, organizationWithIdentifierExists);
-				case READ_ACCESS_TAG_VALUE_ROLE:
-					return isValidRoleReadAccessTag(coding, organizationWithIdentifierExists, roleExists);
-				case READ_ACCESS_TAG_VALUE_ALL:
-					return true;
-
-				default:
-					return false;
-			}
+			case READ_ACCESS_TAG_VALUE_LOCAL -> true;
+			case READ_ACCESS_TAG_VALUE_ORGANIZATION ->
+				isValidOrganizationReadAccessTag(coding, organizationWithIdentifierExists);
+			case READ_ACCESS_TAG_VALUE_ROLE ->
+				isValidRoleReadAccessTag(coding, organizationWithIdentifierExists, roleExists);
+			case READ_ACCESS_TAG_VALUE_ALL -> true;
+			default -> false;
 		};
 	}
 
 	private boolean isValidOrganizationReadAccessTag(Coding coding,
 			Predicate<Identifier> organizationWithIdentifierExists)
 	{
-		List<Extension> exts = coding.getExtension().stream().filter(e -> e.hasUrl())
+		List<Extension> exts = coding.getExtension().stream().filter(Extension::hasUrl)
 				.filter(e -> EXTENSION_READ_ACCESS_ORGANIZATION.equals(e.getUrl())).collect(Collectors.toList());
 
 		return coding.hasExtension() && exts.size() == 1
@@ -365,7 +358,7 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 	private boolean isValidRoleReadAccessTag(Coding coding, Predicate<Identifier> organizationWithIdentifierExists,
 			Predicate<Coding> roleExists)
 	{
-		List<Extension> exts = coding.getExtension().stream().filter(e -> e.hasUrl())
+		List<Extension> exts = coding.getExtension().stream().filter(Extension::hasUrl)
 				.filter(e -> EXTENSION_READ_ACCESS_PARENT_ORGANIZATION_ROLE.equals(e.getUrl()))
 				.collect(Collectors.toList());
 

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferHandlingType.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferHandlingType.java
@@ -16,14 +16,12 @@ public enum PreferHandlingType
 		if (prefer == null)
 			return LENIENT;
 
-		switch (prefer)
+		return switch (prefer)
 		{
-			case "handling=strict":
-				return STRICT;
-			case "handling=lenient":
-			default:
-				return LENIENT;
-		}
+			case "handling=strict" -> STRICT;
+			case "handling=lenient" -> LENIENT;
+			default -> LENIENT;
+		};
 	}
 
 	public String getHeaderValue()

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferReturnType.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/prefer/PreferReturnType.java
@@ -16,16 +16,13 @@ public enum PreferReturnType
 		if (prefer == null)
 			return REPRESENTATION;
 
-		switch (prefer)
+		return switch (prefer)
 		{
-			case "return=minimal":
-				return MINIMAL;
-			case "return=OperationOutcome":
-				return OPERATION_OUTCOME;
-			case "return=representation":
-			default:
-				return REPRESENTATION;
-		}
+			case "return=minimal" -> MINIMAL;
+			case "return=OperationOutcome" -> OPERATION_OUTCOME;
+			case "return=representation" -> REPRESENTATION;
+			default -> REPRESENTATION;
+		};
 	}
 
 	public String getHeaderValue()

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ReferenceCleanerImpl.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/service/ReferenceCleanerImpl.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Reference;
@@ -51,7 +52,7 @@ public class ReferenceCleanerImpl implements ReferenceCleaner
 			return null;
 
 		if (resource instanceof Bundle b)
-			b.getEntry().stream().map(e -> e.getResource()).forEach(this::fixBundleEntry);
+			b.getEntry().stream().map(BundleEntryComponent::getResource).forEach(this::fixBundleEntry);
 
 		return resource;
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/EndpointHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/EndpointHtmlGenerator.java
@@ -5,6 +5,7 @@ import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.util.List;
 
+import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -71,7 +72,7 @@ public class EndpointHtmlGenerator extends ResourceHtmlGenerator implements Html
 			writeRowWithList("Payload Types", payloadTypes, out);
 		}
 
-		List<String> payloadMimeTypes = resource.getPayloadMimeType().stream().map(c -> c.getCode()).toList();
+		List<String> payloadMimeTypes = resource.getPayloadMimeType().stream().map(CodeType::getCode).toList();
 		if (!payloadMimeTypes.isEmpty())
 		{
 			writeRowWithList("Payload Mime Types", payloadMimeTypes, out);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/HtmlFhirAdapter.java
@@ -32,6 +32,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleLinkComponent;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
 import org.springframework.web.util.HtmlUtils;
@@ -354,7 +355,8 @@ public class HtmlFhirAdapter extends AbstractAdapter implements MessageBodyWrite
 								resource.getIdElement().getIdPart(), resource.getIdElement().getVersionIdPart()));
 		}
 		else if (resource instanceof Bundle b && !resource.getIdElement().hasIdPart())
-			return b.getLink().stream().filter(c -> "self".equals(c.getRelation())).findFirst().map(c -> c.getUrl());
+			return b.getLink().stream().filter(c -> "self".equals(c.getRelation())).findFirst()
+					.map(BundleLinkComponent::getUrl);
 		else
 			return Optional.empty();
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/OrganizationHtmlGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/OrganizationHtmlGenerator.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Organization.OrganizationContactComponent;
 import org.hl7.fhir.r4.model.Reference;
@@ -59,9 +60,9 @@ public class OrganizationHtmlGenerator extends ResourceHtmlGenerator implements 
 		}
 
 		List<String> thumbprints = resource.getExtension().stream()
-				.filter(e -> EXTENSION_THUMBPRINT_URL.equals(e.getUrl()) && e.hasValue()).map(e -> e.getValue())
-				.filter(t -> t instanceof StringType).map(t -> (StringType) t).filter(s -> s.hasValue())
-				.map(s -> s.getValue()).toList();
+				.filter(e -> EXTENSION_THUMBPRINT_URL.equals(e.getUrl()) && e.hasValue()).map(Extension::getValue)
+				.filter(t -> t instanceof StringType).map(t -> (StringType) t).filter(StringType::hasValue)
+				.map(StringType::getValue).toList();
 		if (!thumbprints.isEmpty())
 		{
 			writeRowWithList("Thumbprints", thumbprints, out);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authentication/PractitionerProviderImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authentication/PractitionerProviderImpl.java
@@ -102,9 +102,9 @@ public class PractitionerProviderImpl extends AbstractProvider implements Practi
 		String iss = credentials.getStringClaimOrDefault("iss", "");
 		String sub = credentials.getStringClaimOrDefault("sub", "");
 
-		Stream<String> surname = Stream.of((String) credentials.getStringClaimOrDefault("family_name", ""));
-		Stream<String> givenNames = Stream.of((String) credentials.getStringClaimOrDefault("given_name", ""));
-		Stream<String> emails = Stream.of((String) credentials.getStringClaimOrDefault("email", ""), toEmail(iss, sub));
+		Stream<String> surname = Stream.of(credentials.getStringClaimOrDefault("family_name", ""));
+		Stream<String> givenNames = Stream.of(credentials.getStringClaimOrDefault("given_name", ""));
+		Stream<String> emails = Stream.of(credentials.getStringClaimOrDefault("email", ""), toEmail(iss, sub));
 
 		return toPractitioner(surname, givenNames, emails);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/AbstractAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/AbstractAuthorizationRule.java
@@ -315,9 +315,7 @@ public abstract class AbstractAuthorizationRule<R extends Resource, D extends Re
 
 	protected final boolean isLocalOrganization(Organization organization)
 	{
-		if (organization == null)
-			return false;
-		if (!organization.hasIdElement())
+		if (organization == null || !organization.hasIdElement())
 			return false;
 
 		return organizationProvider.getLocalOrganization()

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
@@ -65,7 +65,7 @@ public class ActivityDefinitionAuthorizationRule
 
 	private Optional<String> newResourceOk(Connection connection, ActivityDefinition newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		// TODO check existence of profiles, codes and identifier against DB
 		if (!processAuthorizationHelper.isValid(newResource, taskProfile -> true, practitionerRole -> true,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/BinaryAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/BinaryAuthorizationRule.java
@@ -32,7 +32,7 @@ public class BinaryAuthorizationRule extends AbstractMetaTagAuthorizationRule<Bi
 		super(Binary.class, daoProvider, serverBase, referenceResolver, organizationProvider, readAccessHelper,
 				parameterConverter);
 
-		this.rules = Arrays.stream(supportedSecurityContextRules)
+		rules = Arrays.stream(supportedSecurityContextRules)
 				.collect(Collectors.toMap(AuthorizationRule::getResourceType, Function.identity()));
 	}
 
@@ -51,7 +51,7 @@ public class BinaryAuthorizationRule extends AbstractMetaTagAuthorizationRule<Bi
 
 	private Optional<String> newResourceOk(Connection connection, Identity identity, Binary newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		boolean hasValidReadAccessTag = hasValidReadAccessTag(connection, newResource);
 		boolean hasValidSecurityContext = hasValidSecurityContext(connection, identity, newResource);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/BundleAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/BundleAuthorizationRule.java
@@ -40,7 +40,7 @@ public class BundleAuthorizationRule extends AbstractMetaTagAuthorizationRule<Bu
 
 	private Optional<String> newResourceOk(Connection connection, Bundle newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/CodeSystemAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/CodeSystemAuthorizationRule.java
@@ -47,7 +47,7 @@ public class CodeSystemAuthorizationRule extends AbstractMetaTagAuthorizationRul
 
 	private Optional<String> newResourceOk(Connection connection, CodeSystem newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasStatus())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/DocumentReferenceAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/DocumentReferenceAuthorizationRule.java
@@ -43,7 +43,7 @@ public class DocumentReferenceAuthorizationRule
 
 	private Optional<String> newResourceOk(Connection connection, DocumentReference newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/EndpointAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/EndpointAuthorizationRule.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 
 	private Optional<String> newResourceOk(Connection connection, Endpoint newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasIdentifier())
 		{
@@ -100,7 +101,7 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 	{
 		String identifierValue = newResource.getIdentifier().stream()
 				.filter(i -> i.hasSystem() && i.hasValue() && ENDPOINT_IDENTIFIER_SYSTEM.equals(i.getSystem()))
-				.map(i -> i.getValue()).findFirst().orElseThrow();
+				.map(Identifier::getValue).findFirst().orElseThrow();
 
 		return endpointWithAddressExists(connection, newResource.getAddress())
 				|| endpointWithIdentifierExists(connection, identifierValue);
@@ -167,10 +168,10 @@ public class EndpointAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 	protected boolean modificationsOk(Connection connection, Endpoint oldResource, Endpoint newResource)
 	{
 		String oldIdentifierValue = oldResource.getIdentifier().stream()
-				.filter(i -> ENDPOINT_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(i -> i.getValue()).findFirst()
+				.filter(i -> ENDPOINT_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(Identifier::getValue).findFirst()
 				.orElseThrow();
 		String newIdentifierValue = newResource.getIdentifier().stream()
-				.filter(i -> ENDPOINT_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(i -> i.getValue()).findFirst()
+				.filter(i -> ENDPOINT_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(Identifier::getValue).findFirst()
 				.orElseThrow();
 
 		return oldResource.getAddress().equals(newResource.getAddress())

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/GroupAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/GroupAuthorizationRule.java
@@ -40,7 +40,7 @@ public class GroupAuthorizationRule extends AbstractMetaTagAuthorizationRule<Gro
 
 	private Optional<String> newResourceOk(Connection connection, Group newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/HealthcareServiceAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/HealthcareServiceAuthorizationRule.java
@@ -43,7 +43,7 @@ public class HealthcareServiceAuthorizationRule
 
 	private Optional<String> newResourceOk(Connection connection, HealthcareService newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LibraryAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LibraryAuthorizationRule.java
@@ -40,7 +40,7 @@ public class LibraryAuthorizationRule extends AbstractMetaTagAuthorizationRule<L
 
 	private Optional<String> newResourceOk(Connection connection, Library newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LocationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/LocationAuthorizationRule.java
@@ -40,7 +40,7 @@ public class LocationAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 
 	private Optional<String> newResourceOk(Connection connection, Location newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureAuthorizationRule.java
@@ -40,7 +40,7 @@ public class MeasureAuthorizationRule extends AbstractMetaTagAuthorizationRule<M
 
 	private Optional<String> newResourceOk(Connection connection, Measure newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureReportAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/MeasureReportAuthorizationRule.java
@@ -42,7 +42,7 @@ public class MeasureReportAuthorizationRule extends AbstractMetaTagAuthorization
 
 	private Optional<String> newResourceOk(Connection connection, MeasureReport newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/NamingSystemAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/NamingSystemAuthorizationRule.java
@@ -52,7 +52,7 @@ public class NamingSystemAuthorizationRule extends AbstractMetaTagAuthorizationR
 
 	private Optional<String> newResourceOk(Connection connection, NamingSystem newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasStatus())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAffiliationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAffiliationAuthorizationRule.java
@@ -57,7 +57,7 @@ public class OrganizationAffiliationAuthorizationRule
 
 	private Optional<String> newResourceOk(Connection connection, OrganizationAffiliation newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasOrganization())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/OrganizationAuthorizationRule.java
@@ -59,7 +59,7 @@ public class OrganizationAuthorizationRule extends AbstractMetaTagAuthorizationR
 
 	private Optional<String> newResourceOk(Connection connection, Organization newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasIdentifier())
 		{
@@ -151,11 +151,11 @@ public class OrganizationAuthorizationRule extends AbstractMetaTagAuthorizationR
 	private boolean isIdentifierSame(Organization oldResource, Organization newResource)
 	{
 		String oldIdentifierValue = oldResource.getIdentifier().stream()
-				.filter(i -> ORGANIZATION_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(i -> i.getValue()).findFirst()
+				.filter(i -> ORGANIZATION_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(Identifier::getValue).findFirst()
 				.orElseThrow();
 
 		String newIdentifierValue = newResource.getIdentifier().stream()
-				.filter(i -> ORGANIZATION_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(i -> i.getValue()).findFirst()
+				.filter(i -> ORGANIZATION_IDENTIFIER_SYSTEM.equals(i.getSystem())).map(Identifier::getValue).findFirst()
 				.orElseThrow();
 
 		return oldIdentifierValue.equals(newIdentifierValue);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PatientAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PatientAuthorizationRule.java
@@ -40,7 +40,7 @@ public class PatientAuthorizationRule extends AbstractMetaTagAuthorizationRule<P
 
 	private Optional<String> newResourceOk(Connection connection, Patient newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerAuthorizationRule.java
@@ -42,7 +42,7 @@ public class PractitionerAuthorizationRule extends AbstractMetaTagAuthorizationR
 
 	private Optional<String> newResourceOk(Connection connection, Practitioner newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerRoleAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/PractitionerRoleAuthorizationRule.java
@@ -43,7 +43,7 @@ public class PractitionerRoleAuthorizationRule
 
 	private Optional<String> newResourceOk(Connection connection, PractitionerRole newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasOrganization())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ProvenanceAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ProvenanceAuthorizationRule.java
@@ -40,7 +40,7 @@ public class ProvenanceAuthorizationRule extends AbstractMetaTagAuthorizationRul
 
 	private Optional<String> newResourceOk(Connection connection, Provenance newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireAuthorizationRule.java
@@ -42,7 +42,7 @@ public class QuestionnaireAuthorizationRule extends AbstractMetaTagAuthorization
 
 	private Optional<String> newResourceOk(Connection connection, Questionnaire newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireResponseAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/QuestionnaireResponseAuthorizationRule.java
@@ -71,7 +71,7 @@ public class QuestionnaireResponseAuthorizationRule
 	private Optional<String> newResourceOk(QuestionnaireResponse newResource,
 			EnumSet<QuestionnaireResponseStatus> allowedStatus)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasStatus())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ResearchStudyAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ResearchStudyAuthorizationRule.java
@@ -42,7 +42,7 @@ public class ResearchStudyAuthorizationRule extends AbstractMetaTagAuthorization
 
 	private Optional<String> newResourceOk(Connection connection, ResearchStudy newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (!hasValidReadAccessTag(connection, newResource))
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
@@ -50,7 +50,7 @@ public class StructureDefinitionAuthorizationRule
 
 	private Optional<String> newResourceOk(Connection connection, StructureDefinition newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasStatus())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
@@ -57,7 +57,7 @@ public class SubscriptionAuthorizationRule extends AbstractMetaTagAuthorizationR
 
 	private Optional<String> newResourceOk(Connection connection, Subscription newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasChannel())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/TaskAuthorizationRule.java
@@ -175,7 +175,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 	 */
 	private Optional<String> requestedTaskOk(Connection connection, Identity identity, Task newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.getIdentifier().stream().anyMatch(i -> NAMING_SYSTEM_TASK_IDENTIFIER.equals(i.getSystem())))
 		{
@@ -282,7 +282,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 	 */
 	private Optional<String> draftTaskOk(Connection connection, Identity identity, Task newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.getIdentifier().stream().noneMatch(i -> NAMING_SYSTEM_TASK_IDENTIFIER.equals(i.getSystem())))
 		{
@@ -395,7 +395,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 						.anyMatch(c -> CODE_SYSTEM_BPMN_MESSAGE.equals(c.getSystem())
 								&& CODE_SYSTEM_BPMN_MESSAGE_MESSAGE_NAME.equals(c.getCode())))
 				.filter(ParameterComponent::hasValue).filter(i -> i.getValue() instanceof StringType)
-				.map(ParameterComponent::getValue).map(v -> (StringType) v).map(t -> t.getValueAsString())
+				.map(ParameterComponent::getValue).map(v -> (StringType) v).map(StringType::getValueAsString)
 				.filter(s -> !s.isBlank());
 	}
 
@@ -792,7 +792,7 @@ public class TaskAuthorizationRule extends AbstractAuthorizationRule<Task, TaskD
 
 	private Optional<String> reasonNotSame(Task oldResource, Task newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 		if (!oldResource.getRequester().equalsDeep(newResource.getRequester()))
 		{
 			errors.add("Task.requester");

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ValueSetAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ValueSetAuthorizationRule.java
@@ -47,7 +47,7 @@ public class ValueSetAuthorizationRule extends AbstractMetaTagAuthorizationRule<
 
 	private Optional<String> newResourceOk(Connection connection, ValueSet newResource)
 	{
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 
 		if (newResource.hasStatus())
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/client/ClientProviderImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/client/ClientProviderImpl.java
@@ -26,7 +26,7 @@ public class ClientProviderImpl implements ClientProvider, InitializingBean
 
 	private final int remoteReadTimeout;
 	private final int remoteConnectTimeout;
-	private ProxyConfig proxyConfig;
+	private final ProxyConfig proxyConfig;
 	private final boolean logRequests;
 	private final FhirContext fhirContext;
 	private final ReferenceCleaner referenceCleaner;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AbstractCommandWithResource.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/AbstractCommandWithResource.java
@@ -43,7 +43,7 @@ public abstract class AbstractCommandWithResource<R extends Resource, D extends 
 			ResponseGenerator responseGenerator, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver)
 	{
-		return new ReferencesHelperImpl<R>(index, identity, resource, serverBase, referenceExtractor, referenceResolver,
+		return new ReferencesHelperImpl<>(index, identity, resource, serverBase, referenceExtractor, referenceResolver,
 				responseGenerator);
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/BatchCommandList.java
@@ -55,8 +55,7 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 					initialReadOnly, initialAutoCommit,
 					getTransactionIsolationLevelString(initialTransactionIsolationLevel));
 
-			Map<Integer, Exception> caughtExceptions = new HashMap<Integer, Exception>(
-					(int) (commands.size() / 0.75) + 1);
+			Map<Integer, Exception> caughtExceptions = new HashMap<>((int) (commands.size() / 0.75) + 1);
 			Map<String, IdType> idTranslationTable = new HashMap<>();
 
 			if (hasModifyingCommands)
@@ -113,22 +112,16 @@ public class BatchCommandList extends AbstractCommandList implements CommandList
 
 	private String getTransactionIsolationLevelString(int level)
 	{
-		switch (level)
+		return switch (level)
 		{
-			case Connection.TRANSACTION_NONE:
-				return "NONE";
-			case Connection.TRANSACTION_READ_UNCOMMITTED:
-				return "READ_UNCOMMITTED";
-			case Connection.TRANSACTION_READ_COMMITTED:
-				return "READ_COMMITTED";
-			case Connection.TRANSACTION_REPEATABLE_READ:
-				return "REPEATABLE_READ";
-			case Connection.TRANSACTION_SERIALIZABLE:
-				return "SERIALIZABLE";
+			case Connection.TRANSACTION_NONE -> "NONE";
+			case Connection.TRANSACTION_READ_UNCOMMITTED -> "READ_UNCOMMITTED";
+			case Connection.TRANSACTION_READ_COMMITTED -> "READ_COMMITTED";
+			case Connection.TRANSACTION_REPEATABLE_READ -> "REPEATABLE_READ";
+			case Connection.TRANSACTION_SERIALIZABLE -> "SERIALIZABLE";
 
-			default:
-				return "?";
-		}
+			default -> "?";
+		};
 	}
 
 	private Consumer<Command> preExecute(Map<String, IdType> idTranslationTable, Connection connection,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteStructureDefinitionCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/DeleteStructureDefinitionCommand.java
@@ -24,7 +24,7 @@ public class DeleteStructureDefinitionCommand extends DeleteCommand
 {
 	private static final Logger logger = LoggerFactory.getLogger(DeleteStructureDefinitionCommand.class);
 
-	private StructureDefinitionDao snapshotDao;
+	private final StructureDefinitionDao snapshotDao;
 
 	public DeleteStructureDefinitionCommand(int index, Identity identity, PreferReturnType returnType, Bundle bundle,
 			BundleEntryComponent entry, String serverBase, AuthorizationHelper authorizationHelper,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/ReadCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/ReadCommand.java
@@ -218,7 +218,7 @@ public class ReadCommand extends AbstractCommand implements Command
 			// map single search result from multipleResult field to singleResult field
 			if (multipleResult != null && multipleResult.getEntry().size() == 1)
 			{
-				singleResult = (Resource) multipleResult.getEntry().get(0).getResource();
+				singleResult = multipleResult.getEntry().get(0).getResource();
 				multipleResult = null;
 
 				authorizationHelper.checkReadAllowed(index, connection, identity, singleResult);
@@ -227,7 +227,7 @@ public class ReadCommand extends AbstractCommand implements Command
 					&& SearchEntryMode.MATCH.equals(multipleResult.getEntry().get(0).getSearch().getMode())
 					&& SearchEntryMode.OUTCOME.equals(multipleResult.getEntry().get(1).getSearch().getMode()))
 			{
-				singleResult = (Resource) multipleResult.getEntry().get(0).getResource();
+				singleResult = multipleResult.getEntry().get(0).getResource();
 				singleResultSearchWarning = (OperationOutcome) multipleResult.getEntry().get(1).getResource();
 				multipleResult = null;
 
@@ -237,7 +237,7 @@ public class ReadCommand extends AbstractCommand implements Command
 					&& SearchEntryMode.MATCH.equals(multipleResult.getEntry().get(1).getSearch().getMode())
 					&& SearchEntryMode.OUTCOME.equals(multipleResult.getEntry().get(0).getSearch().getMode()))
 			{
-				singleResult = (Resource) multipleResult.getEntry().get(1).getResource();
+				singleResult = multipleResult.getEntry().get(1).getResource();
 				singleResultSearchWarning = (OperationOutcome) multipleResult.getEntry().get(0).getResource();
 				multipleResult = null;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/ReferencesHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/ReferencesHelperImpl.java
@@ -69,43 +69,35 @@ public final class ReferencesHelperImpl<R extends Resource> implements Reference
 	private Optional<OperationOutcome> resolveTemporaryOrConditionalReferenceOrLiteralInternalRelatedArtifactOrAttachmentUrl(
 			ResourceReference reference, Map<String, IdType> idTranslationTable, Connection connection)
 	{
-		ReferenceType type = reference.getType(serverBase);
-		switch (type)
+		return switch (reference.getType(serverBase))
 		{
-			case TEMPORARY:
-				return resolveTemporary(reference, idTranslationTable, reference.getReference()::getReference,
-						reference.getReference()::setReferenceElement);
+			case TEMPORARY -> resolveTemporary(reference, idTranslationTable, reference.getReference()::getReference,
+					reference.getReference()::setReferenceElement);
 
-			case RELATED_ARTEFACT_TEMPORARY_URL:
-				return resolveTemporary(reference, idTranslationTable, reference.getRelatedArtifact()::getUrl,
-						newIdToAbsoluteUrl(reference.getRelatedArtifact()::setUrl));
+			case RELATED_ARTEFACT_TEMPORARY_URL -> resolveTemporary(reference, idTranslationTable,
+					reference.getRelatedArtifact()::getUrl, newIdToAbsoluteUrl(reference.getRelatedArtifact()::setUrl));
 
-			case ATTACHMENT_TEMPORARY_URL:
-				return resolveTemporary(reference, idTranslationTable, reference.getAttachment()::getUrl,
-						newIdToAbsoluteUrl(reference.getAttachment()::setUrl));
+			case ATTACHMENT_TEMPORARY_URL -> resolveTemporary(reference, idTranslationTable,
+					reference.getAttachment()::getUrl, newIdToAbsoluteUrl(reference.getAttachment()::setUrl));
 
-			case CONDITIONAL:
-				return resolveConditional(reference, connection, target -> reference.getReference().setReferenceElement(
+			case CONDITIONAL ->
+				resolveConditional(reference, connection, target -> reference.getReference().setReferenceElement(
 						new IdType(target.getResourceType().name(), target.getIdElement().getIdPart())));
 
-			case RELATED_ARTEFACT_CONDITIONAL_URL:
-				return resolveConditional(reference, connection,
-						targetToAbsoluteUrl(reference.getRelatedArtifact()::setUrl));
+			case RELATED_ARTEFACT_CONDITIONAL_URL ->
+				resolveConditional(reference, connection, targetToAbsoluteUrl(reference.getRelatedArtifact()::setUrl));
 
-			case ATTACHMENT_CONDITIONAL_URL:
-				return resolveConditional(reference, connection,
-						targetToAbsoluteUrl(reference.getAttachment()::setUrl));
+			case ATTACHMENT_CONDITIONAL_URL ->
+				resolveConditional(reference, connection, targetToAbsoluteUrl(reference.getAttachment()::setUrl));
 
-			case RELATED_ARTEFACT_LITERAL_INTERNAL_URL:
-				return resolveLiteralInternalUrl(reference::getRelatedArtifact, RelatedArtifact::getUrl,
-						RelatedArtifact::setUrl);
+			case RELATED_ARTEFACT_LITERAL_INTERNAL_URL -> resolveLiteralInternalUrl(reference::getRelatedArtifact,
+					RelatedArtifact::getUrl, RelatedArtifact::setUrl);
 
-			case ATTACHMENT_LITERAL_INTERNAL_URL:
-				return resolveLiteralInternalUrl(reference::getAttachment, Attachment::getUrl, Attachment::setUrl);
+			case ATTACHMENT_LITERAL_INTERNAL_URL ->
+				resolveLiteralInternalUrl(reference::getAttachment, Attachment::getUrl, Attachment::setUrl);
 
-			default:
-				return Optional.empty();
-		}
+			default -> Optional.empty();
+		};
 	}
 
 	private Consumer<IdType> newIdToAbsoluteUrl(Consumer<String> absoluteUrlConsumer)
@@ -222,26 +214,22 @@ public final class ReferencesHelperImpl<R extends Resource> implements Reference
 	private Optional<OperationOutcome> checkReference(ResourceReference reference, Connection connection)
 			throws WebApplicationException
 	{
-		ReferenceType type = reference.getType(serverBase);
-		switch (type)
+		return switch (reference.getType(serverBase))
 		{
-			case LITERAL_INTERNAL:
-			case RELATED_ARTEFACT_LITERAL_INTERNAL_URL:
-			case ATTACHMENT_LITERAL_INTERNAL_URL:
-				return referenceResolver.checkLiteralInternalReference(resource, reference, connection, index);
-			case LITERAL_EXTERNAL:
-			case RELATED_ARTEFACT_LITERAL_EXTERNAL_URL:
-			case ATTACHMENT_LITERAL_EXTERNAL_URL:
-				return referenceResolver.checkLiteralExternalReference(resource, reference, index);
-			case LOGICAL:
-				return referenceResolver.checkLogicalReference(identity, resource, reference, connection, index);
+			case LITERAL_INTERNAL, RELATED_ARTEFACT_LITERAL_INTERNAL_URL, ATTACHMENT_LITERAL_INTERNAL_URL ->
+				referenceResolver.checkLiteralInternalReference(resource, reference, connection, index);
+
+			case LITERAL_EXTERNAL, RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, ATTACHMENT_LITERAL_EXTERNAL_URL ->
+				referenceResolver.checkLiteralExternalReference(resource, reference, index);
+
+			case LOGICAL -> referenceResolver.checkLogicalReference(identity, resource, reference, connection, index);
+
 			// unknown URLs to non FHIR servers in related artifacts must not be checked
-			case RELATED_ARTEFACT_UNKNOWN_URL:
-			case ATTACHMENT_UNKNOWN_URL:
-				return Optional.empty();
-			case UNKNOWN:
-			default:
-				return Optional.of(responseGenerator.unknownReference(resource, reference, index));
-		}
+			case RELATED_ARTEFACT_UNKNOWN_URL, ATTACHMENT_UNKNOWN_URL -> Optional.empty();
+
+			case UNKNOWN -> Optional.of(responseGenerator.unknownReference(resource, reference, index));
+
+			default -> Optional.of(responseGenerator.unknownReference(resource, reference, index));
+		};
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
@@ -9,7 +9,6 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -81,10 +80,7 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 		@Override
 		public int hashCode()
 		{
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((id == null) ? 0 : id.hashCode());
-			return result;
+			return Objects.hash(id);
 		}
 
 		@Override
@@ -92,19 +88,10 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 		{
 			if (this == obj)
 				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
+			if (obj == null || getClass() != obj.getClass())
 				return false;
 			ResourceDistinctById other = (ResourceDistinctById) obj;
-			if (id == null)
-			{
-				if (other.id != null)
-					return false;
-			}
-			else if (!id.equals(other.id))
-				return false;
-			return true;
+			return Objects.equals(id, other.id);
 		}
 
 		public Resource getResource()
@@ -202,11 +189,11 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 			this.searchRevIncludeParameterFactories.addAll(searchRevIncludeParameterFactories);
 
 		resourceIdFactory = new SearchQueryParameterFactory<>(ResourceId.PARAMETER_NAME,
-				() -> new ResourceId<>(resourceIdColumn));
+				() -> new ResourceId<>(resourceType, resourceIdColumn));
 		resourceLastUpdatedFactory = new SearchQueryParameterFactory<>(ResourceLastUpdated.PARAMETER_NAME,
-				() -> new ResourceLastUpdated<>(resourceColumn));
+				() -> new ResourceLastUpdated<>(resourceType, resourceColumn));
 		resourceProfileFactory = new SearchQueryParameterFactory<>(ResourceProfile.PARAMETER_NAME,
-				() -> new ResourceProfile<>(resourceColumn), ResourceProfile.getNameModifiers());
+				() -> new ResourceProfile<>(resourceType, resourceColumn), ResourceProfile.getNameModifiers());
 	}
 
 	@Override
@@ -896,11 +883,8 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 			return;
 
 		JsonArray array = (JsonArray) JsonParser.parseString(json);
-
-		Iterator<JsonElement> it = array.iterator();
-		while (it.hasNext())
+		for (JsonElement jsonElement : array)
 		{
-			JsonElement jsonElement = it.next();
 			IBaseResource resource = preparedStatementFactory.getJsonParser().parseResource(jsonElement.toString());
 			if (resource instanceof Resource r)
 			{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractStructureDefinitionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractStructureDefinitionDaoJdbc.java
@@ -21,6 +21,7 @@ import dev.dsf.fhir.search.SearchQueryParameter;
 import dev.dsf.fhir.search.SearchQueryParameterFactory;
 import dev.dsf.fhir.search.parameters.StructureDefinitionDate;
 import dev.dsf.fhir.search.parameters.StructureDefinitionIdentifier;
+import dev.dsf.fhir.search.parameters.StructureDefinitionName;
 import dev.dsf.fhir.search.parameters.StructureDefinitionStatus;
 import dev.dsf.fhir.search.parameters.StructureDefinitionUrl;
 import dev.dsf.fhir.search.parameters.StructureDefinitionVersion;
@@ -52,6 +53,8 @@ abstract class AbstractStructureDefinitionDaoJdbc extends AbstractResourceDaoJdb
 						factory(resourceColumn, StructureDefinitionDate.PARAMETER_NAME, StructureDefinitionDate::new),
 						factory(resourceColumn, StructureDefinitionIdentifier.PARAMETER_NAME,
 								StructureDefinitionIdentifier::new, StructureDefinitionIdentifier.getNameModifiers()),
+						factory(resourceColumn, StructureDefinitionName.PARAMETER_NAME, StructureDefinitionName::new,
+								StructureDefinitionName.getNameModifiers()),
 						factory(resourceColumn, StructureDefinitionStatus.PARAMETER_NAME,
 								StructureDefinitionStatus::new, StructureDefinitionStatus.getNameModifiers()),
 						factory(resourceColumn, StructureDefinitionUrl.PARAMETER_NAME, StructureDefinitionUrl::new,
@@ -60,8 +63,7 @@ abstract class AbstractStructureDefinitionDaoJdbc extends AbstractResourceDaoJdb
 								StructureDefinitionVersion::new, StructureDefinitionVersion.getNameModifiers())),
 				Collections.emptyList());
 
-		readByUrl = new ReadByUrlDaoJdbc<StructureDefinition>(this::getDataSource, this::getResource, resourceTable,
-				resourceColumn);
+		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, resourceTable, resourceColumn);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractStructureDefinitionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractStructureDefinitionDaoJdbc.java
@@ -2,8 +2,6 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -49,8 +47,7 @@ abstract class AbstractStructureDefinitionDaoJdbc extends AbstractResourceDaoJdb
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, StructureDefinition.class, resourceTable,
 				resourceColumn, resourceIdColumn, userFilter,
-				Arrays.asList(
-						factory(resourceColumn, StructureDefinitionDate.PARAMETER_NAME, StructureDefinitionDate::new),
+				List.of(factory(resourceColumn, StructureDefinitionDate.PARAMETER_NAME, StructureDefinitionDate::new),
 						factory(resourceColumn, StructureDefinitionIdentifier.PARAMETER_NAME,
 								StructureDefinitionIdentifier::new, StructureDefinitionIdentifier.getNameModifiers()),
 						factory(resourceColumn, StructureDefinitionName.PARAMETER_NAME, StructureDefinitionName::new,
@@ -61,7 +58,7 @@ abstract class AbstractStructureDefinitionDaoJdbc extends AbstractResourceDaoJdb
 								StructureDefinitionUrl.getNameModifiers()),
 						factory(resourceColumn, StructureDefinitionVersion.PARAMETER_NAME,
 								StructureDefinitionVersion::new, StructureDefinitionVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, resourceTable, resourceColumn);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ActivityDefinitionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ActivityDefinitionDaoJdbc.java
@@ -50,7 +50,7 @@ public class ActivityDefinitionDaoJdbc extends AbstractResourceDaoJdbc<ActivityD
 								ActivityDefinitionVersion.getNameModifiers())),
 				Collections.emptyList());
 
-		readByUrl = new ReadByUrlDaoJdbc<ActivityDefinition>(this::getDataSource, this::getResource, getResourceTable(),
+		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ActivityDefinitionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ActivityDefinitionDaoJdbc.java
@@ -5,8 +5,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,7 +37,7 @@ public class ActivityDefinitionDaoJdbc extends AbstractResourceDaoJdbc<ActivityD
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, ActivityDefinition.class, "activity_definitions",
 				"activity_definition", "activity_definition_id", ActivityDefinitionIdentityFilter::new,
-				Arrays.asList(factory(ActivityDefinitionDate.PARAMETER_NAME, ActivityDefinitionDate::new),
+				List.of(factory(ActivityDefinitionDate.PARAMETER_NAME, ActivityDefinitionDate::new),
 						factory(ActivityDefinitionIdentifier.PARAMETER_NAME, ActivityDefinitionIdentifier::new),
 						factory(ActivityDefinitionName.PARAMETER_NAME, ActivityDefinitionName::new,
 								ActivityDefinitionName.getNameModifiers()),
@@ -48,7 +46,7 @@ public class ActivityDefinitionDaoJdbc extends AbstractResourceDaoJdbc<ActivityD
 						factory(ActivityDefinitionUrl.PARAMETER_NAME, ActivityDefinitionUrl::new),
 						factory(ActivityDefinitionVersion.PARAMETER_NAME, ActivityDefinitionVersion::new,
 								ActivityDefinitionVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BinaryDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BinaryDaoJdbc.java
@@ -4,8 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -24,9 +23,9 @@ public class BinaryDaoJdbc extends AbstractResourceDaoJdbc<Binary> implements Bi
 	{
 		super(dataSource, permanentDeleteDataSource, Binary.class, "binaries", "binary_json", "binary_id",
 				new PreparedStatementFactoryBinary(fhirContext), BinaryIdentityFilter::new,
-				Arrays.asList(factory(BinaryContentType.PARAMETER_NAME, BinaryContentType::new,
+				List.of(factory(BinaryContentType.PARAMETER_NAME, BinaryContentType::new,
 						BinaryContentType.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BundleDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/BundleDaoJdbc.java
@@ -2,8 +2,7 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -20,9 +19,9 @@ public class BundleDaoJdbc extends AbstractResourceDaoJdbc<Bundle> implements Bu
 	public BundleDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource, FhirContext fhirContext)
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Bundle.class, "bundles", "bundle", "bundle_id",
-				BundleIdentityFilter::new, Arrays.asList(factory(BundleIdentifier.PARAMETER_NAME, BundleIdentifier::new,
+				BundleIdentityFilter::new, List.of(factory(BundleIdentifier.PARAMETER_NAME, BundleIdentifier::new,
 						BundleIdentifier.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/CodeSystemDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/CodeSystemDaoJdbc.java
@@ -2,8 +2,7 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -28,7 +27,7 @@ public class CodeSystemDaoJdbc extends AbstractResourceDaoJdbc<CodeSystem> imple
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, CodeSystem.class, "code_systems", "code_system",
 				"code_system_id", CodeSystemIdentityFilter::new,
-				Arrays.asList(factory(CodeSystemDate.PARAMETER_NAME, CodeSystemDate::new),
+				List.of(factory(CodeSystemDate.PARAMETER_NAME, CodeSystemDate::new),
 						factory(CodeSystemIdentifier.PARAMETER_NAME, CodeSystemIdentifier::new,
 								CodeSystemIdentifier.getNameModifiers()),
 						factory(CodeSystemName.PARAMETER_NAME, CodeSystemName::new, CodeSystemName.getNameModifiers()),
@@ -37,7 +36,7 @@ public class CodeSystemDaoJdbc extends AbstractResourceDaoJdbc<CodeSystem> imple
 						factory(CodeSystemUrl.PARAMETER_NAME, CodeSystemUrl::new, CodeSystemUrl.getNameModifiers()),
 						factory(CodeSystemVersion.PARAMETER_NAME, CodeSystemVersion::new,
 								CodeSystemVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/CodeSystemDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/CodeSystemDaoJdbc.java
@@ -15,6 +15,7 @@ import dev.dsf.fhir.dao.CodeSystemDao;
 import dev.dsf.fhir.search.filter.CodeSystemIdentityFilter;
 import dev.dsf.fhir.search.parameters.CodeSystemDate;
 import dev.dsf.fhir.search.parameters.CodeSystemIdentifier;
+import dev.dsf.fhir.search.parameters.CodeSystemName;
 import dev.dsf.fhir.search.parameters.CodeSystemStatus;
 import dev.dsf.fhir.search.parameters.CodeSystemUrl;
 import dev.dsf.fhir.search.parameters.CodeSystemVersion;
@@ -30,6 +31,7 @@ public class CodeSystemDaoJdbc extends AbstractResourceDaoJdbc<CodeSystem> imple
 				Arrays.asList(factory(CodeSystemDate.PARAMETER_NAME, CodeSystemDate::new),
 						factory(CodeSystemIdentifier.PARAMETER_NAME, CodeSystemIdentifier::new,
 								CodeSystemIdentifier.getNameModifiers()),
+						factory(CodeSystemName.PARAMETER_NAME, CodeSystemName::new, CodeSystemName.getNameModifiers()),
 						factory(CodeSystemStatus.PARAMETER_NAME, CodeSystemStatus::new,
 								CodeSystemStatus.getNameModifiers()),
 						factory(CodeSystemUrl.PARAMETER_NAME, CodeSystemUrl::new, CodeSystemUrl.getNameModifiers()),

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/DocumentReferenceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/DocumentReferenceDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -19,9 +18,9 @@ public class DocumentReferenceDaoJdbc extends AbstractResourceDaoJdbc<DocumentRe
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, DocumentReference.class, "document_references",
 				"document_reference", "document_reference_id", DocumentReferenceIdentityFilter::new,
-				Arrays.asList(factory(DocumentReferenceIdentifier.PARAMETER_NAME, DocumentReferenceIdentifier::new,
+				List.of(factory(DocumentReferenceIdentifier.PARAMETER_NAME, DocumentReferenceIdentifier::new,
 						DocumentReferenceIdentifier.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/EndpointDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/EndpointDaoJdbc.java
@@ -4,7 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -30,9 +30,8 @@ public class EndpointDaoJdbc extends AbstractResourceDaoJdbc<Endpoint> implement
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Endpoint.class, "endpoints", "endpoint",
 				"endpoint_id", EndpointIdentityFilter::new,
-				Arrays.asList(
-						factory(EndpointAddress.PARAMETER_NAME, EndpointAddress::new,
-								EndpointAddress.getNameModifiers()),
+				List.of(factory(EndpointAddress.PARAMETER_NAME, EndpointAddress::new,
+						EndpointAddress.getNameModifiers()),
 						factory(EndpointIdentifier.PARAMETER_NAME, EndpointIdentifier::new,
 								EndpointIdentifier.getNameModifiers()),
 						factory(EndpointName.PARAMETER_NAME, EndpointName::new, EndpointName.getNameModifiers()),
@@ -40,7 +39,7 @@ public class EndpointDaoJdbc extends AbstractResourceDaoJdbc<Endpoint> implement
 								EndpointOrganization.getNameModifiers(), EndpointOrganization::new,
 								EndpointOrganization.getIncludeParameterValues()),
 						factory(EndpointStatus.PARAMETER_NAME, EndpointStatus::new, EndpointStatus.getNameModifiers())),
-				Arrays.asList(factory(OrganizationEndpointRevInclude::new,
+				List.of(factory(OrganizationEndpointRevInclude::new,
 						OrganizationEndpointRevInclude.getRevIncludeParameterValues())));
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/GroupDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/GroupDaoJdbc.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -18,9 +18,9 @@ public class GroupDaoJdbc extends AbstractResourceDaoJdbc<Group> implements Grou
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Group.class, "groups", "group_json", "group_id",
 				GroupIdentityFilter::new,
-				Arrays.asList(factory(GroupIdentifier.PARAMETER_NAME, GroupIdentifier::new,
+				List.of(factory(GroupIdentifier.PARAMETER_NAME, GroupIdentifier::new,
 						GroupIdentifier.getNameModifiers())),
-				Arrays.asList(factory(ResearchStudyEnrollmentRevInclude::new,
+				List.of(factory(ResearchStudyEnrollmentRevInclude::new,
 						ResearchStudyEnrollmentRevInclude.getRevIncludeParameterValues())));
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HealthcareServiceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HealthcareServiceDaoJdbc.java
@@ -12,6 +12,7 @@ import dev.dsf.fhir.dao.HealthcareServiceDao;
 import dev.dsf.fhir.search.filter.HealthcareServiceIdentityFilter;
 import dev.dsf.fhir.search.parameters.HealthcareServiceActive;
 import dev.dsf.fhir.search.parameters.HealthcareServiceIdentifier;
+import dev.dsf.fhir.search.parameters.HealthcareServiceName;
 
 public class HealthcareServiceDaoJdbc extends AbstractResourceDaoJdbc<HealthcareService> implements HealthcareServiceDao
 {
@@ -21,6 +22,8 @@ public class HealthcareServiceDaoJdbc extends AbstractResourceDaoJdbc<Healthcare
 		super(dataSource, permanentDeleteDataSource, fhirContext, HealthcareService.class, "healthcare_services",
 				"healthcare_service", "healthcare_service_id", HealthcareServiceIdentityFilter::new,
 				Arrays.asList(factory(HealthcareServiceActive.PARAMETER_NAME, HealthcareServiceActive::new),
+						factory(HealthcareServiceName.PARAMETER_NAME, HealthcareServiceName::new,
+								HealthcareServiceName.getNameModifiers()),
 						factory(HealthcareServiceIdentifier.PARAMETER_NAME, HealthcareServiceIdentifier::new,
 								HealthcareServiceIdentifier.getNameModifiers())),
 				Collections.emptyList());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HealthcareServiceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HealthcareServiceDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -21,12 +20,12 @@ public class HealthcareServiceDaoJdbc extends AbstractResourceDaoJdbc<Healthcare
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, HealthcareService.class, "healthcare_services",
 				"healthcare_service", "healthcare_service_id", HealthcareServiceIdentityFilter::new,
-				Arrays.asList(factory(HealthcareServiceActive.PARAMETER_NAME, HealthcareServiceActive::new),
+				List.of(factory(HealthcareServiceActive.PARAMETER_NAME, HealthcareServiceActive::new),
 						factory(HealthcareServiceName.PARAMETER_NAME, HealthcareServiceName::new,
 								HealthcareServiceName.getNameModifiers()),
 						factory(HealthcareServiceIdentifier.PARAMETER_NAME, HealthcareServiceIdentifier::new,
 								HealthcareServiceIdentifier.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HistroyDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/HistroyDaoJdbc.java
@@ -228,8 +228,8 @@ public class HistroyDaoJdbc implements HistoryDao, InitializingBean
 	{
 		String idSql = forId ? "id = ?" : null;
 		String typeSql = forResource ? "type = ?" : null;
-		String filterSql = filter.stream().filter(HistoryIdentityFilter::isDefined).map(f -> f.getFilterQuery())
-				.collect(Collectors.joining(" OR ", "(", ")"));
+		String filterSql = filter.stream().filter(HistoryIdentityFilter::isDefined)
+				.map(HistoryIdentityFilter::getFilterQuery).collect(Collectors.joining(" OR ", "(", ")"));
 		filterSql = "()".equals(filterSql) ? null : filterSql;
 
 		Stream<String> params = Stream.concat(atParameters.stream(), Stream.of(sinceParameter))

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LibraryDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LibraryDaoJdbc.java
@@ -15,6 +15,7 @@ import dev.dsf.fhir.dao.LibraryDao;
 import dev.dsf.fhir.search.filter.LibraryIdentityFilter;
 import dev.dsf.fhir.search.parameters.LibraryDate;
 import dev.dsf.fhir.search.parameters.LibraryIdentifier;
+import dev.dsf.fhir.search.parameters.LibraryName;
 import dev.dsf.fhir.search.parameters.LibraryStatus;
 import dev.dsf.fhir.search.parameters.LibraryUrl;
 import dev.dsf.fhir.search.parameters.LibraryVersion;
@@ -31,6 +32,7 @@ public class LibraryDaoJdbc extends AbstractResourceDaoJdbc<Library> implements 
 				Arrays.asList(factory(LibraryDate.PARAMETER_NAME, LibraryDate::new),
 						factory(LibraryIdentifier.PARAMETER_NAME, LibraryIdentifier::new,
 								LocationIdentifier.getNameModifiers()),
+						factory(LibraryName.PARAMETER_NAME, LibraryName::new, LibraryName.getNameModifiers()),
 						factory(LibraryStatus.PARAMETER_NAME, LibraryStatus::new, LibraryStatus.getNameModifiers()),
 						factory(LibraryUrl.PARAMETER_NAME, LibraryUrl::new, LibraryUrl.getNameModifiers()),
 						factory(LibraryVersion.PARAMETER_NAME, LibraryVersion::new, LibraryVersion.getNameModifiers())),

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LibraryDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LibraryDaoJdbc.java
@@ -2,8 +2,7 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -29,14 +28,14 @@ public class LibraryDaoJdbc extends AbstractResourceDaoJdbc<Library> implements 
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Library.class, "libraries", "library", "library_id",
 				LibraryIdentityFilter::new,
-				Arrays.asList(factory(LibraryDate.PARAMETER_NAME, LibraryDate::new),
+				List.of(factory(LibraryDate.PARAMETER_NAME, LibraryDate::new),
 						factory(LibraryIdentifier.PARAMETER_NAME, LibraryIdentifier::new,
 								LocationIdentifier.getNameModifiers()),
 						factory(LibraryName.PARAMETER_NAME, LibraryName::new, LibraryName.getNameModifiers()),
 						factory(LibraryStatus.PARAMETER_NAME, LibraryStatus::new, LibraryStatus.getNameModifiers()),
 						factory(LibraryUrl.PARAMETER_NAME, LibraryUrl::new, LibraryUrl.getNameModifiers()),
 						factory(LibraryVersion.PARAMETER_NAME, LibraryVersion::new, LibraryVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LocationDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LocationDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -19,11 +18,10 @@ public class LocationDaoJdbc extends AbstractResourceDaoJdbc<Location> implement
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Location.class, "locations", "location",
 				"location_id", LocationIdentityFilter::new,
-				Arrays.asList(
-						factory(LocationIdentifier.PARAMETER_NAME, LocationIdentifier::new,
-								LocationIdentifier.getNameModifiers()),
+				List.of(factory(LocationIdentifier.PARAMETER_NAME, LocationIdentifier::new,
+						LocationIdentifier.getNameModifiers()),
 						factory(LocationName.PARAMETER_NAME, LocationName::new, LocationName.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LocationDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/LocationDaoJdbc.java
@@ -11,14 +11,18 @@ import ca.uhn.fhir.context.FhirContext;
 import dev.dsf.fhir.dao.LocationDao;
 import dev.dsf.fhir.search.filter.LocationIdentityFilter;
 import dev.dsf.fhir.search.parameters.LocationIdentifier;
+import dev.dsf.fhir.search.parameters.LocationName;
 
 public class LocationDaoJdbc extends AbstractResourceDaoJdbc<Location> implements LocationDao
 {
 	public LocationDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource, FhirContext fhirContext)
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Location.class, "locations", "location",
-				"location_id", LocationIdentityFilter::new, Arrays.asList(factory(LocationIdentifier.PARAMETER_NAME,
-						LocationIdentifier::new, LocationIdentifier.getNameModifiers())),
+				"location_id", LocationIdentityFilter::new,
+				Arrays.asList(
+						factory(LocationIdentifier.PARAMETER_NAME, LocationIdentifier::new,
+								LocationIdentifier.getNameModifiers()),
+						factory(LocationName.PARAMETER_NAME, LocationName::new, LocationName.getNameModifiers())),
 				Collections.emptyList());
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/MeasureDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/MeasureDaoJdbc.java
@@ -2,8 +2,7 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -29,7 +28,7 @@ public class MeasureDaoJdbc extends AbstractResourceDaoJdbc<Measure> implements 
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Measure.class, "measures", "measure", "measure_id",
 				MeasureIdentityFilter::new,
-				Arrays.asList(factory(MeasureDate.PARAMETER_NAME, MeasureDate::new),
+				List.of(factory(MeasureDate.PARAMETER_NAME, MeasureDate::new),
 						factory(MeasureDependsOn.PARAMETER_NAME, MeasureDependsOn::new,
 								MeasureDependsOn.getNameModifiers(), MeasureDependsOn::new,
 								MeasureDependsOn.getIncludeParameterValues()),
@@ -39,7 +38,7 @@ public class MeasureDaoJdbc extends AbstractResourceDaoJdbc<Measure> implements 
 						factory(MeasureStatus.PARAMETER_NAME, MeasureStatus::new, MeasureStatus.getNameModifiers()),
 						factory(MeasureUrl.PARAMETER_NAME, MeasureUrl::new, MeasureUrl.getNameModifiers()),
 						factory(MeasureVersion.PARAMETER_NAME, MeasureVersion::new, MeasureVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/MeasureDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/MeasureDaoJdbc.java
@@ -16,6 +16,7 @@ import dev.dsf.fhir.search.filter.MeasureIdentityFilter;
 import dev.dsf.fhir.search.parameters.MeasureDate;
 import dev.dsf.fhir.search.parameters.MeasureDependsOn;
 import dev.dsf.fhir.search.parameters.MeasureIdentifier;
+import dev.dsf.fhir.search.parameters.MeasureName;
 import dev.dsf.fhir.search.parameters.MeasureStatus;
 import dev.dsf.fhir.search.parameters.MeasureUrl;
 import dev.dsf.fhir.search.parameters.MeasureVersion;
@@ -34,6 +35,7 @@ public class MeasureDaoJdbc extends AbstractResourceDaoJdbc<Measure> implements 
 								MeasureDependsOn.getIncludeParameterValues()),
 						factory(MeasureIdentifier.PARAMETER_NAME, MeasureIdentifier::new,
 								MeasureIdentifier.getNameModifiers()),
+						factory(MeasureName.PARAMETER_NAME, MeasureName::new, MeasureName.getNameModifiers()),
 						factory(MeasureStatus.PARAMETER_NAME, MeasureStatus::new, MeasureStatus.getNameModifiers()),
 						factory(MeasureUrl.PARAMETER_NAME, MeasureUrl::new, MeasureUrl.getNameModifiers()),
 						factory(MeasureVersion.PARAMETER_NAME, MeasureVersion::new, MeasureVersion.getNameModifiers())),

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/MeasureReportDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/MeasureReportDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -18,9 +17,9 @@ public class MeasureReportDaoJdbc extends AbstractResourceDaoJdbc<MeasureReport>
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, MeasureReport.class, "measure_reports",
 				"measure_report", "measure_report_id", MeasureReportIdentityFilter::new,
-				Arrays.asList(factory(MeasureReportIdentifier.PARAMETER_NAME, MeasureReportIdentifier::new,
+				List.of(factory(MeasureReportIdentifier.PARAMETER_NAME, MeasureReportIdentifier::new,
 						MeasureReportIdentifier.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/NamingSystemDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/NamingSystemDaoJdbc.java
@@ -4,8 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -30,12 +29,12 @@ public class NamingSystemDaoJdbc extends AbstractResourceDaoJdbc<NamingSystem> i
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, NamingSystem.class, "naming_systems", "naming_system",
 				"naming_system_id", NamingSystemIdentityFilter::new,
-				Arrays.asList(factory(NamingSystemDate.PARAMETER_NAME, NamingSystemDate::new),
+				List.of(factory(NamingSystemDate.PARAMETER_NAME, NamingSystemDate::new),
 						factory(NamingSystemName.PARAMETER_NAME, NamingSystemName::new,
 								NamingSystemName.getNameModifiers()),
 						factory(NamingSystemStatus.PARAMETER_NAME, NamingSystemStatus::new,
 								NamingSystemStatus.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/OrganizationAffiliationDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/OrganizationAffiliationDaoJdbc.java
@@ -5,7 +5,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -38,7 +37,7 @@ public class OrganizationAffiliationDaoJdbc extends AbstractResourceDaoJdbc<Orga
 		super(dataSource, permanentDeleteDataSource, fhirContext, OrganizationAffiliation.class,
 				"organization_affiliations", "organization_affiliation", "organization_affiliation_id",
 				OrganizationAffiliationIdentityFilter::new,
-				Arrays.asList(factory(OrganizationAffiliationActive.PARAMETER_NAME, OrganizationAffiliationActive::new),
+				List.of(factory(OrganizationAffiliationActive.PARAMETER_NAME, OrganizationAffiliationActive::new),
 						factory(OrganizationAffiliationEndpoint.PARAMETER_NAME, OrganizationAffiliationEndpoint::new,
 								OrganizationAffiliationEndpoint.getNameModifiers(),
 								OrganizationAffiliationEndpoint::new,
@@ -58,7 +57,7 @@ public class OrganizationAffiliationDaoJdbc extends AbstractResourceDaoJdbc<Orga
 								OrganizationAffiliationPrimaryOrganization.getIncludeParameterValues()),
 						factory(OrganizationAffiliationRole.PARAMETER_NAME, OrganizationAffiliationRole::new,
 								OrganizationAffiliationRole.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/OrganizationDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/OrganizationDaoJdbc.java
@@ -4,7 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -33,7 +33,7 @@ public class OrganizationDaoJdbc extends AbstractResourceDaoJdbc<Organization> i
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Organization.class, "organizations", "organization",
 				"organization_id", OrganizationIdentityFilter::new,
-				Arrays.asList(factory(OrganizationActive.PARAMETER_NAME, OrganizationActive::new),
+				List.of(factory(OrganizationActive.PARAMETER_NAME, OrganizationActive::new),
 						factory(OrganizationEndpoint.PARAMETER_NAME, OrganizationEndpoint::new,
 								OrganizationEndpoint.getNameModifiers(), OrganizationEndpoint::new,
 								OrganizationEndpoint.getIncludeParameterValues()),
@@ -43,9 +43,8 @@ public class OrganizationDaoJdbc extends AbstractResourceDaoJdbc<Organization> i
 								OrganizationName.getNameModifiers()),
 						factory(OrganizationType.PARAMETER_NAME, OrganizationType::new,
 								OrganizationType.getNameModifiers())),
-				Arrays.asList(
-						factory(EndpointOrganizationRevInclude::new,
-								EndpointOrganizationRevInclude.getRevIncludeParameterValues()),
+				List.of(factory(EndpointOrganizationRevInclude::new,
+						EndpointOrganizationRevInclude.getRevIncludeParameterValues()),
 						factory(OrganizationAffiliationPrimaryOrganizationRevInclude::new,
 								OrganizationAffiliationPrimaryOrganizationRevInclude.getRevIncludeParameterValues()),
 						factory(OrganizationAffiliationParticipatingOrganizationRevInclude::new,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/PatientDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/PatientDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -19,10 +18,10 @@ public class PatientDaoJdbc extends AbstractResourceDaoJdbc<Patient> implements 
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Patient.class, "patients", "patient", "patient_id",
 				PatientIdentityFilter::new,
-				Arrays.asList(factory(PatientActive.PARAMETER_NAME, PatientActive::new),
+				List.of(factory(PatientActive.PARAMETER_NAME, PatientActive::new),
 						factory(PatientIdentifier.PARAMETER_NAME, PatientIdentifier::new,
 								PatientIdentifier.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/PractitionerDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/PractitionerDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -19,10 +18,10 @@ public class PractitionerDaoJdbc extends AbstractResourceDaoJdbc<Practitioner> i
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Practitioner.class, "practitioners", "practitioner",
 				"practitioner_id", PractitionerIdentityFilter::new,
-				Arrays.asList(factory(PractitionerActive.PARAMETER_NAME, PractitionerActive::new),
+				List.of(factory(PractitionerActive.PARAMETER_NAME, PractitionerActive::new),
 						factory(PractitionerIdentifier.PARAMETER_NAME, PractitionerIdentifier::new,
 								PractitionerIdentifier.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/PractitionerRoleDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/PractitionerRoleDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -21,7 +20,7 @@ public class PractitionerRoleDaoJdbc extends AbstractResourceDaoJdbc<Practitione
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, PractitionerRole.class, "practitioner_roles",
 				"practitioner_role", "practitioner_role_id", PractitionerRoleIdentityFilter::new,
-				Arrays.asList(factory(PractitionerRoleActive.PARAMETER_NAME, PractitionerRoleActive::new),
+				List.of(factory(PractitionerRoleActive.PARAMETER_NAME, PractitionerRoleActive::new),
 						factory(PractitionerRoleIdentifier.PARAMETER_NAME, PractitionerRoleIdentifier::new,
 								PractitionerRoleIdentifier.getNameModifiers()),
 						factory(PractitionerRoleOrganization.PARAMETER_NAME, PractitionerRoleOrganization::new,
@@ -30,7 +29,7 @@ public class PractitionerRoleDaoJdbc extends AbstractResourceDaoJdbc<Practitione
 						factory(PractitionerRolePractitioner.PARAMETER_NAME, PractitionerRolePractitioner::new,
 								PractitionerRolePractitioner.getNameModifiers(), PractitionerRolePractitioner::new,
 								PractitionerRolePractitioner.getIncludeParameterValues())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ProvenanceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ProvenanceDaoJdbc.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -15,7 +15,7 @@ public class ProvenanceDaoJdbc extends AbstractResourceDaoJdbc<Provenance> imple
 	public ProvenanceDaoJdbc(DataSource dataSource, DataSource permanentDeleteDataSource, FhirContext fhirContext)
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Provenance.class, "provenances", "provenance",
-				"provenance_id", ProvenanceIdentityFilter::new, Collections.emptyList(), Collections.emptyList());
+				"provenance_id", ProvenanceIdentityFilter::new, List.of(), List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/QuestionnaireDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/QuestionnaireDaoJdbc.java
@@ -2,8 +2,7 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -28,7 +27,7 @@ public class QuestionnaireDaoJdbc extends AbstractResourceDaoJdbc<Questionnaire>
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Questionnaire.class, "questionnaires",
 				"questionnaire", "questionnaire_id", QuestionnaireIdentityFilter::new,
-				Arrays.asList(factory(QuestionnaireDate.PARAMETER_NAME, QuestionnaireDate::new),
+				List.of(factory(QuestionnaireDate.PARAMETER_NAME, QuestionnaireDate::new),
 						factory(QuestionnaireIdentifier.PARAMETER_NAME, QuestionnaireIdentifier::new,
 								QuestionnaireIdentifier.getNameModifiers()),
 						factory(QuestionnaireName.PARAMETER_NAME, QuestionnaireName::new,
@@ -39,7 +38,7 @@ public class QuestionnaireDaoJdbc extends AbstractResourceDaoJdbc<Questionnaire>
 								QuestionnaireUrl.getNameModifiers()),
 						factory(QuestionnaireVersion.PARAMETER_NAME, QuestionnaireVersion::new,
 								QuestionnaireVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/QuestionnaireDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/QuestionnaireDaoJdbc.java
@@ -15,6 +15,7 @@ import dev.dsf.fhir.dao.QuestionnaireDao;
 import dev.dsf.fhir.search.filter.QuestionnaireIdentityFilter;
 import dev.dsf.fhir.search.parameters.QuestionnaireDate;
 import dev.dsf.fhir.search.parameters.QuestionnaireIdentifier;
+import dev.dsf.fhir.search.parameters.QuestionnaireName;
 import dev.dsf.fhir.search.parameters.QuestionnaireStatus;
 import dev.dsf.fhir.search.parameters.QuestionnaireUrl;
 import dev.dsf.fhir.search.parameters.QuestionnaireVersion;
@@ -30,6 +31,8 @@ public class QuestionnaireDaoJdbc extends AbstractResourceDaoJdbc<Questionnaire>
 				Arrays.asList(factory(QuestionnaireDate.PARAMETER_NAME, QuestionnaireDate::new),
 						factory(QuestionnaireIdentifier.PARAMETER_NAME, QuestionnaireIdentifier::new,
 								QuestionnaireIdentifier.getNameModifiers()),
+						factory(QuestionnaireName.PARAMETER_NAME, QuestionnaireName::new,
+								QuestionnaireName.getNameModifiers()),
 						factory(QuestionnaireStatus.PARAMETER_NAME, QuestionnaireStatus::new,
 								QuestionnaireStatus.getNameModifiers()),
 						factory(QuestionnaireUrl.PARAMETER_NAME, QuestionnaireUrl::new,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/QuestionnaireResponseDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/QuestionnaireResponseDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -25,7 +24,7 @@ public class QuestionnaireResponseDaoJdbc extends AbstractResourceDaoJdbc<Questi
 		super(dataSource, permanentDeleteDataSource, fhirContext, QuestionnaireResponse.class,
 				"questionnaire_responses", "questionnaire_response", "questionnaire_response_id",
 				QuestionnaireResponseIdentityFilter::new,
-				Arrays.asList(factory(QuestionnaireResponseAuthored.PARAMETER_NAME, QuestionnaireResponseAuthored::new),
+				List.of(factory(QuestionnaireResponseAuthored.PARAMETER_NAME, QuestionnaireResponseAuthored::new),
 						factory(QuestionnaireResponseIdentifier.PARAMETER_NAME, QuestionnaireResponseIdentifier::new,
 								QuestionnaireResponseIdentifier.getNameModifiers()),
 						factory(QuestionnaireResponseQuestionnaire.PARAMETER_NAME,
@@ -38,7 +37,7 @@ public class QuestionnaireResponseDaoJdbc extends AbstractResourceDaoJdbc<Questi
 						factory(QuestionnaireResponseSubject.PARAMETER_NAME, QuestionnaireResponseSubject::new,
 								QuestionnaireResponseSubject.getNameModifiers(), QuestionnaireResponseSubject::new,
 								QuestionnaireResponseSubject.getIncludeParameterValues())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ResearchStudyDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ResearchStudyDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -20,10 +19,9 @@ public class ResearchStudyDaoJdbc extends AbstractResourceDaoJdbc<ResearchStudy>
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, ResearchStudy.class, "research_studies",
 				"research_study", "research_study_id", ResearchStudyIdentityFilter::new,
-				Arrays.asList(
-						factory(ResearchStudyEnrollment.PARAMETER_NAME, ResearchStudyEnrollment::new,
-								ResearchStudyEnrollment.getNameModifiers(), ResearchStudyEnrollment::new,
-								ResearchStudyEnrollment.getIncludeParameterValues()),
+				List.of(factory(ResearchStudyEnrollment.PARAMETER_NAME, ResearchStudyEnrollment::new,
+						ResearchStudyEnrollment.getNameModifiers(), ResearchStudyEnrollment::new,
+						ResearchStudyEnrollment.getIncludeParameterValues()),
 						factory(ResearchStudyIdentifier.PARAMETER_NAME, ResearchStudyIdentifier::new,
 								ResearchStudyIdentifier.getNameModifiers()),
 						factory(ResearchStudyPrincipalInvestigator.PARAMETER_NAME,
@@ -31,7 +29,7 @@ public class ResearchStudyDaoJdbc extends AbstractResourceDaoJdbc<ResearchStudy>
 								ResearchStudyPrincipalInvestigator.getNameModifiers(),
 								ResearchStudyPrincipalInvestigator::new,
 								ResearchStudyPrincipalInvestigator.getIncludeParameterValues())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/SubscriptionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/SubscriptionDaoJdbc.java
@@ -5,7 +5,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,16 +30,15 @@ public class SubscriptionDaoJdbc extends AbstractResourceDaoJdbc<Subscription> i
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Subscription.class, "subscriptions", "subscription",
 				"subscription_id", SubscriptionIdentityFilter::new,
-				Arrays.asList(
-						factory(SubscriptionCriteria.PARAMETER_NAME, SubscriptionCriteria::new,
-								SubscriptionCriteria.getNameModifiers()),
+				List.of(factory(SubscriptionCriteria.PARAMETER_NAME, SubscriptionCriteria::new,
+						SubscriptionCriteria.getNameModifiers()),
 						factory(SubscriptionPayload.PARAMETER_NAME, SubscriptionPayload::new,
 								SubscriptionPayload.getNameModifiers()),
 						factory(SubscriptionStatus.PARAMETER_NAME, SubscriptionStatus::new,
 								SubscriptionStatus.getNameModifiers()),
 						factory(SubscriptionType.PARAMETER_NAME, SubscriptionType::new,
 								SubscriptionType.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/TaskDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/TaskDaoJdbc.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.dao.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -22,13 +21,13 @@ public class TaskDaoJdbc extends AbstractResourceDaoJdbc<Task> implements TaskDa
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, Task.class, "tasks", "task", "task_id",
 				TaskIdentityFilter::new,
-				Arrays.asList(factory(TaskAuthoredOn.PARAMETER_NAME, TaskAuthoredOn::new),
+				List.of(factory(TaskAuthoredOn.PARAMETER_NAME, TaskAuthoredOn::new),
 						factory(TaskIdentifier.PARAMETER_NAME, TaskIdentifier::new, TaskIdentifier.getNameModifiers()),
 						factory(TaskModified.PARAMETER_NAME, TaskModified::new),
 						factory(TaskRequester.PARAMETER_NAME, TaskRequester::new, TaskRequester.getNameModifiers(),
 								TaskRequester::new, TaskRequester.getIncludeParameterValues()),
 						factory(TaskStatus.PARAMETER_NAME, TaskStatus::new, TaskStatus.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ValueSetDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ValueSetDaoJdbc.java
@@ -15,6 +15,7 @@ import dev.dsf.fhir.dao.ValueSetDao;
 import dev.dsf.fhir.search.filter.ValueSetIdentityFilter;
 import dev.dsf.fhir.search.parameters.ValueSetDate;
 import dev.dsf.fhir.search.parameters.ValueSetIdentifier;
+import dev.dsf.fhir.search.parameters.ValueSetName;
 import dev.dsf.fhir.search.parameters.ValueSetStatus;
 import dev.dsf.fhir.search.parameters.ValueSetUrl;
 import dev.dsf.fhir.search.parameters.ValueSetVersion;
@@ -30,6 +31,7 @@ public class ValueSetDaoJdbc extends AbstractResourceDaoJdbc<ValueSet> implement
 				Arrays.asList(factory(ValueSetDate.PARAMETER_NAME, ValueSetDate::new),
 						factory(ValueSetIdentifier.PARAMETER_NAME, ValueSetIdentifier::new,
 								ValueSetIdentifier.getNameModifiers()),
+						factory(ValueSetName.PARAMETER_NAME, ValueSetName::new, ValueSetName.getNameModifiers()),
 						factory(ValueSetStatus.PARAMETER_NAME, ValueSetStatus::new, ValueSetStatus.getNameModifiers()),
 						factory(ValueSetUrl.PARAMETER_NAME, ValueSetUrl::new, ValueSetUrl.getNameModifiers()),
 						factory(ValueSetVersion.PARAMETER_NAME, ValueSetVersion::new,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ValueSetDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/ValueSetDaoJdbc.java
@@ -2,8 +2,7 @@ package dev.dsf.fhir.dao.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -28,7 +27,7 @@ public class ValueSetDaoJdbc extends AbstractResourceDaoJdbc<ValueSet> implement
 	{
 		super(dataSource, permanentDeleteDataSource, fhirContext, ValueSet.class, "value_sets", "value_set",
 				"value_set_id", ValueSetIdentityFilter::new,
-				Arrays.asList(factory(ValueSetDate.PARAMETER_NAME, ValueSetDate::new),
+				List.of(factory(ValueSetDate.PARAMETER_NAME, ValueSetDate::new),
 						factory(ValueSetIdentifier.PARAMETER_NAME, ValueSetIdentifier::new,
 								ValueSetIdentifier.getNameModifiers()),
 						factory(ValueSetName.PARAMETER_NAME, ValueSetName::new, ValueSetName.getNameModifiers()),
@@ -36,7 +35,7 @@ public class ValueSetDaoJdbc extends AbstractResourceDaoJdbc<ValueSet> implement
 						factory(ValueSetUrl.PARAMETER_NAME, ValueSetUrl::new, ValueSetUrl.getNameModifiers()),
 						factory(ValueSetVersion.PARAMETER_NAME, ValueSetVersion::new,
 								ValueSetVersion.getNameModifiers())),
-				Collections.emptyList());
+				List.of());
 
 		readByUrl = new ReadByUrlDaoJdbc<>(this::getDataSource, this::getResource, getResourceTable(),
 				getResourceColumn());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ResponseGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/help/ResponseGenerator.java
@@ -210,7 +210,7 @@ public class ResponseGenerator
 		bundle.setType(BundleType.HISTORY);
 
 		if (!SummaryMode.COUNT.equals(summaryMode))
-			history.getEntries().stream().map(e -> toBundleEntryComponent(e)).forEach(bundle::addEntry);
+			history.getEntries().stream().map(this::toBundleEntryComponent).forEach(bundle::addEntry);
 
 		if (!errors.isEmpty())
 			bundle.addEntry(toBundleEntryComponent(toOperationOutcomeWarning(errors), SearchEntryMode.OUTCOME));
@@ -247,17 +247,13 @@ public class ResponseGenerator
 
 	private String toStatus(String method)
 	{
-		switch (method)
+		return switch (method)
 		{
-			case "POST":
-				return "201 Created";
-			case "PUT":
-				return "200 OK";
-			case "DELETE":
-				return "200 OK";
-			default:
-				throw new RuntimeException("Method " + method + " not supported");
-		}
+			case "POST" -> "201 Created";
+			case "PUT" -> "200 OK";
+			case "DELETE" -> "200 OK";
+			default -> throw new RuntimeException("Method " + method + " not supported");
+		};
 	}
 
 	private String toLocation(String resourceType, String id, String version)
@@ -943,94 +939,52 @@ public class ResponseGenerator
 
 	private IssueSeverity convert(ValidationMessage.IssueSeverity severity)
 	{
-		switch (severity)
+		return switch (severity)
 		{
-			case FATAL:
-				return IssueSeverity.FATAL;
-			case ERROR:
-				return IssueSeverity.ERROR;
-			case WARNING:
-				return IssueSeverity.WARNING;
-			case INFORMATION:
-				return IssueSeverity.INFORMATION;
-			case NULL:
-				return IssueSeverity.NULL;
-			default:
-				throw new RuntimeException("IssueSeverity " + severity + " not supported");
-		}
+			case FATAL -> IssueSeverity.FATAL;
+			case ERROR -> IssueSeverity.ERROR;
+			case WARNING -> IssueSeverity.WARNING;
+			case INFORMATION -> IssueSeverity.INFORMATION;
+			case NULL -> IssueSeverity.NULL;
+		};
 	}
 
 	private IssueType convert(ValidationMessage.IssueType type)
 	{
-		switch (type)
+		return switch (type)
 		{
-			case INVALID:
-				return IssueType.INVALID;
-			case STRUCTURE:
-				return IssueType.STRUCTURE;
-			case REQUIRED:
-				return IssueType.REQUIRED;
-			case VALUE:
-				return IssueType.VALUE;
-			case INVARIANT:
-				return IssueType.INVARIANT;
-			case SECURITY:
-				return IssueType.SECURITY;
-			case LOGIN:
-				return IssueType.LOGIN;
-			case UNKNOWN:
-				return IssueType.UNKNOWN;
-			case EXPIRED:
-				return IssueType.EXPIRED;
-			case FORBIDDEN:
-				return IssueType.FORBIDDEN;
-			case SUPPRESSED:
-				return IssueType.SUPPRESSED;
-			case PROCESSING:
-				return IssueType.PROCESSING;
-			case NOTSUPPORTED:
-				return IssueType.NOTSUPPORTED;
-			case DUPLICATE:
-				return IssueType.DUPLICATE;
-			case MULTIPLEMATCHES:
-				return IssueType.MULTIPLEMATCHES;
-			case NOTFOUND:
-				return IssueType.NOTFOUND;
-			case DELETED:
-				return IssueType.DELETED;
-			case TOOLONG:
-				return IssueType.TOOLONG;
-			case CODEINVALID:
-				return IssueType.CODEINVALID;
-			case EXTENSION:
-				return IssueType.EXTENSION;
-			case TOOCOSTLY:
-				return IssueType.TOOCOSTLY;
-			case BUSINESSRULE:
-				return IssueType.BUSINESSRULE;
-			case CONFLICT:
-				return IssueType.CONFLICT;
-			case TRANSIENT:
-				return IssueType.TRANSIENT;
-			case LOCKERROR:
-				return IssueType.LOCKERROR;
-			case NOSTORE:
-				return IssueType.NOSTORE;
-			case EXCEPTION:
-				return IssueType.EXCEPTION;
-			case TIMEOUT:
-				return IssueType.TIMEOUT;
-			case INCOMPLETE:
-				return IssueType.INCOMPLETE;
-			case THROTTLED:
-				return IssueType.THROTTLED;
-			case INFORMATIONAL:
-				return IssueType.INFORMATIONAL;
-			case NULL:
-				return IssueType.NULL;
-
-			default:
-				throw new RuntimeException("IssueType " + type + " not supported");
-		}
+			case INVALID -> IssueType.INVALID;
+			case STRUCTURE -> IssueType.STRUCTURE;
+			case REQUIRED -> IssueType.REQUIRED;
+			case VALUE -> IssueType.VALUE;
+			case INVARIANT -> IssueType.INVARIANT;
+			case SECURITY -> IssueType.SECURITY;
+			case LOGIN -> IssueType.LOGIN;
+			case UNKNOWN -> IssueType.UNKNOWN;
+			case EXPIRED -> IssueType.EXPIRED;
+			case FORBIDDEN -> IssueType.FORBIDDEN;
+			case SUPPRESSED -> IssueType.SUPPRESSED;
+			case PROCESSING -> IssueType.PROCESSING;
+			case NOTSUPPORTED -> IssueType.NOTSUPPORTED;
+			case DUPLICATE -> IssueType.DUPLICATE;
+			case MULTIPLEMATCHES -> IssueType.MULTIPLEMATCHES;
+			case NOTFOUND -> IssueType.NOTFOUND;
+			case DELETED -> IssueType.DELETED;
+			case TOOLONG -> IssueType.TOOLONG;
+			case CODEINVALID -> IssueType.CODEINVALID;
+			case EXTENSION -> IssueType.EXTENSION;
+			case TOOCOSTLY -> IssueType.TOOCOSTLY;
+			case BUSINESSRULE -> IssueType.BUSINESSRULE;
+			case CONFLICT -> IssueType.CONFLICT;
+			case TRANSIENT -> IssueType.TRANSIENT;
+			case LOCKERROR -> IssueType.LOCKERROR;
+			case NOSTORE -> IssueType.NOSTORE;
+			case EXCEPTION -> IssueType.EXCEPTION;
+			case TIMEOUT -> IssueType.TIMEOUT;
+			case INCOMPLETE -> IssueType.INCOMPLETE;
+			case THROTTLED -> IssueType.THROTTLED;
+			case INFORMATIONAL -> IssueType.INFORMATIONAL;
+			case NULL -> IssueType.NULL;
+		};
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/AtParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/AtParameter.java
@@ -1,21 +1,20 @@
 package dev.dsf.fhir.history;
 
-import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.parameters.basic.AbstractDateTimeParameter;
 
-public class AtParameter extends AbstractDateTimeParameter<DomainResource>
+public class AtParameter extends AbstractDateTimeParameter<Resource>
 {
 	public static final String PARAMETER_NAME = "_at";
 
 	public AtParameter()
 	{
-		super(PARAMETER_NAME, "last_updated");
+		super(Resource.class, PARAMETER_NAME, "last_updated", null);
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Resource resource)
 	{
 		// Not implemented for history
 		throw new UnsupportedOperationException();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/HistoryService.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/HistoryService.java
@@ -11,8 +11,8 @@ public interface HistoryService
 {
 	Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers);
 
-	Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers, Class<? extends Resource> resource);
+	Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers, Class<? extends Resource> resourceType);
 
-	Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers, Class<? extends Resource> resource,
+	Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers, Class<? extends Resource> resourceType,
 			String id);
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/HistoryServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/HistoryServiceImpl.java
@@ -82,8 +82,8 @@ public class HistoryServiceImpl implements HistoryService, InitializingBean
 	}
 
 	@Override
-	public Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers, Class<? extends Resource> resource,
-			String id)
+	public Bundle getHistory(Identity identity, UriInfo uri, HttpHeaders headers,
+			Class<? extends Resource> resourceType, String id)
 	{
 		MultivaluedMap<String, String> queryParameters = uri.getQueryParameters();
 
@@ -114,22 +114,22 @@ public class HistoryServiceImpl implements HistoryService, InitializingBean
 
 		String path = null;
 		History history;
-		if (resource == null && id == null)
+		if (resourceType == null && id == null)
 			history = exceptionHandler.handleSqlException(() -> historyDao.readHistory(
 					historyUserFilterFactory.getIdentityFilters(identity), pageAndCount, atParameters, sinceParameter));
-		else if (resource != null && id != null)
+		else if (resourceType != null && id != null)
 		{
 			history = exceptionHandler.handleSqlException(() -> historyDao.readHistory(
-					historyUserFilterFactory.getIdentityFilter(identity, resource), pageAndCount, atParameters,
-					sinceParameter, resource, parameterConverter.toUuid(getResourceTypeName(resource), id)));
-			path = resource.getAnnotation(ResourceDef.class).name();
+					historyUserFilterFactory.getIdentityFilter(identity, resourceType), pageAndCount, atParameters,
+					sinceParameter, resourceType, parameterConverter.toUuid(getResourceTypeName(resourceType), id)));
+			path = resourceType.getAnnotation(ResourceDef.class).name();
 		}
-		else if (resource != null)
+		else if (resourceType != null)
 		{
 			history = exceptionHandler.handleSqlException(
-					() -> historyDao.readHistory(historyUserFilterFactory.getIdentityFilter(identity, resource),
-							pageAndCount, atParameters, sinceParameter, resource));
-			path = resource.getAnnotation(ResourceDef.class).name();
+					() -> historyDao.readHistory(historyUserFilterFactory.getIdentityFilter(identity, resourceType),
+							pageAndCount, atParameters, sinceParameter, resourceType));
+			path = resourceType.getAnnotation(ResourceDef.class).name();
 		}
 		else
 			throw new WebApplicationException();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/SinceParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/history/SinceParameter.java
@@ -2,20 +2,19 @@ package dev.dsf.fhir.history;
 
 import java.util.List;
 
-import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameterError;
 import dev.dsf.fhir.search.SearchQueryParameterError.SearchQueryParameterErrorType;
 import dev.dsf.fhir.search.parameters.basic.AbstractDateTimeParameter;
 
-public class SinceParameter extends AbstractDateTimeParameter<DomainResource>
+public class SinceParameter extends AbstractDateTimeParameter<Resource>
 {
 	public static final String PARAMETER_NAME = "_since";
 
 	public SinceParameter()
 	{
-		super(PARAMETER_NAME, "last_updated");
+		super(Resource.class, PARAMETER_NAME, "last_updated", null);
 	}
 
 	@Override
@@ -39,7 +38,7 @@ public class SinceParameter extends AbstractDateTimeParameter<DomainResource>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	public boolean resourceMatches(Resource resource)
 	{
 		// Not implemented for history
 		throw new UnsupportedOperationException();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuery.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/SearchQuery.java
@@ -50,7 +50,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 		public static <R extends Resource> SearchQueryBuilder<R> create(Class<R> resourceType, String resourceTable,
 				String resourceColumn, int page, int count)
 		{
-			return new SearchQueryBuilder<R>(resourceType, resourceTable, resourceColumn, page, count);
+			return new SearchQueryBuilder<>(resourceType, resourceTable, resourceColumn, page, count);
 		}
 
 		private final Class<R> resourceType;
@@ -119,7 +119,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 
 		public SearchQuery<R> build()
 		{
-			return new SearchQuery<R>(resourceType, resourceTable, resourceColumn, identityFilter, page, count,
+			return new SearchQuery<>(resourceType, resourceTable, resourceColumn, identityFilter, page, count,
 					searchParameters, revIncludeParameters);
 		}
 	}
@@ -470,7 +470,8 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 
 		if (!sortParameters.isEmpty())
 		{
-			String values = sortParameters.stream().map(p -> p.getBundleUriQueryParameterValuePart())
+			String values = sortParameters.stream()
+					.map(SearchQuerySortParameterConfiguration::getBundleUriQueryParameterValuePart)
 					.collect(Collectors.joining(","));
 			bundleUri.replaceQueryParam(PARAMETER_SORT, values);
 		}
@@ -490,6 +491,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 		return bundleUri;
 	}
 
+	@Override
 	public Class<R> getResourceType()
 	{
 		return resourceType;
@@ -498,10 +500,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 	@Override
 	public void resloveReferencesForMatching(Resource resource, DaoProvider daoProvider) throws SQLException
 	{
-		if (resource == null)
-			return;
-
-		if (!getResourceType().isInstance(resource))
+		if (resource == null || !getResourceType().isInstance(resource))
 			return;
 
 		List<SQLException> exceptions = searchParameters.stream().filter(SearchQueryParameter::isDefined).map(p ->
@@ -528,10 +527,7 @@ public class SearchQuery<R extends Resource> implements DbSearchQuery, Matcher
 	@Override
 	public boolean matches(Resource resource)
 	{
-		if (resource == null)
-			return false;
-
-		if (!getResourceType().isInstance(resource))
+		if (resource == null || !getResourceType().isInstance(resource))
 			return false;
 
 		return searchParameters.stream().filter(SearchQueryParameter::isDefined).map(p -> p.matches(resource))

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionDate.java
@@ -13,6 +13,7 @@ public class ActivityDefinitionDate extends AbstractDateTimeParameter<ActivityDe
 
 	public ActivityDefinitionDate()
 	{
-		super(PARAMETER_NAME, "activity_definition->>'date'");
+		super(ActivityDefinition.class, PARAMETER_NAME, "activity_definition->>'date'",
+				fromDateTime(ActivityDefinition::hasDateElement, ActivityDefinition::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the activity definition")
 public class ActivityDefinitionIdentifier extends AbstractIdentifierParameter<ActivityDefinition>
 {
-	private static final String RESOURCE_COLUMN = "activity_definition";
-
 	public ActivityDefinitionIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof ActivityDefinition))
-			return false;
-
-		ActivityDefinition e = (ActivityDefinition) resource;
-
-		return identifierMatches(e.getIdentifier());
+		super(ActivityDefinition.class, "activity_definition",
+				listMatcher(ActivityDefinition::hasIdentifier, ActivityDefinition::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionName.java
@@ -1,91 +1,17 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Objects;
-
 import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractStringParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
 
-@SearchParameterDefinition(name = ActivityDefinitionName.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the activity definition")
-public class ActivityDefinitionName extends AbstractStringParameter<ActivityDefinition>
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the activity definition")
+public class ActivityDefinitionName extends AbstractNameParameter<ActivityDefinition>
 {
-	public static final String PARAMETER_NAME = "name";
-
 	public ActivityDefinitionName()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-			case CONTAINS:
-				return "lower(activity_definition->>'name') LIKE ?";
-			case EXACT:
-				return "activity_definition->>'name' = ?";
-			default:
-				return "";
-		}
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
-				return;
-			case CONTAINS:
-				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
-				return;
-			case EXACT:
-				statement.setString(parameterIndex, valueAndType.value);
-				return;
-		}
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof ActivityDefinition))
-			return false;
-
-		ActivityDefinition e = (ActivityDefinition) resource;
-
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				return e.getName() != null && e.getName().toLowerCase().startsWith(valueAndType.value.toLowerCase());
-			case CONTAINS:
-				return e.getName() != null && e.getName().toLowerCase().contains(valueAndType.value.toLowerCase());
-			case EXACT:
-				return Objects.equals(e.getName(), valueAndType.value);
-			default:
-				throw notDefined();
-		}
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "activity_definition->>'name'" + sortDirectionWithSpacePrefix;
+		super(ActivityDefinition.class, "activity_definition", ActivityDefinition::hasName,
+				ActivityDefinition::getName);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-status", type = SearchParamType.TOKEN, documentation = "The current status of the activity definition")
 public class ActivityDefinitionStatus extends AbstractStatusParameter<ActivityDefinition>
 {
-	private static final String RESOURCE_COLUMN = "activity_definition";
-
 	public ActivityDefinitionStatus()
 	{
-		super(RESOURCE_COLUMN, ActivityDefinition.class);
+		super(ActivityDefinition.class, "activity_definition");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionUrl.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
@@ -10,16 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-url", type = SearchParamType.URI, documentation = "The uri that identifies the activity definition")
 public class ActivityDefinitionUrl extends AbstractUrlAndVersionParameter<ActivityDefinition>
 {
-	private static final String RESOURCE_COLUMN = "activity_definition";
-
 	public ActivityDefinitionUrl()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof ActivityDefinition;
+		super(ActivityDefinition.class, "activity_definition");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ActivityDefinitionVersion.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ActivityDefinition-version", type = SearchParamType.TOKEN, documentation = "The business version of the activity definition")
 public class ActivityDefinitionVersion extends AbstractVersionParameter<ActivityDefinition>
 {
-	private static final String RESOURCE_COLUMN = "activity_definition";
-
 	public ActivityDefinitionVersion()
 	{
-		this(RESOURCE_COLUMN);
-	}
-
-	public ActivityDefinitionVersion(String resourceColumn)
-	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof ActivityDefinition;
+		super(ActivityDefinition.class, "activity_definition");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BinaryContentType.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BinaryContentType.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -20,13 +19,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class BinaryContentType extends AbstractTokenParameter<Binary>
 {
 	public static final String PARAMETER_NAME = "contentType";
-	private static final String RESOURCE_COLUMN = "binary_json";
 
 	private CodeType contentType;
 
 	public BinaryContentType()
 	{
-		super(PARAMETER_NAME);
+		super(Binary.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -54,9 +52,15 @@ public class BinaryContentType extends AbstractTokenParameter<Binary>
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->>'contentType' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "binary_json->>'contentType' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "binary_json->>'contentType' <> ?";
 	}
 
 	@Override
@@ -79,20 +83,15 @@ public class BinaryContentType extends AbstractTokenParameter<Binary>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Binary resource)
 	{
-		if (!(resource instanceof Binary))
-			return false;
-
-		if (valueAndType.negated)
-			return !((Binary) resource).getContentType().equals(contentType.getValue());
-		else
-			return ((Binary) resource).getContentType().equals(contentType.getValue());
+		return valueAndType.negated ^ resource.hasContentType()
+				&& resource.getContentType().equals(contentType.getValue());
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->>'contentType'" + sortDirectionWithSpacePrefix;
+		return "binary_json->>'contentType'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BundleIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/BundleIdentifier.java
@@ -1,102 +1,17 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
-import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractSingleIdentifierParameter;
 
-@SearchParameterDefinition(name = BundleIdentifier.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Bundle-identifier", type = SearchParamType.TOKEN, documentation = "Persistent identifier for the bundle")
-public class BundleIdentifier extends AbstractTokenParameter<Bundle>
+@SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Bundle-identifier", type = SearchParamType.TOKEN, documentation = "Persistent identifier for the bundle")
+public class BundleIdentifier extends AbstractSingleIdentifierParameter<Bundle>
 {
-	public static final String PARAMETER_NAME = "identifier";
-	private static final String RESOURCE_COLUMN = "bundle";
-
 	public BundleIdentifier()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		switch (valueAndType.type)
-		{
-			case CODE:
-			case CODE_AND_SYSTEM:
-			case SYSTEM:
-				return RESOURCE_COLUMN + "->'identifier' " + (valueAndType.negated ? "<>" : "=") + " ?::jsonb";
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				if (valueAndType.negated)
-					return RESOURCE_COLUMN + "->'identifier'->>'value' <> ? OR (" + RESOURCE_COLUMN
-							+ "->'identifier' ?? 'system')";
-				else
-					return RESOURCE_COLUMN + "->'identifier'->>'value' = ? AND NOT (" + RESOURCE_COLUMN
-							+ "->'identifier' ?? 'system')";
-			default:
-				return "";
-		}
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		switch (valueAndType.type)
-		{
-			case CODE:
-				statement.setString(parameterIndex, "{\"value\": \"" + valueAndType.codeValue + "\"}");
-				return;
-			case CODE_AND_SYSTEM:
-				statement.setString(parameterIndex, "{\"value\": \"" + valueAndType.codeValue + "\", \"system\": \""
-						+ valueAndType.systemValue + "\"}");
-				return;
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				statement.setString(parameterIndex, valueAndType.codeValue);
-				return;
-			case SYSTEM:
-				statement.setString(parameterIndex, "{\"system\": \"" + valueAndType.systemValue + "\"}");
-				return;
-		}
-	}
-
-	private boolean identifierMatches(Identifier identifier)
-	{
-		if (valueAndType.negated)
-			return !AbstractIdentifierParameter.identifierMatches(valueAndType, identifier);
-		else
-			return AbstractIdentifierParameter.identifierMatches(valueAndType, identifier);
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(" + RESOURCE_COLUMN + "->'identifier'->>'system')::text || (" + RESOURCE_COLUMN
-				+ "->'identifier'->>'value')::text" + sortDirectionWithSpacePrefix;
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Bundle))
-			return false;
-
-		Bundle e = (Bundle) resource;
-
-		return identifierMatches(e.getIdentifier());
+		super(Bundle.class, "bundle", singleMatcher(Bundle::hasIdentifier, Bundle::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemDate.java
@@ -13,6 +13,7 @@ public class CodeSystemDate extends AbstractDateTimeParameter<CodeSystem>
 
 	public CodeSystemDate()
 	{
-		super(PARAMETER_NAME, "(code_system->>'date')");
+		super(CodeSystem.class, PARAMETER_NAME, "code_system->>'date'",
+				fromDateTime(CodeSystem::hasDateElement, CodeSystem::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the code system")
 public class CodeSystemIdentifier extends AbstractIdentifierParameter<CodeSystem>
 {
-	private static final String RESOURCE_COLUMN = "code_system";
-
 	public CodeSystemIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof CodeSystem))
-			return false;
-
-		CodeSystem c = (CodeSystem) resource;
-
-		return identifierMatches(c.getIdentifier());
+		super(CodeSystem.class, "code_system", listMatcher(CodeSystem::hasIdentifier, CodeSystem::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the code system")
+public class CodeSystemName extends AbstractNameParameter<CodeSystem>
+{
+	public CodeSystemName()
+	{
+		super(CodeSystem.class, "code_system", CodeSystem::hasName, CodeSystem::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-status", type = SearchParamType.TOKEN, documentation = "The current status of the code system")
 public class CodeSystemStatus extends AbstractStatusParameter<CodeSystem>
 {
-	private static final String RESOURCE_COLUMN = "code_system";
-
 	public CodeSystemStatus()
 	{
-		super(RESOURCE_COLUMN, CodeSystem.class);
+		super(CodeSystem.class, "code_system");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemUrl.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
@@ -10,16 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-url", type = SearchParamType.URI, documentation = "The uri that identifies the code system")
 public class CodeSystemUrl extends AbstractUrlAndVersionParameter<CodeSystem>
 {
-	private static final String RESOURCE_COLUMN = "code_system";
-
 	public CodeSystemUrl()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof CodeSystem;
+		super(CodeSystem.class, "code_system");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/CodeSystemVersion.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/CodeSystem-version", type = SearchParamType.TOKEN, documentation = "The business version of the code system")
 public class CodeSystemVersion extends AbstractVersionParameter<CodeSystem>
 {
-	private static final String RESOURCE_COLUMN = "code_system";
-
 	public CodeSystemVersion()
 	{
-		this(RESOURCE_COLUMN);
-	}
-
-	public CodeSystemVersion(String resourceColumn)
-	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof CodeSystem;
+		super(CodeSystem.class, "code_system");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/DocumentReferenceIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/DocumentReferenceIdentifier.java
@@ -3,90 +3,71 @@ package dev.dsf.fhir.search.parameters;
 import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.Objects;
 
 import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
-import dev.dsf.fhir.search.parameters.basic.TokenValueAndSearchType;
 
 @SearchParameterDefinition(name = DocumentReferenceIdentifier.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/clinical-identifier", type = SearchParamType.TOKEN, documentation = "Identifies this document reference across multiple systems")
 public class DocumentReferenceIdentifier extends AbstractTokenParameter<DocumentReference>
 {
 	public static final String PARAMETER_NAME = "identifier";
-	private static final String RESOURCE_COLUMN = "document_reference";
 
 	public DocumentReferenceIdentifier()
 	{
-		super(PARAMETER_NAME);
+		super(DocumentReference.class, PARAMETER_NAME);
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case CODE:
-				if (valueAndType.negated)
-					return "NOT (" + RESOURCE_COLUMN + "->'identifier' @> ?::jsonb OR " + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'value' = ?)";
-				else
-					return "(" + RESOURCE_COLUMN + "->'identifier' @> ?::jsonb OR " + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'value' = ?)";
-			case CODE_AND_SYSTEM:
-				if (valueAndType.negated)
-					return "NOT (" + RESOURCE_COLUMN + "->'identifier' @> ?::jsonb OR (" + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'value' = ? AND " + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'system' = ?))";
-				else
-					return "(" + RESOURCE_COLUMN + "->'identifier' @> ?::jsonb OR (" + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'value' = ? AND " + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'system' = ?))";
-			case SYSTEM:
-				if (valueAndType.negated)
-					return "NOT (" + RESOURCE_COLUMN + "->'identifier' @> ?::jsonb OR " + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'system' = ?)";
-				else
-					return "(" + RESOURCE_COLUMN + "->'identifier' @> ?::jsonb OR " + RESOURCE_COLUMN
-							+ "->'masterIdentifier'->>'system' = ?)";
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				if (valueAndType.negated)
-					return "(SELECT count(*) FROM (" + "SELECT identifier FROM jsonb_array_elements(" + RESOURCE_COLUMN
-							+ "->'identifier') AS identifier UNION SELECT " + RESOURCE_COLUMN
-							+ "->'masterIdentifier') AS document_reference_identifiers "
-							+ "WHERE identifier->>'value' <> ? OR (identifier ?? 'system')" + ") > 0";
-				else
-					return "(SELECT count(*) FROM (" + "SELECT identifier FROM jsonb_array_elements(" + RESOURCE_COLUMN
-							+ "->'identifier') AS identifier UNION SELECT " + RESOURCE_COLUMN
-							+ "->'masterIdentifier') AS document_reference_identifiers "
-							+ "WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')" + ") > 0";
-			default:
-				return "";
-		}
+			case CODE ->
+				"(document_reference->'identifier' @> ?::jsonb OR document_reference->'masterIdentifier'->>'value' = ?)";
+			case CODE_AND_SYSTEM ->
+				"(document_reference->'identifier' @> ?::jsonb OR (document_reference->'masterIdentifier'->>'value' = ? AND document_reference->'masterIdentifier'->>'system' = ?))";
+			case SYSTEM ->
+				"(document_reference->'identifier' @> ?::jsonb OR document_reference->'masterIdentifier'->>'system' = ?)";
+			case CODE_AND_NO_SYSTEM_PROPERTY -> "(SELECT count(*) FROM ("
+					+ "SELECT identifier FROM jsonb_array_elements(document_reference->'identifier') AS identifier "
+					+ "UNION SELECT document_reference->'masterIdentifier') AS document_reference_identifiers "
+					+ "WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')" + ") > 0";
+		};
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return switch (valueAndType.type)
+		{
+			case CODE ->
+				"NOT (document_reference->'identifier' @> ?::jsonb OR document_reference->'masterIdentifier'->>'value' = ?)";
+			case CODE_AND_SYSTEM ->
+				"NOT (document_reference->'identifier' @> ?::jsonb OR (document_reference->'masterIdentifier'->>'value' = ? AND document_reference->'masterIdentifier'->>'system' = ?))";
+			case SYSTEM ->
+				"NOT (document_reference->'identifier' @> ?::jsonb OR document_reference->'masterIdentifier'->>'system' = ?)";
+			case CODE_AND_NO_SYSTEM_PROPERTY -> "(SELECT count(*) FROM ("
+					+ "SELECT identifier FROM jsonb_array_elements(document_reference->'identifier') AS identifier "
+					+ "UNION SELECT document_reference->'masterIdentifier') AS document_reference_identifiers "
+					+ "WHERE identifier->>'value' <> ? OR (identifier ?? 'system')" + ") > 0";
+		};
 	}
 
 	@Override
 	public int getSqlParameterCount()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case CODE:
-				return 2;
-			case CODE_AND_SYSTEM:
-				return 3;
-			case SYSTEM:
-				return 2;
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				return 1;
-			default:
-				throw notDefined();
-		}
+			case CODE -> 2;
+			case CODE_AND_SYSTEM -> 3;
+			case SYSTEM -> 2;
+			case CODE_AND_NO_SYSTEM_PROPERTY -> 1;
+		};
 	}
 
 	@Override
@@ -101,6 +82,7 @@ public class DocumentReferenceIdentifier extends AbstractTokenParameter<Document
 				else if (subqueryParameterIndex == 2)
 					statement.setString(parameterIndex, valueAndType.codeValue);
 				return;
+
 			case CODE_AND_SYSTEM:
 				if (subqueryParameterIndex == 1)
 					statement.setString(parameterIndex, "[{\"value\": \"" + valueAndType.codeValue
@@ -110,12 +92,14 @@ public class DocumentReferenceIdentifier extends AbstractTokenParameter<Document
 				else if (subqueryParameterIndex == 3)
 					statement.setString(parameterIndex, valueAndType.systemValue);
 				return;
+
 			case SYSTEM:
 				if (subqueryParameterIndex == 1)
 					statement.setString(parameterIndex, "[{\"system\": \"" + valueAndType.systemValue + "\"}]");
 				else if (subqueryParameterIndex == 2)
 					statement.setString(parameterIndex, valueAndType.systemValue);
 				return;
+
 			case CODE_AND_NO_SYSTEM_PROPERTY:
 				statement.setString(parameterIndex, valueAndType.codeValue);
 				return;
@@ -123,48 +107,29 @@ public class DocumentReferenceIdentifier extends AbstractTokenParameter<Document
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(DocumentReference resource)
 	{
-		if (!(resource instanceof DocumentReference))
-			return false;
-
-		DocumentReference d = (DocumentReference) resource;
-
-		return identifierMatches(d.getIdentifier())
-				|| (valueAndType.negated ? !identifierMatches(valueAndType, d.getMasterIdentifier())
-						: identifierMatches(valueAndType, d.getMasterIdentifier()));
+		return identifierMatches(resource) || masterIdentifierMatches(resource);
 	}
 
-	private boolean identifierMatches(List<Identifier> identifiers)
+	private boolean identifierMatches(DocumentReference r)
 	{
-		return identifiers.stream().anyMatch(
-				i -> valueAndType.negated ? !identifierMatches(valueAndType, i) : identifierMatches(valueAndType, i));
+		return r.hasIdentifier()
+				&& r.getIdentifier().stream().anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType));
 	}
 
-	private boolean identifierMatches(TokenValueAndSearchType valueAndType, Identifier identifier)
+	private boolean masterIdentifierMatches(DocumentReference r)
 	{
-		switch (valueAndType.type)
-		{
-			case CODE:
-				return Objects.equals(valueAndType.codeValue, identifier.getValue());
-			case CODE_AND_SYSTEM:
-				return Objects.equals(valueAndType.codeValue, identifier.getValue())
-						&& Objects.equals(valueAndType.systemValue, identifier.getSystem());
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				return Objects.equals(valueAndType.codeValue, identifier.getValue())
-						&& (identifier.getSystem() == null || identifier.getSystem().isBlank());
-			case SYSTEM:
-				return Objects.equals(valueAndType.systemValue, identifier.getSystem());
-			default:
-				return false;
-		}
+		return r.hasMasterIdentifier()
+				&& AbstractIdentifierParameter.identifierMatches(valueAndType, r.getMasterIdentifier());
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return "(SELECT string_agg((identifier->>'system')::text || (identifier->>'value')::text, ' ') FROM (SELECT identifier FROM jsonb_array_elements("
-				+ RESOURCE_COLUMN + "->'identifier') identifier " + "UNION SELECT " + RESOURCE_COLUMN
-				+ "->'masterIdentifier') AS document_reference_identifier)" + sortDirectionWithSpacePrefix;
+		return "(SELECT string_agg((identifier->>'system')::text || (identifier->>'value')::text, ' ') "
+				+ "FROM (SELECT identifier FROM jsonb_array_elements(document_reference->'identifier') identifier "
+				+ "UNION SELECT document_reference->'masterIdentifier') AS document_reference_identifier)"
+				+ sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointAddress.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointAddress.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -20,21 +19,17 @@ public class EndpointAddress extends AbstractCanonicalUrlParameter<Endpoint>
 
 	public EndpointAddress()
 	{
-		super(PARAMETER_NAME);
+		super(Endpoint.class, PARAMETER_NAME);
 	}
 
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case PRECISE:
-				return "endpoint->>'address' = ?";
-			case BELOW:
-				return "endpoint->>'address' LIKE ?";
-			default:
-				return "";
-		}
+			case PRECISE -> "endpoint->>'address' = ?";
+			case BELOW -> "endpoint->>'address' LIKE ?";
+		};
 	}
 
 	@Override
@@ -52,31 +47,21 @@ public class EndpointAddress extends AbstractCanonicalUrlParameter<Endpoint>
 			case PRECISE:
 				statement.setString(parameterIndex, valueAndType.url);
 				return;
+
 			case BELOW:
 				statement.setString(parameterIndex, valueAndType.url + "%");
-				return;
-			default:
 				return;
 		}
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Endpoint resource)
 	{
-		if (!(resource instanceof Endpoint))
-			return false;
-
-		Endpoint endpoint = (Endpoint) resource;
-
-		switch (valueAndType.type)
+		return resource.hasAddress() && switch (valueAndType.type)
 		{
-			case PRECISE:
-				return Objects.equals(endpoint.getAddress(), valueAndType.url);
-			case BELOW:
-				return endpoint.getAddress() != null && endpoint.getAddress().startsWith(valueAndType.url);
-			default:
-				throw notDefined();
-		}
+			case PRECISE -> Objects.equals(resource.getAddress(), valueAndType.url);
+			case BELOW -> resource.getAddress().startsWith(valueAndType.url);
+		};
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Endpoint-identifier", type = SearchParamType.TOKEN, documentation = "Identifies this endpoint across multiple systems")
 public class EndpointIdentifier extends AbstractIdentifierParameter<Endpoint>
 {
-	private static final String RESOURCE_COLUMN = "endpoint";
-
 	public EndpointIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Endpoint))
-			return false;
-
-		Endpoint e = (Endpoint) resource;
-
-		return identifierMatches(e.getIdentifier());
+		super(Endpoint.class, "endpoint", listMatcher(Endpoint::hasIdentifier, Endpoint::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointName.java
@@ -1,91 +1,16 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Objects;
-
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractStringParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
 
-@SearchParameterDefinition(name = EndpointName.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Endpoint-name", type = SearchParamType.STRING, documentation = "A name that this endpoint can be identified by")
-public class EndpointName extends AbstractStringParameter<Endpoint>
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Endpoint-name", type = SearchParamType.STRING, documentation = "A name that this endpoint can be identified by")
+public class EndpointName extends AbstractNameParameter<Endpoint>
 {
-	public static final String PARAMETER_NAME = "name";
-
 	public EndpointName()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-			case CONTAINS:
-				return "lower(endpoint->>'name') LIKE ?";
-			case EXACT:
-				return "endpoint->>'name' = ?";
-			default:
-				return "";
-		}
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
-				return;
-			case CONTAINS:
-				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
-				return;
-			case EXACT:
-				statement.setString(parameterIndex, valueAndType.value);
-				return;
-		}
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Endpoint))
-			return false;
-
-		Endpoint e = (Endpoint) resource;
-
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				return e.getName() != null && e.getName().toLowerCase().startsWith(valueAndType.value.toLowerCase());
-			case CONTAINS:
-				return e.getName() != null && e.getName().toLowerCase().contains(valueAndType.value.toLowerCase());
-			case EXACT:
-				return Objects.equals(e.getName(), valueAndType.value);
-			default:
-				throw notDefined();
-		}
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "endpoint->>'name'" + sortDirectionWithSpacePrefix;
+		super(Endpoint.class, "endpoint", Endpoint::hasName, Endpoint::getName);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointOrganization.java
@@ -49,30 +49,17 @@ public class EndpointOrganization extends AbstractReferenceParameter<Endpoint>
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "endpoint->'managingOrganization'->>'reference' = ?";
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"endpoint->'managingOrganization'->>'reference' = ?";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM jsonb_array_elements(" + IDENTIFIERS_SUBQUERY
-								+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM -> IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY -> "(SELECT count(*) FROM jsonb_array_elements(" + IDENTIFIERS_SUBQUERY
+						+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -142,37 +129,26 @@ public class EndpointOrganization extends AbstractReferenceParameter<Endpoint>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Endpoint resource)
 	{
-		if (!(resource instanceof Endpoint))
-			return false;
-
-		Endpoint e = (Endpoint) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (e.getManagingOrganization().getResource() instanceof Organization o)
-			{
+			if (resource.getManagingOrganization().getResource() instanceof Organization o)
 				return o.getIdentifier().stream()
-						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
-			}
+						.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 			else
 				return false;
 		}
 		else
 		{
-			String ref = e.getManagingOrganization().getReference();
-			switch (valueAndType.type)
+			String ref = resource.getManagingOrganization().getReference();
+			return switch (valueAndType.type)
 			{
-				case ID:
-					return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-				case RESOURCE_NAME_AND_ID:
-					return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-				case URL:
-					return ref.equals(valueAndType.url);
-				default:
-					return false;
-			}
+				case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+				case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+				case URL -> ref.equals(valueAndType.url);
+				default -> false;
+			};
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/EndpointStatus.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -22,13 +21,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class EndpointStatus extends AbstractTokenParameter<Endpoint>
 {
 	public static final String PARAMETER_NAME = "status";
-	private static final String RESOURCE_COLUMN = "endpoint";
 
 	private Endpoint.EndpointStatus status;
 
 	public EndpointStatus()
 	{
-		super(PARAMETER_NAME);
+		super(Endpoint.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -66,9 +64,15 @@ public class EndpointStatus extends AbstractTokenParameter<Endpoint>
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->>'status' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "endpoint->>'status' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "endpoint->>'status' <> ?";
 	}
 
 	@Override
@@ -91,20 +95,14 @@ public class EndpointStatus extends AbstractTokenParameter<Endpoint>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Endpoint resource)
 	{
-		if (!(resource instanceof Endpoint))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((Endpoint) resource).getStatus(), status);
-		else
-			return Objects.equals(((Endpoint) resource).getStatus(), status);
+		return valueAndType.negated ^ (resource.hasStatus() && Objects.equals(resource.getStatus(), status));
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->>'status'" + sortDirectionWithSpacePrefix;
+		return "endpoint->>'status'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/GroupIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/GroupIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Group;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Group-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the group")
 public class GroupIdentifier extends AbstractIdentifierParameter<Group>
 {
-	private static final String RESOURCE_COLUMN = "group_json";
-
 	public GroupIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Group))
-			return false;
-
-		Group l = (Group) resource;
-
-		return identifierMatches(l.getIdentifier());
+		super(Group.class, "group_json", listMatcher(Group::hasIdentifier, Group::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceActive.java
@@ -1,60 +1,17 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.HealthcareService;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractActiveParameter;
 
-@SearchParameterDefinition(name = HealthcareServiceActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/HealthcareService-active", type = SearchParamType.TOKEN, documentation = "The Healthcare Service is currently marked as active [true|false]")
-public class HealthcareServiceActive extends AbstractBooleanParameter<HealthcareService>
+@SearchParameterDefinition(name = AbstractActiveParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/HealthcareService-active", type = SearchParamType.TOKEN, documentation = "The Healthcare Service is currently marked as active [true|false]")
+public class HealthcareServiceActive extends AbstractActiveParameter<HealthcareService>
 {
-	public static final String PARAMETER_NAME = "active";
-
 	public HealthcareServiceActive()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		return "(healthcare_service->>'active')::BOOLEAN = ?";
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		statement.setBoolean(parameterIndex, value);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof HealthcareService))
-			return false;
-
-		HealthcareService h = (HealthcareService) resource;
-
-		return h.getActive() == value;
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(healthcare_service->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+		super(HealthcareService.class, "healthcare_service", HealthcareService::hasActive,
+				HealthcareService::getActive);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.HealthcareService;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/HealthcareService-identifier", type = SearchParamType.TOKEN, documentation = "External identifiers for this item")
 public class HealthcareServiceIdentifier extends AbstractIdentifierParameter<HealthcareService>
 {
-	private static final String RESOURCE_COLUMN = "healthcare_service";
-
 	public HealthcareServiceIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof HealthcareService))
-			return false;
-
-		HealthcareService h = (HealthcareService) resource;
-
-		return identifierMatches(h.getIdentifier());
+		super(HealthcareService.class, "healthcare_service",
+				listMatcher(HealthcareService::hasIdentifier, HealthcareService::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/HealthcareServiceName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.HealthcareService;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/HealthcareService-name", type = SearchParamType.STRING, documentation = "A portion of the Healthcare service name")
+public class HealthcareServiceName extends AbstractNameParameter<HealthcareService>
+{
+	public HealthcareServiceName()
+	{
+		super(HealthcareService.class, "healthcare_service", HealthcareService::hasName, HealthcareService::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryDate.java
@@ -13,6 +13,7 @@ public class LibraryDate extends AbstractDateTimeParameter<Library>
 
 	public LibraryDate()
 	{
-		super(PARAMETER_NAME, "library->>'date'");
+		super(Library.class, PARAMETER_NAME, "library->>'date'",
+				fromDateTime(Library::hasDateElement, Library::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the library")
 public class LibraryIdentifier extends AbstractIdentifierParameter<Library>
 {
-	private static final String RESOURCE_COLUMN = "library";
-
 	public LibraryIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Library))
-			return false;
-
-		Library l = (Library) resource;
-
-		return identifierMatches(l.getIdentifier());
+		super(Library.class, "library", listMatcher(Library::hasIdentifier, Library::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.Library;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the library")
+public class LibraryName extends AbstractNameParameter<Library>
+{
+	public LibraryName()
+	{
+		super(Library.class, "library", Library::hasName, Library::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-status", type = SearchParamType.TOKEN, documentation = "The current status of the library")
 public class LibraryStatus extends AbstractStatusParameter<Library>
 {
-	private static final String RESOURCE_COLUMN = "library";
-
 	public LibraryStatus()
 	{
-		super(RESOURCE_COLUMN, Library.class);
+		super(Library.class, "library");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryUrl.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
@@ -10,16 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-url", type = SearchParamType.URI, documentation = "The uri that identifies the library")
 public class LibraryUrl extends AbstractUrlAndVersionParameter<Library>
 {
-	private static final String RESOURCE_COLUMN = "library";
-
 	public LibraryUrl()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof Library;
+		super(Library.class, "library");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LibraryVersion.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Library-version", type = SearchParamType.TOKEN, documentation = "The business version of the library")
 public class LibraryVersion extends AbstractVersionParameter<Library>
 {
-	private static final String RESOURCE_COLUMN = "library";
-
 	public LibraryVersion()
 	{
-		this(RESOURCE_COLUMN);
-	}
-
-	public LibraryVersion(String resourceColumn)
-	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof Library;
+		super(Library.class, "library");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LocationIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LocationIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Location;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Location-identifier", type = SearchParamType.TOKEN, documentation = "An identifier for the location")
 public class LocationIdentifier extends AbstractIdentifierParameter<Location>
 {
-	private static final String RESOURCE_COLUMN = "location";
-
 	public LocationIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Location))
-			return false;
-
-		Location l = (Location) resource;
-
-		return identifierMatches(l.getIdentifier());
+		super(Location.class, "location", listMatcher(Location::hasIdentifier, Location::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LocationName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/LocationName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.Location;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameOrAliasParameter;
+
+@SearchParameterDefinition(name = AbstractNameOrAliasParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Location-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the library")
+public class LocationName extends AbstractNameOrAliasParameter<Location>
+{
+	public LocationName()
+	{
+		super(Location.class, "location", Location::hasName, Location::getName, Location::hasAlias, Location::getAlias);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureDate.java
@@ -13,6 +13,7 @@ public class MeasureDate extends AbstractDateTimeParameter<Measure>
 
 	public MeasureDate()
 	{
-		super(PARAMETER_NAME, "measure->>'date'");
+		super(Measure.class, PARAMETER_NAME, "measure->>'date'",
+				fromDateTime(Measure::hasDateElement, Measure::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureDependsOn.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureDependsOn.java
@@ -6,6 +6,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Measure;
@@ -79,14 +80,10 @@ public class MeasureDependsOn extends AbstractCanonicalReferenceParameter<Measur
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Measure resource)
 	{
-		if (!(resource instanceof Measure))
-			return false;
-
-		Measure o = (Measure) resource;
-
-		return o.getLibrary().stream().anyMatch(ref -> ref.equals(valueAndType.url));
+		return resource.hasLibrary() && resource.getLibrary().stream().filter(CanonicalType::hasValue)
+				.anyMatch(ref -> ref.equals(valueAndType.url));
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Measure;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the measure")
 public class MeasureIdentifier extends AbstractIdentifierParameter<Measure>
 {
-	private static final String RESOURCE_COLUMN = "measure";
-
 	public MeasureIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Measure))
-			return false;
-
-		Measure m = (Measure) resource;
-
-		return identifierMatches(m.getIdentifier());
+		super(Measure.class, "measure", listMatcher(Measure::hasIdentifier, Measure::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.Measure;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the measure")
+public class MeasureName extends AbstractNameParameter<Measure>
+{
+	public MeasureName()
+	{
+		super(Measure.class, "measure", Measure::hasName, Measure::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureReportIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureReportIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.MeasureReport;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/MeasureReport-identifier", type = SearchParamType.TOKEN, documentation = "External identifier of the measure report to be returned")
 public class MeasureReportIdentifier extends AbstractIdentifierParameter<MeasureReport>
 {
-	private static final String RESOURCE_COLUMN = "measure_report";
-
 	public MeasureReportIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof MeasureReport))
-			return false;
-
-		MeasureReport m = (MeasureReport) resource;
-
-		return identifierMatches(m.getIdentifier());
+		super(MeasureReport.class, "measure_report",
+				listMatcher(MeasureReport::hasIdentifier, MeasureReport::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-status", type = SearchParamType.TOKEN, documentation = "The current status of the measure")
 public class MeasureStatus extends AbstractStatusParameter<Measure>
 {
-	private static final String RESOURCE_COLUMN = "measure";
-
 	public MeasureStatus()
 	{
-		super(RESOURCE_COLUMN, Measure.class);
+		super(Measure.class, "measure");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureUrl.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Measure;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
@@ -10,16 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-url", type = SearchParamType.URI, documentation = "The uri that identifies the measure")
 public class MeasureUrl extends AbstractUrlAndVersionParameter<Measure>
 {
-	private static final String RESOURCE_COLUMN = "measure";
-
 	public MeasureUrl()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof Measure;
+		super(Measure.class, "measure");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/MeasureVersion.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Measure;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Measure-version", type = SearchParamType.TOKEN, documentation = "The business version of the measure")
 public class MeasureVersion extends AbstractVersionParameter<Measure>
 {
-	private static final String RESOURCE_COLUMN = "measure";
-
 	public MeasureVersion()
 	{
-		this(RESOURCE_COLUMN);
-	}
-
-	public MeasureVersion(String resourceColumn)
-	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof Measure;
+		super(Measure.class, "measure");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemDate.java
@@ -13,6 +13,7 @@ public class NamingSystemDate extends AbstractDateTimeParameter<NamingSystem>
 
 	public NamingSystemDate()
 	{
-		super(PARAMETER_NAME, "naming_system->>'date'");
+		super(NamingSystem.class, PARAMETER_NAME, "naming_system->>'date'",
+				fromDateTime(NamingSystem::hasDateElement, NamingSystem::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemName.java
@@ -1,91 +1,16 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Objects;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.NamingSystem;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractStringParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
 
-@SearchParameterDefinition(name = NamingSystemName.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/NamingSystem-name", type = SearchParamType.STRING, documentation = "A name that this NamingSystem can be identified by")
-public class NamingSystemName extends AbstractStringParameter<NamingSystem>
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the naming system")
+public class NamingSystemName extends AbstractNameParameter<NamingSystem>
 {
-	public static final String PARAMETER_NAME = "name";
-
 	public NamingSystemName()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-			case CONTAINS:
-				return "lower(naming_system->>'name') LIKE ?";
-			case EXACT:
-				return "naming_system->>'name' = ?";
-			default:
-				return "";
-		}
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
-				return;
-			case CONTAINS:
-				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
-				return;
-			case EXACT:
-				statement.setString(parameterIndex, valueAndType.value);
-				return;
-		}
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof NamingSystem))
-			return false;
-
-		NamingSystem n = (NamingSystem) resource;
-
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				return n.getName() != null && n.getName().toLowerCase().startsWith(valueAndType.value.toLowerCase());
-			case CONTAINS:
-				return n.getName() != null && n.getName().toLowerCase().contains(valueAndType.value.toLowerCase());
-			case EXACT:
-				return Objects.equals(n.getName(), valueAndType.value);
-			default:
-				throw notDefined();
-		}
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "naming_system->>'name'" + sortDirectionWithSpacePrefix;
+		super(NamingSystem.class, "naming_system", NamingSystem::hasName, NamingSystem::getName);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/NamingSystemStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/NamingSystem-status", type = SearchParamType.TOKEN, documentation = "The current status of the naming system")
 public class NamingSystemStatus extends AbstractStatusParameter<NamingSystem>
 {
-	private static final String RESOURCE_COLUMN = "naming_system";
-
 	public NamingSystemStatus()
 	{
-		super(RESOURCE_COLUMN, NamingSystem.class);
+		super(NamingSystem.class, "naming_system");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationActive.java
@@ -1,60 +1,16 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Organization;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractActiveParameter;
 
-@SearchParameterDefinition(name = OrganizationActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-active", type = SearchParamType.TOKEN, documentation = "Is the Organization record active [true|false]")
-public class OrganizationActive extends AbstractBooleanParameter<Organization>
+@SearchParameterDefinition(name = AbstractActiveParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-active", type = SearchParamType.TOKEN, documentation = "Is the Organization record active [true|false]")
+public class OrganizationActive extends AbstractActiveParameter<Organization>
 {
-	public static final String PARAMETER_NAME = "active";
-
 	public OrganizationActive()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		return "(organization->>'active')::BOOLEAN = ?";
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		statement.setBoolean(parameterIndex, value);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Organization))
-			return false;
-
-		Organization o = (Organization) resource;
-
-		return o.getActive() == value;
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(organization->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+		super(Organization.class, "organization", Organization::hasActive, Organization::getActive);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationActive.java
@@ -1,60 +1,17 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.OrganizationAffiliation;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractActiveParameter;
 
-@SearchParameterDefinition(name = OrganizationAffiliationActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-active", type = SearchParamType.TOKEN, documentation = "Whether this organization affiliation record is in active use [true|false]")
-public class OrganizationAffiliationActive extends AbstractBooleanParameter<OrganizationAffiliation>
+@SearchParameterDefinition(name = AbstractActiveParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-active", type = SearchParamType.TOKEN, documentation = "Whether this organization affiliation record is in active use [true|false]")
+public class OrganizationAffiliationActive extends AbstractActiveParameter<OrganizationAffiliation>
 {
-	public static final String PARAMETER_NAME = "active";
-
 	public OrganizationAffiliationActive()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		return "(organization_affiliation->>'active')::BOOLEAN = ?";
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		statement.setBoolean(parameterIndex, value);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof OrganizationAffiliation))
-			return false;
-
-		OrganizationAffiliation o = (OrganizationAffiliation) resource;
-
-		return o.getActive() == value;
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(organization_affiliation->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+		super(OrganizationAffiliation.class, "organization_affiliation", OrganizationAffiliation::hasActive,
+				OrganizationAffiliation::getActive);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.OrganizationAffiliation;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/OrganizationAffiliation-identifier", type = SearchParamType.TOKEN, documentation = "An organization affiliation's Identifier")
 public class OrganizationAffiliationIdentifier extends AbstractIdentifierParameter<OrganizationAffiliation>
 {
-	private static final String RESOURCE_COLUMN = "organization_affiliation";
-
 	public OrganizationAffiliationIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof OrganizationAffiliation))
-			return false;
-
-		OrganizationAffiliation o = (OrganizationAffiliation) resource;
-
-		return identifierMatches(o.getIdentifier());
+		super(OrganizationAffiliation.class, "organization_affiliation",
+				listMatcher(OrganizationAffiliation::hasIdentifier, OrganizationAffiliation::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationParticipatingOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationParticipatingOrganization.java
@@ -50,30 +50,17 @@ public class OrganizationAffiliationParticipatingOrganization
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "organization_affiliation->'participatingOrganization'->>'reference' = ?";
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"organization_affiliation->'participatingOrganization'->>'reference' = ?";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM jsonb_array_elements(" + IDENTIFIERS_SUBQUERY
-								+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM -> IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY -> "(SELECT count(*) FROM jsonb_array_elements(" + IDENTIFIERS_SUBQUERY
+						+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -144,37 +131,26 @@ public class OrganizationAffiliationParticipatingOrganization
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(OrganizationAffiliation resource)
 	{
-		if (!(resource instanceof OrganizationAffiliation))
-			return false;
-
-		OrganizationAffiliation oA = (OrganizationAffiliation) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (oA.getParticipatingOrganization().getResource() instanceof Organization o)
-			{
+			if (resource.getParticipatingOrganization().getResource() instanceof Organization o)
 				return o.getIdentifier().stream()
-						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
-			}
+						.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 			else
 				return false;
 		}
 		else
 		{
-			String ref = oA.getParticipatingOrganization().getReference();
-			switch (valueAndType.type)
+			String ref = resource.getParticipatingOrganization().getReference();
+			return switch (valueAndType.type)
 			{
-				case ID:
-					return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-				case RESOURCE_NAME_AND_ID:
-					return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-				case URL:
-					return ref.equals(valueAndType.url);
-				default:
-					return false;
-			}
+				case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+				case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+				case URL -> ref.equals(valueAndType.url);
+				default -> false;
+			};
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationPrimaryOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationPrimaryOrganization.java
@@ -49,30 +49,17 @@ public class OrganizationAffiliationPrimaryOrganization extends AbstractReferenc
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "organization_affiliation->'organization'->>'reference' = ?";
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"organization_affiliation->'organization'->>'reference' = ?";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM jsonb_array_elements(" + IDENTIFIERS_SUBQUERY
-								+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM -> IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY -> "(SELECT count(*) FROM jsonb_array_elements(" + IDENTIFIERS_SUBQUERY
+						+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -143,37 +130,26 @@ public class OrganizationAffiliationPrimaryOrganization extends AbstractReferenc
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(OrganizationAffiliation resource)
 	{
-		if (!(resource instanceof OrganizationAffiliation))
-			return false;
-
-		OrganizationAffiliation oA = (OrganizationAffiliation) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (oA.getOrganization().getResource() instanceof Organization o)
-			{
+			if (resource.getOrganization().getResource() instanceof Organization o)
 				return o.getIdentifier().stream()
-						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
-			}
+						.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 			else
 				return false;
 		}
 		else
 		{
-			String ref = oA.getOrganization().getReference();
-			switch (valueAndType.type)
+			String ref = resource.getOrganization().getReference();
+			return switch (valueAndType.type)
 			{
-				case ID:
-					return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-				case RESOURCE_NAME_AND_ID:
-					return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-				case URL:
-					return ref.equals(valueAndType.url);
-				default:
-					return false;
-			}
+				case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+				case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+				case URL -> ref.equals(valueAndType.url);
+				default -> false;
+			};
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationRole.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationAffiliationRole.java
@@ -6,7 +6,6 @@ import java.sql.SQLException;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.OrganizationAffiliation;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -16,39 +15,36 @@ import dev.dsf.fhir.search.parameters.basic.AbstractTokenParameter;
 public class OrganizationAffiliationRole extends AbstractTokenParameter<OrganizationAffiliation>
 {
 	public static final String PARAMETER_NAME = "role";
-	private static final String RESOURCE_COLUMN = "organization_affiliation";
 
 	public OrganizationAffiliationRole()
 	{
-		super(PARAMETER_NAME);
+		super(OrganizationAffiliation.class, PARAMETER_NAME);
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case CODE:
-			case CODE_AND_SYSTEM:
-			case SYSTEM:
-				if (valueAndType.negated)
-					return "NOT ((SELECT jsonb_agg(coding) FROM jsonb_array_elements(" + RESOURCE_COLUMN
-							+ "->'code') AS code, jsonb_array_elements(code->'coding') AS coding) @> ?::jsonb)";
-				else
-					return "(SELECT jsonb_agg(coding) FROM jsonb_array_elements(" + RESOURCE_COLUMN
-							+ "->'code') AS code, jsonb_array_elements(code->'coding') AS coding) @> ?::jsonb";
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				if (valueAndType.negated)
-					return "(SELECT COUNT(*) FROM jsonb_array_elements(" + RESOURCE_COLUMN
-							+ "->'code') AS code, jsonb_array_elements(code->'coding') AS coding "
-							+ "WHERE coding->>'code' <> ? OR (coding ?? 'system')) > 0";
-				else
-					return "(SELECT COUNT(*) FROM jsonb_array_elements(" + RESOURCE_COLUMN
-							+ "->'code') AS code, jsonb_array_elements(code->'coding') AS coding "
-							+ "WHERE coding->>'code' = ? AND NOT (coding ?? 'system')) > 0";
-			default:
-				return "";
-		}
+			case CODE, CODE_AND_SYSTEM, SYSTEM ->
+				"(SELECT jsonb_agg(coding) FROM jsonb_array_elements(organization_affiliation->'code') AS code, jsonb_array_elements(code->'coding') AS coding) @> ?::jsonb";
+			case CODE_AND_NO_SYSTEM_PROPERTY ->
+				"(SELECT COUNT(*) FROM jsonb_array_elements(organization_affiliation->'code') AS code, jsonb_array_elements(code->'coding') AS coding "
+						+ "WHERE coding->>'code' = ? AND NOT (coding ?? 'system')) > 0";
+		};
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return switch (valueAndType.type)
+		{
+			case CODE, CODE_AND_SYSTEM, SYSTEM ->
+				"NOT ((SELECT jsonb_agg(coding) FROM jsonb_array_elements(organization_affiliation->'code') AS code, jsonb_array_elements(code->'coding') AS coding) @> ?::jsonb)";
+			case CODE_AND_NO_SYSTEM_PROPERTY ->
+				"(SELECT COUNT(*) FROM jsonb_array_elements(organization_affiliation->'code') AS code, jsonb_array_elements(code->'coding') AS coding "
+						+ "WHERE coding->>'code' <> ? OR (coding ?? 'system')) > 0";
+		};
 	}
 
 	@Override
@@ -66,13 +62,16 @@ public class OrganizationAffiliationRole extends AbstractTokenParameter<Organiza
 			case CODE:
 				statement.setString(parameterIndex, "[{\"code\": \"" + valueAndType.codeValue + "\"}]");
 				return;
+
 			case CODE_AND_SYSTEM:
 				statement.setString(parameterIndex, "[{\"code\": \"" + valueAndType.codeValue + "\", \"system\": \""
 						+ valueAndType.systemValue + "\"}]");
 				return;
+
 			case CODE_AND_NO_SYSTEM_PROPERTY:
 				statement.setString(parameterIndex, valueAndType.codeValue);
 				return;
+
 			case SYSTEM:
 				statement.setString(parameterIndex, "[{\"system\": \"" + valueAndType.systemValue + "\"}]");
 				return;
@@ -82,18 +81,13 @@ public class OrganizationAffiliationRole extends AbstractTokenParameter<Organiza
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return "(SELECT string_agg((coding->>'system')::text || (coding->>'code')::text, ' ') FROM jsonb_array_elements("
-				+ RESOURCE_COLUMN + "->'code'->'coding') coding)" + sortDirectionWithSpacePrefix;
+		return "(SELECT string_agg((coding->>'system')::text || (coding->>'code')::text, ' ') FROM jsonb_array_elements(organization_affiliation->'code'->'coding') coding)"
+				+ sortDirectionWithSpacePrefix;
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(OrganizationAffiliation resource)
 	{
-		if (!(resource instanceof OrganizationAffiliation))
-			return false;
-
-		OrganizationAffiliation a = (OrganizationAffiliation) resource;
-
-		return codingMatches(a.getCode());
+		return resource.hasCode() && codingMatches(resource.getCode());
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationEndpoint.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationEndpoint.java
@@ -46,33 +46,22 @@ public class OrganizationEndpoint extends AbstractReferenceParameter<Organizatio
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "? IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization->'endpoint') AS reference)";
-
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"? IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization->'endpoint') AS reference)";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return "(SELECT jsonb_agg(identifier) FROM (SELECT identifier FROM current_endpoints, jsonb_array_elements(endpoint->'identifier') identifier"
-								+ " WHERE concat('Endpoint/', endpoint->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization->'endpoint') reference)"
-								+ " ) AS identifiers) @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM (SELECT identifier FROM current_endpoints, jsonb_array_elements(endpoint->'identifier') identifier"
-								+ " WHERE concat('Endpoint/', endpoint->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization->'endpoint') reference)"
-								+ " ) AS identifiers WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM ->
+					"(SELECT jsonb_agg(identifier) FROM (SELECT identifier FROM current_endpoints, jsonb_array_elements(endpoint->'identifier') identifier"
+							+ " WHERE concat('Endpoint/', endpoint->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization->'endpoint') reference)"
+							+ " ) AS identifiers) @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY ->
+					"(SELECT count(*) FROM (SELECT identifier FROM current_endpoints, jsonb_array_elements(endpoint->'identifier') identifier"
+							+ " WHERE concat('Endpoint/', endpoint->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(organization->'endpoint') reference)"
+							+ " ) AS identifiers WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -144,34 +133,25 @@ public class OrganizationEndpoint extends AbstractReferenceParameter<Organizatio
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Organization resource)
 	{
-		if (!(resource instanceof Organization))
-			return false;
-
-		Organization o = (Organization) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			return o.getEndpoint().stream().map(Reference::getResource).filter(r -> r instanceof Endpoint)
-					.flatMap(r -> ((Endpoint) r).getIdentifier().stream())
-					.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
+			return resource.getEndpoint().stream().map(Reference::getResource).filter(r -> r instanceof Endpoint)
+					.map(r -> (Endpoint) r).map(Endpoint::getIdentifier).flatMap(List::stream)
+					.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 		}
 		else
 		{
-			return o.getEndpoint().stream().map(Reference::getReference).anyMatch(ref ->
+			return resource.getEndpoint().stream().map(Reference::getReference).anyMatch(ref ->
 			{
-				switch (valueAndType.type)
+				return switch (valueAndType.type)
 				{
-					case ID:
-						return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-					case RESOURCE_NAME_AND_ID:
-						return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-					case URL:
-						return ref.equals(valueAndType.url);
-					default:
-						return false;
-				}
+					case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+					case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+					case URL -> ref.equals(valueAndType.url);
+					default -> false;
+				};
 			});
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Organization;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-identifier", type = SearchParamType.TOKEN, documentation = "Any identifier for the organization (not the accreditation issuer's identifier)")
 public class OrganizationIdentifier extends AbstractIdentifierParameter<Organization>
 {
-	private static final String RESOURCE_COLUMN = "organization";
-
 	public OrganizationIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Organization))
-			return false;
-
-		Organization o = (Organization) resource;
-
-		return identifierMatches(o.getIdentifier());
+		super(Organization.class, "organization",
+				listMatcher(Organization::hasIdentifier, Organization::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/OrganizationName.java
@@ -1,97 +1,17 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Objects;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Organization;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractStringParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameOrAliasParameter;
 
-@SearchParameterDefinition(name = OrganizationName.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-name", type = SearchParamType.STRING, documentation = "A portion of the organization's name or alias")
-public class OrganizationName extends AbstractStringParameter<Organization>
+@SearchParameterDefinition(name = AbstractNameOrAliasParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Organization-name", type = SearchParamType.STRING, documentation = "A portion of the organization's name or alias")
+public class OrganizationName extends AbstractNameOrAliasParameter<Organization>
 {
-	public static final String PARAMETER_NAME = "name";
-
 	public OrganizationName()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	// FIXME property alias is a list
-	@Override
-	public String getFilterQuery()
-	{
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-			case CONTAINS:
-				return "(lower(organization->>'name') LIKE ? OR lower(organization->>'alias') LIKE ?)";
-			case EXACT:
-				return "(organization->>'name' = ? OR organization->>'alias' = ?)";
-			default:
-				return "";
-		}
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 2;
-	}
-
-	// FIXME property alias is a list
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		// will be called twice, once with subqueryParameterIndex = 1 and once with subqueryParameterIndex = 2
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
-				return;
-			case CONTAINS:
-				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
-				return;
-			case EXACT:
-				statement.setString(parameterIndex, valueAndType.value);
-				return;
-		}
-	}
-
-	// FIXME match against aliases
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Organization))
-			return false;
-
-		Organization o = (Organization) resource;
-
-		switch (valueAndType.type)
-		{
-			case STARTS_WITH:
-				return o.getName() != null && o.getName().toLowerCase().startsWith(valueAndType.value.toLowerCase());
-			case CONTAINS:
-				return o.getName() != null && o.getName().toLowerCase().contains(valueAndType.value.toLowerCase());
-			case EXACT:
-				return Objects.equals(o.getName(), valueAndType.value);
-			default:
-				throw notDefined();
-		}
-	}
-
-	// FIXME property alias is a list
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "organization->>'name'" + sortDirectionWithSpacePrefix + ", organization->>'alias'"
-				+ sortDirectionWithSpacePrefix;
+		super(Organization.class, "organization", Organization::hasName, Organization::getName, Organization::hasAlias,
+				Organization::getAlias);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientActive.java
@@ -1,60 +1,16 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractActiveParameter;
 
-@SearchParameterDefinition(name = PatientActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Patient-active", type = SearchParamType.TOKEN, documentation = "Whether the patient record is active [true|false]")
-public class PatientActive extends AbstractBooleanParameter<Patient>
+@SearchParameterDefinition(name = AbstractActiveParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Patient-active", type = SearchParamType.TOKEN, documentation = "Whether the patient record is active [true|false]")
+public class PatientActive extends AbstractActiveParameter<Patient>
 {
-	public static final String PARAMETER_NAME = "active";
-
 	public PatientActive()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		return "(patient->>'active')::BOOLEAN = ?";
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		statement.setBoolean(parameterIndex, value);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Patient))
-			return false;
-
-		Patient p = (Patient) resource;
-
-		return p.getActive() == value;
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(patient->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+		super(Patient.class, "patient", Patient::hasActive, Patient::getActive);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PatientIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Patient-identifier", type = SearchParamType.TOKEN, documentation = "A patient identifier")
 public class PatientIdentifier extends AbstractIdentifierParameter<Patient>
 {
-	private static final String RESOURCE_COLUMN = "patient";
-
 	public PatientIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Patient))
-			return false;
-
-		Patient p = (Patient) resource;
-
-		return identifierMatches(p.getIdentifier());
+		super(Patient.class, "patient", listMatcher(Patient::hasIdentifier, Patient::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerActive.java
@@ -1,60 +1,16 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Practitioner;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractActiveParameter;
 
-@SearchParameterDefinition(name = PractitionerActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Practitioner-active", type = SearchParamType.TOKEN, documentation = "Whether the practitioner record is active [true|false]")
-public class PractitionerActive extends AbstractBooleanParameter<Practitioner>
+@SearchParameterDefinition(name = AbstractActiveParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Practitioner-active", type = SearchParamType.TOKEN, documentation = "Whether the practitioner record is active [true|false]")
+public class PractitionerActive extends AbstractActiveParameter<Practitioner>
 {
-	public static final String PARAMETER_NAME = "active";
-
 	public PractitionerActive()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		return "(practitioner->>'active')::BOOLEAN = ?";
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		statement.setBoolean(parameterIndex, value);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Practitioner))
-			return false;
-
-		Practitioner p = (Practitioner) resource;
-
-		return p.getActive() == value;
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(practitioner->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+		super(Practitioner.class, "practitioner", Practitioner::hasActive, Practitioner::getActive);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Practitioner;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Practitioner-identifier", type = SearchParamType.TOKEN, documentation = "A practitioner's Identifier")
 public class PractitionerIdentifier extends AbstractIdentifierParameter<Practitioner>
 {
-	private static final String RESOURCE_COLUMN = "practitioner";
-
 	public PractitionerIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Practitioner))
-			return false;
-
-		Practitioner p = (Practitioner) resource;
-
-		return identifierMatches(p.getIdentifier());
+		super(Practitioner.class, "practitioner",
+				listMatcher(Practitioner::hasIdentifier, Practitioner::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleActive.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleActive.java
@@ -1,60 +1,16 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.PractitionerRole;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
-import dev.dsf.fhir.search.parameters.basic.AbstractBooleanParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractActiveParameter;
 
-@SearchParameterDefinition(name = PractitionerRoleActive.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-active", type = SearchParamType.TOKEN, documentation = "Whether this practitioner role record is in active use [true|false]")
-public class PractitionerRoleActive extends AbstractBooleanParameter<PractitionerRole>
+@SearchParameterDefinition(name = AbstractActiveParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-active", type = SearchParamType.TOKEN, documentation = "Whether this practitioner role record is in active use [true|false]")
+public class PractitionerRoleActive extends AbstractActiveParameter<PractitionerRole>
 {
-	public static final String PARAMETER_NAME = "active";
-
 	public PractitionerRoleActive()
 	{
-		super(PARAMETER_NAME);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		return "(practitioner_role->>'active')::BOOLEAN = ?";
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		statement.setBoolean(parameterIndex, value);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof PractitionerRole))
-			return false;
-
-		PractitionerRole p = (PractitionerRole) resource;
-
-		return p.getActive() == value;
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(practitioner_role->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+		super(PractitionerRole.class, "practitioner_role", PractitionerRole::hasActive, PractitionerRole::getActive);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.PractitionerRole;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-identifier", type = SearchParamType.TOKEN, documentation = "A practitioner's Identifier")
 public class PractitionerRoleIdentifier extends AbstractIdentifierParameter<PractitionerRole>
 {
-	private static final String RESOURCE_COLUMN = "practitioner_role";
-
 	public PractitionerRoleIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof PractitionerRole))
-			return false;
-
-		PractitionerRole p = (PractitionerRole) resource;
-
-		return identifierMatches(p.getIdentifier());
+		super(PractitionerRole.class, "practitioner_role",
+				listMatcher(PractitionerRole::hasIdentifier, PractitionerRole::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleOrganization.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRoleOrganization.java
@@ -49,30 +49,18 @@ public class PractitionerRoleOrganization extends AbstractReferenceParameter<Pra
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "practitioner_role->'organization'->>'reference' = ?";
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"practitioner_role->'organization'->>'reference' = ?";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return PRACTITIONER_IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM jsonb_array_elements(" + PRACTITIONER_IDENTIFIERS_SUBQUERY
-								+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM -> PRACTITIONER_IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY ->
+					"(SELECT count(*) FROM jsonb_array_elements(" + PRACTITIONER_IDENTIFIERS_SUBQUERY
+							+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -143,37 +131,26 @@ public class PractitionerRoleOrganization extends AbstractReferenceParameter<Pra
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(PractitionerRole resource)
 	{
-		if (!(resource instanceof PractitionerRole))
-			return false;
-
-		PractitionerRole pR = (PractitionerRole) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (pR.getOrganization().getResource() instanceof Organization o)
-			{
+			if (resource.getOrganization().getResource() instanceof Organization o)
 				return o.getIdentifier().stream()
-						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
-			}
+						.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 			else
 				return false;
 		}
 		else
 		{
-			String ref = pR.getOrganization().getReference();
-			switch (valueAndType.type)
+			String ref = resource.getOrganization().getReference();
+			return switch (valueAndType.type)
 			{
-				case ID:
-					return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-				case RESOURCE_NAME_AND_ID:
-					return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-				case URL:
-					return ref.equals(valueAndType.url);
-				default:
-					return false;
-			}
+				case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+				case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+				case URL -> ref.equals(valueAndType.url);
+				default -> false;
+			};
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRolePractitioner.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/PractitionerRolePractitioner.java
@@ -49,30 +49,18 @@ public class PractitionerRolePractitioner extends AbstractReferenceParameter<Pra
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "practitioner_role->'practitioner'->>'reference' = ?";
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"practitioner_role->'practitioner'->>'reference' = ?";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return PRACTITIONER_IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM jsonb_array_elements(" + PRACTITIONER_IDENTIFIERS_SUBQUERY
-								+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM -> PRACTITIONER_IDENTIFIERS_SUBQUERY + " @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY ->
+					"(SELECT count(*) FROM jsonb_array_elements(" + PRACTITIONER_IDENTIFIERS_SUBQUERY
+							+ ") identifier WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -143,37 +131,26 @@ public class PractitionerRolePractitioner extends AbstractReferenceParameter<Pra
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(PractitionerRole resource)
 	{
-		if (!(resource instanceof PractitionerRole))
-			return false;
-
-		PractitionerRole pR = (PractitionerRole) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			if (pR.getPractitioner().getResource() instanceof Practitioner p)
-			{
+			if (resource.getPractitioner().getResource() instanceof Practitioner p)
 				return p.getIdentifier().stream()
-						.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
-			}
+						.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 			else
 				return false;
 		}
 		else
 		{
-			String ref = pR.getPractitioner().getReference();
-			switch (valueAndType.type)
+			String ref = resource.getPractitioner().getReference();
+			return switch (valueAndType.type)
 			{
-				case ID:
-					return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-				case RESOURCE_NAME_AND_ID:
-					return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-				case URL:
-					return ref.equals(valueAndType.url);
-				default:
-					return false;
-			}
+				case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+				case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+				case URL -> ref.equals(valueAndType.url);
+				default -> false;
+			};
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireDate.java
@@ -13,6 +13,7 @@ public class QuestionnaireDate extends AbstractDateTimeParameter<Questionnaire>
 
 	public QuestionnaireDate()
 	{
-		super(PARAMETER_NAME, "questionnaire->>'date'");
+		super(Questionnaire.class, PARAMETER_NAME, "questionnaire->>'date'",
+				fromDateTime(Questionnaire::hasDateElement, Questionnaire::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the questionnaire")
 public class QuestionnaireIdentifier extends AbstractIdentifierParameter<Questionnaire>
 {
-	private static final String RESOURCE_COLUMN = "questionnaire";
-
 	public QuestionnaireIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Questionnaire))
-			return false;
-
-		Questionnaire q = (Questionnaire) resource;
-
-		return identifierMatches(q.getIdentifier());
+		super(Questionnaire.class, "questionnaire",
+				listMatcher(Questionnaire::hasIdentifier, Questionnaire::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.Questionnaire;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the questionnaire")
+public class QuestionnaireName extends AbstractNameParameter<Questionnaire>
+{
+	public QuestionnaireName()
+	{
+		super(Questionnaire.class, "questionnaire", Questionnaire::hasName, Questionnaire::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseAuthored.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseAuthored.java
@@ -13,6 +13,7 @@ public class QuestionnaireResponseAuthored extends AbstractDateTimeParameter<Que
 
 	public QuestionnaireResponseAuthored()
 	{
-		super(PARAMETER_NAME, "questionnaire_response->>'authored'");
+		super(QuestionnaireResponse.class, PARAMETER_NAME, "questionnaire_response->>'authored'",
+				fromDateTime(QuestionnaireResponse::hasAuthoredElement, QuestionnaireResponse::getAuthoredElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseIdentifier.java
@@ -1,98 +1,18 @@
 package dev.dsf.fhir.search.parameters;
 
-import java.sql.Array;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
-import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
+import dev.dsf.fhir.search.parameters.basic.AbstractSingleIdentifierParameter;
 
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/QuestionnaireResponse-identifier", type = SearchParamType.TOKEN, documentation = "The unique identifier for the questionnaire response")
-public class QuestionnaireResponseIdentifier extends AbstractIdentifierParameter<QuestionnaireResponse>
+public class QuestionnaireResponseIdentifier extends AbstractSingleIdentifierParameter<QuestionnaireResponse>
 {
-	private static final String RESOURCE_COLUMN = "questionnaire_response";
-
 	public QuestionnaireResponseIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public String getFilterQuery()
-	{
-		switch (valueAndType.type)
-		{
-			case CODE:
-			case CODE_AND_SYSTEM:
-			case SYSTEM:
-				return "questionnaire_response->'identifier' " + (valueAndType.negated ? "<>" : "=") + " ?::jsonb";
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				if (valueAndType.negated)
-					return "questionnaire_response->'identifier'->>'value' <> ? OR (questionnaire_response->'identifier' ?? 'system')";
-				else
-					return "questionnaire_response->'identifier'->>'value' = ? AND NOT (questionnaire_response->'identifier' ?? 'system')";
-			default:
-				return "";
-		}
-	}
-
-	@Override
-	public int getSqlParameterCount()
-	{
-		return 1;
-	}
-
-	@Override
-	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
-			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
-	{
-		switch (valueAndType.type)
-		{
-			case CODE:
-				statement.setString(parameterIndex, "{\"value\": \"" + valueAndType.codeValue + "\"}");
-				return;
-			case CODE_AND_SYSTEM:
-				statement.setString(parameterIndex, "{\"value\": \"" + valueAndType.codeValue + "\", \"system\": \""
-						+ valueAndType.systemValue + "\"}");
-				return;
-			case CODE_AND_NO_SYSTEM_PROPERTY:
-				statement.setString(parameterIndex, valueAndType.codeValue);
-				return;
-			case SYSTEM:
-				statement.setString(parameterIndex, "{\"system\": \"" + valueAndType.systemValue + "\"}");
-				return;
-		}
-	}
-
-	private boolean identifierMatches(Identifier identifier)
-	{
-		if (valueAndType.negated)
-			return !AbstractIdentifierParameter.identifierMatches(valueAndType, identifier);
-		else
-			return AbstractIdentifierParameter.identifierMatches(valueAndType, identifier);
-	}
-
-	@Override
-	protected String getSortSql(String sortDirectionWithSpacePrefix)
-	{
-		return "(questionnaire_response->'identifier'->>'system')::text || (questionnaire_response->'identifier'->>'value')::text"
-				+ sortDirectionWithSpacePrefix;
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof QuestionnaireResponse))
-			return false;
-
-		QuestionnaireResponse qr = (QuestionnaireResponse) resource;
-
-		return identifierMatches(qr.getIdentifier());
+		super(QuestionnaireResponse.class, "questionnaire_response",
+				singleMatcher(QuestionnaireResponse::hasIdentifier, QuestionnaireResponse::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseQuestionnaire.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseQuestionnaire.java
@@ -70,14 +70,9 @@ public class QuestionnaireResponseQuestionnaire extends AbstractCanonicalReferen
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(QuestionnaireResponse resource)
 	{
-		if (!(resource instanceof QuestionnaireResponse))
-			return false;
-
-		QuestionnaireResponse qr = (QuestionnaireResponse) resource;
-
-		return qr.getQuestionnaire().equals(valueAndType.url);
+		return resource.hasQuestionnaire() && resource.getQuestionnaire().equals(valueAndType.url);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireResponseStatus.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -22,13 +21,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class QuestionnaireResponseStatus extends AbstractTokenParameter<QuestionnaireResponse>
 {
 	public static final String PARAMETER_NAME = "status";
-	private static final String RESOURCE_COLUMN = "questionnaire_response";
 
 	private QuestionnaireResponse.QuestionnaireResponseStatus status;
 
 	public QuestionnaireResponseStatus()
 	{
-		super(PARAMETER_NAME);
+		super(QuestionnaireResponse.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -66,9 +64,15 @@ public class QuestionnaireResponseStatus extends AbstractTokenParameter<Question
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->>'status' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "questionnaire_response->>'status' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "questionnaire_response->>'status' <> ?";
 	}
 
 	@Override
@@ -90,22 +94,15 @@ public class QuestionnaireResponseStatus extends AbstractTokenParameter<Question
 		return status.toCode();
 	}
 
-
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(QuestionnaireResponse resource)
 	{
-		if (!(resource instanceof QuestionnaireResponse))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((QuestionnaireResponse) resource).getStatus(), status);
-		else
-			return Objects.equals(((QuestionnaireResponse) resource).getStatus(), status);
+		return valueAndType.negated ^ (resource.hasStatus() && Objects.equals(resource.getStatus(), status));
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->>'status'" + sortDirectionWithSpacePrefix;
+		return "questionnaire_response->>'status'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-status", type = SearchParamType.TOKEN, documentation = "The current status of the questionnaire")
 public class QuestionnaireStatus extends AbstractStatusParameter<Questionnaire>
 {
-	private static final String RESOURCE_COLUMN = "questionnaire";
-
 	public QuestionnaireStatus()
 	{
-		super(RESOURCE_COLUMN, Questionnaire.class);
+		super(Questionnaire.class, "questionnaire");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireUrl.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
@@ -10,16 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-url", type = SearchParamType.URI, documentation = "The uri that identifies the questionnaire")
 public class QuestionnaireUrl extends AbstractUrlAndVersionParameter<Questionnaire>
 {
-	private static final String RESOURCE_COLUMN = "questionnaire";
-
 	public QuestionnaireUrl()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof Questionnaire;
+		super(Questionnaire.class, "questionnaire");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/QuestionnaireVersion.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Questionnaire-version", type = SearchParamType.TOKEN, documentation = "The business version of the questionnaire")
 public class QuestionnaireVersion extends AbstractVersionParameter<Questionnaire>
 {
-	private static final String RESOURCE_COLUMN = "questionnaire";
-
 	public QuestionnaireVersion()
 	{
-		this(RESOURCE_COLUMN);
-	}
-
-	public QuestionnaireVersion(String resourceColumn)
-	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof Questionnaire;
+		super(Questionnaire.class, "questionnaire");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyEnrollment.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyEnrollment.java
@@ -46,33 +46,22 @@ public class ResearchStudyEnrollment extends AbstractReferenceParameter<Research
 	@Override
 	public String getFilterQuery()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case ID:
-			case RESOURCE_NAME_AND_ID:
-			case URL:
-			case TYPE_AND_ID:
-			case TYPE_AND_RESOURCE_NAME_AND_ID:
-				return "? IN (SELECT reference->>'reference' FROM jsonb_array_elements(research_study->'enrollment') AS reference)";
-
-			case IDENTIFIER:
+			case ID, RESOURCE_NAME_AND_ID, URL, TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID ->
+				"? IN (SELECT reference->>'reference' FROM jsonb_array_elements(research_study->'enrollment') AS reference)";
+			case IDENTIFIER -> switch (valueAndType.identifier.type)
 			{
-				switch (valueAndType.identifier.type)
-				{
-					case CODE:
-					case CODE_AND_SYSTEM:
-					case SYSTEM:
-						return "(SELECT jsonb_agg(identifier) FROM (SELECT identifier FROM current_groups, jsonb_array_elements(group_json->'identifier') identifier"
-								+ " WHERE concat('Group/', group_json->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(research_study->'enrollment') reference)"
-								+ " ) AS identifiers) @> ?::jsonb";
-					case CODE_AND_NO_SYSTEM_PROPERTY:
-						return "(SELECT count(*) FROM (SELECT identifier FROM current_groups, jsonb_array_elements(group_json->'identifier') identifier"
-								+ " WHERE concat('Group/', group_json->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(research_study->'enrollment') reference)"
-								+ " ) AS identifiers WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
-				}
-			}
-		}
-		return "";
+				case CODE, CODE_AND_SYSTEM, SYSTEM ->
+					"(SELECT jsonb_agg(identifier) FROM (SELECT identifier FROM current_groups, jsonb_array_elements(group_json->'identifier') identifier"
+							+ " WHERE concat('Group/', group_json->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(research_study->'enrollment') reference)"
+							+ " ) AS identifiers) @> ?::jsonb";
+				case CODE_AND_NO_SYSTEM_PROPERTY ->
+					"(SELECT count(*) FROM (SELECT identifier FROM current_groups, jsonb_array_elements(group_json->'identifier') identifier"
+							+ " WHERE concat('Group/', group_json->>'id') IN (SELECT reference->>'reference' FROM jsonb_array_elements(research_study->'enrollment') reference)"
+							+ " ) AS identifiers WHERE identifier->>'value' = ? AND NOT (identifier ?? 'system')) > 0";
+			};
+		};
 	}
 
 	@Override
@@ -144,34 +133,25 @@ public class ResearchStudyEnrollment extends AbstractReferenceParameter<Research
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(ResearchStudy resource)
 	{
-		if (!(resource instanceof ResearchStudy))
-			return false;
-
-		ResearchStudy rs = (ResearchStudy) resource;
-
 		if (ReferenceSearchType.IDENTIFIER.equals(valueAndType.type))
 		{
-			return rs.getEnrollment().stream().map(Reference::getResource).filter(r -> r instanceof Group)
-					.flatMap(r -> ((Group) r).getIdentifier().stream())
-					.anyMatch(i -> AbstractIdentifierParameter.identifierMatches(valueAndType.identifier, i));
+			return resource.getEnrollment().stream().map(Reference::getResource).filter(r -> r instanceof Group)
+					.map(r -> (Group) r).map(Group::getIdentifier).flatMap(List::stream)
+					.anyMatch(AbstractIdentifierParameter.identifierMatches(valueAndType.identifier));
 		}
 		else
 		{
-			return rs.getEnrollment().stream().map(Reference::getReference).anyMatch(ref ->
+			return resource.getEnrollment().stream().map(Reference::getReference).anyMatch(ref ->
 			{
-				switch (valueAndType.type)
+				return switch (valueAndType.type)
 				{
-					case ID:
-						return ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
-					case RESOURCE_NAME_AND_ID:
-						return ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
-					case URL:
-						return ref.equals(valueAndType.url);
-					default:
-						return false;
-				}
+					case ID -> ref.equals(TARGET_RESOURCE_TYPE_NAME + "/" + valueAndType.id);
+					case RESOURCE_NAME_AND_ID -> ref.equals(valueAndType.resourceName + "/" + valueAndType.id);
+					case URL -> ref.equals(valueAndType.url);
+					default -> false;
+				};
 			});
 		}
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResearchStudyIdentifier.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.ResearchStudy;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
 import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
@@ -10,21 +9,9 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ResearchStudy-identifier", type = SearchParamType.TOKEN, documentation = "Business Identifier for study")
 public class ResearchStudyIdentifier extends AbstractIdentifierParameter<ResearchStudy>
 {
-	private static final String RESOURCE_COLUMN = "research_study";
-
 	public ResearchStudyIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof ResearchStudy))
-			return false;
-
-		ResearchStudy r = (ResearchStudy) resource;
-
-		return identifierMatches(r.getIdentifier());
+		super(ResearchStudy.class, "research_study",
+				listMatcher(ResearchStudy::hasIdentifier, ResearchStudy::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceId.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceId.java
@@ -24,11 +24,12 @@ public class ResourceId<R extends Resource> extends AbstractSearchParameter<R>
 	public static final String PARAMETER_NAME = "_id";
 
 	private final String resourceIdColumn;
+
 	private UUID id;
 
-	public ResourceId(String resourceIdColumn)
+	public ResourceId(Class<R> resourceType, String resourceIdColumn)
 	{
-		super(PARAMETER_NAME);
+		super(resourceType, PARAMETER_NAME);
 
 		this.resourceIdColumn = resourceIdColumn;
 	}
@@ -117,9 +118,10 @@ public class ResourceId<R extends Resource> extends AbstractSearchParameter<R>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(R resource)
 	{
-		return Objects.equals(resource.getId(), id.toString());
+		return resource.hasIdElement() && resource.getIdElement().hasIdPart()
+				&& Objects.equals(resource.getIdElement().getIdPart(), id.toString());
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceLastUpdated.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceLastUpdated.java
@@ -11,8 +11,9 @@ public class ResourceLastUpdated<R extends Resource> extends AbstractDateTimePar
 {
 	public static final String PARAMETER_NAME = "_lastUpdated";
 
-	public ResourceLastUpdated(String resourceColumn)
+	public ResourceLastUpdated(Class<R> resourceType, String resourceColumn)
 	{
-		super(PARAMETER_NAME, resourceColumn + "->'meta'->>'lastUpdated'");
+		super(resourceType, PARAMETER_NAME, resourceColumn + "->'meta'->>'lastUpdated'", fromInstant(
+				r -> r.hasMeta() && r.getMeta().hasLastUpdatedElement(), r -> r.getMeta().getLastUpdatedElement()));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceProfile.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ResourceProfile.java
@@ -18,9 +18,9 @@ public class ResourceProfile<R extends Resource> extends AbstractCanonicalUrlPar
 
 	private final String resourceColumn;
 
-	public ResourceProfile(String resourceColumn)
+	public ResourceProfile(Class<R> resourceType, String resourceColumn)
 	{
-		super(PARAMETER_NAME);
+		super(resourceType, PARAMETER_NAME);
 
 		this.resourceColumn = resourceColumn;
 	}
@@ -49,15 +49,11 @@ public class ResourceProfile<R extends Resource> extends AbstractCanonicalUrlPar
 	@Override
 	public int getSqlParameterCount()
 	{
-		switch (valueAndType.type)
+		return switch (valueAndType.type)
 		{
-			case PRECISE:
-				return valueAndType.version != null ? 1 : 2;
-			case BELOW:
-				return 1;
-			default:
-				return 0;
-		}
+			case PRECISE -> valueAndType.version != null ? 1 : 2;
+			case BELOW -> 1;
+		};
 	}
 
 	@Override
@@ -89,7 +85,7 @@ public class ResourceProfile<R extends Resource> extends AbstractCanonicalUrlPar
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(R resource)
 	{
 		switch (valueAndType.type)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionDate.java
@@ -18,6 +18,7 @@ public class StructureDefinitionDate extends AbstractDateTimeParameter<Structure
 
 	public StructureDefinitionDate(String resourceColumn)
 	{
-		super(PARAMETER_NAME, resourceColumn + "->>'date'");
+		super(StructureDefinition.class, PARAMETER_NAME, resourceColumn + "->>'date'",
+				fromDateTime(StructureDefinition::hasDateElement, StructureDefinition::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionIdentifier.java
@@ -11,8 +11,7 @@ public class StructureDefinitionIdentifier extends AbstractIdentifierParameter<S
 {
 	public StructureDefinitionIdentifier()
 	{
-		super(StructureDefinition.class, "structure_definition",
-				listMatcher(StructureDefinition::hasIdentifier, StructureDefinition::getIdentifier));
+		this("structure_definition");
 	}
 
 	public StructureDefinitionIdentifier(String resourceColumn)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionIdentifier.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StructureDefinition;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,26 +9,15 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the structure definition")
 public class StructureDefinitionIdentifier extends AbstractIdentifierParameter<StructureDefinition>
 {
-	private static final String RESOURCE_COLUMN = "structure_definition";
-
 	public StructureDefinitionIdentifier()
 	{
-		super(RESOURCE_COLUMN);
+		super(StructureDefinition.class, "structure_definition",
+				listMatcher(StructureDefinition::hasIdentifier, StructureDefinition::getIdentifier));
 	}
 
 	public StructureDefinitionIdentifier(String resourceColumn)
 	{
-		super(resourceColumn);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof StructureDefinition))
-			return false;
-
-		StructureDefinition s = (StructureDefinition) resource;
-
-		return identifierMatches(s.getIdentifier());
+		super(StructureDefinition.class, resourceColumn,
+				listMatcher(StructureDefinition::hasIdentifier, StructureDefinition::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionName.java
@@ -1,0 +1,21 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.StructureDefinition;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the structure definition")
+public class StructureDefinitionName extends AbstractNameParameter<StructureDefinition>
+{
+	public StructureDefinitionName()
+	{
+		this("structure_definition");
+	}
+
+	public StructureDefinitionName(String resourceColumn)
+	{
+		super(StructureDefinition.class, resourceColumn, StructureDefinition::hasName, StructureDefinition::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionStatus.java
@@ -9,15 +9,13 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-status", type = SearchParamType.TOKEN, documentation = "The current status of the structure definition")
 public class StructureDefinitionStatus extends AbstractStatusParameter<StructureDefinition>
 {
-	private static final String RESOURCE_COLUMN = "structure_definition";
-
 	public StructureDefinitionStatus()
 	{
-		this(RESOURCE_COLUMN);
+		this("structure_definition");
 	}
 
 	public StructureDefinitionStatus(String resourceColumn)
 	{
-		super(resourceColumn, StructureDefinition.class);
+		super(StructureDefinition.class, resourceColumn);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionUrl.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StructureDefinition;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,21 +9,13 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-url", type = SearchParamType.URI, documentation = "The uri that identifies the structure definition")
 public class StructureDefinitionUrl extends AbstractUrlAndVersionParameter<StructureDefinition>
 {
-	private static final String RESOURCE_COLUMN = "structure_definition";
-
 	public StructureDefinitionUrl()
 	{
-		this(RESOURCE_COLUMN);
+		this("structure_definition");
 	}
 
 	public StructureDefinitionUrl(String resourceColumn)
 	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof StructureDefinition;
+		super(StructureDefinition.class, resourceColumn);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/StructureDefinitionVersion.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StructureDefinition;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,21 +9,13 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/StructureDefinition-version", type = SearchParamType.TOKEN, documentation = "The business version of the structure definition")
 public class StructureDefinitionVersion extends AbstractVersionParameter<StructureDefinition>
 {
-	private static final String RESOURCE_COLUMN = "structure_definition";
-
 	public StructureDefinitionVersion()
 	{
-		this(RESOURCE_COLUMN);
+		this("structure_definition");
 	}
 
 	public StructureDefinitionVersion(String resourceColumn)
 	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof StructureDefinition;
+		super(StructureDefinition.class, resourceColumn);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionCriteria.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionCriteria.java
@@ -6,7 +6,6 @@ import java.sql.SQLException;
 import java.util.Objects;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Subscription;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
@@ -20,13 +19,17 @@ public class SubscriptionCriteria extends AbstractStringParameter<Subscription>
 
 	public SubscriptionCriteria()
 	{
-		super(PARAMETER_NAME);
+		super(Subscription.class, PARAMETER_NAME);
 	}
 
 	@Override
 	public String getFilterQuery()
 	{
-		return "subscription->>'criteria' = ?";
+		return switch (valueAndType.type)
+		{
+			case STARTS_WITH, CONTAINS -> "lower(subscription->>'criteria') LIKE ?";
+			case EXACT -> "subscription->>'criteria' = ?";
+		};
 	}
 
 	@Override
@@ -39,18 +42,36 @@ public class SubscriptionCriteria extends AbstractStringParameter<Subscription>
 	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
 			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
 	{
-		statement.setString(parameterIndex, valueAndType.value);
+		switch (valueAndType.type)
+		{
+			case STARTS_WITH:
+				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
+				return;
+
+			case CONTAINS:
+				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
+				return;
+
+			case EXACT:
+				statement.setString(parameterIndex, valueAndType.value);
+				return;
+		}
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Subscription resource)
 	{
-		if (!(resource instanceof Subscription))
-			return false;
+		return resource.hasCriteria() && criteriaMatches(resource.getCriteria());
+	}
 
-		Subscription s = (Subscription) resource;
-
-		return Objects.equals(valueAndType.value, s.getCriteria());
+	private boolean criteriaMatches(String criteria)
+	{
+		return switch (valueAndType.type)
+		{
+			case STARTS_WITH -> criteria.toLowerCase().startsWith(valueAndType.value.toLowerCase());
+			case CONTAINS -> criteria.toLowerCase().contains(valueAndType.value.toLowerCase());
+			case EXACT -> Objects.equals(criteria, valueAndType.value);
+		};
 	}
 
 	@Override
@@ -58,5 +79,4 @@ public class SubscriptionCriteria extends AbstractStringParameter<Subscription>
 	{
 		return "subscription->>'criteria'" + sortDirectionWithSpacePrefix;
 	}
-
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionPayload.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionPayload.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Subscription;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
@@ -20,13 +19,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class SubscriptionPayload extends AbstractTokenParameter<Subscription>
 {
 	public static final String PARAMETER_NAME = "payload";
-	private static final String RESOURCE_COLUMN = "subscription";
 
 	private String payloadMimeType;
 
 	public SubscriptionPayload()
 	{
-		super(PARAMETER_NAME);
+		super(Subscription.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -46,9 +44,15 @@ public class SubscriptionPayload extends AbstractTokenParameter<Subscription>
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->'channel'->>'payload' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "subscription->'channel'->>'payload' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "subscription->'channel'->>'payload' <> ?";
 	}
 
 	@Override
@@ -71,20 +75,15 @@ public class SubscriptionPayload extends AbstractTokenParameter<Subscription>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Subscription resource)
 	{
-		if (!(resource instanceof Subscription))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((Subscription) resource).getChannel().getPayload(), payloadMimeType);
-		else
-			return Objects.equals(((Subscription) resource).getChannel().getPayload(), payloadMimeType);
+		return valueAndType.negated ^ (resource.hasChannel() && resource.getChannel().hasPayload()
+				&& Objects.equals(resource.getChannel().getPayload(), payloadMimeType));
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->'channel'->>'payload'" + sortDirectionWithSpacePrefix;
+		return "subscription->'channel'->>'payload'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionStatus.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Subscription;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
@@ -22,13 +21,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class SubscriptionStatus extends AbstractTokenParameter<Subscription>
 {
 	public static final String PARAMETER_NAME = "status";
-	private static final String RESOURCE_COLUMN = "subscription";
 
 	private Subscription.SubscriptionStatus status;
 
 	public SubscriptionStatus()
 	{
-		super(PARAMETER_NAME);
+		super(Subscription.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -66,9 +64,15 @@ public class SubscriptionStatus extends AbstractTokenParameter<Subscription>
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->>'status' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "subscription->>'status' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "subscription->>'status' <> ?";
 	}
 
 	@Override
@@ -91,20 +95,14 @@ public class SubscriptionStatus extends AbstractTokenParameter<Subscription>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Subscription resource)
 	{
-		if (!(resource instanceof Subscription))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((Subscription) resource).getStatus(), status);
-		else
-			return Objects.equals(((Subscription) resource).getStatus(), status);
+		return valueAndType.negated ^ (resource.hasStatus() && Objects.equals(resource.getStatus(), status));
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->>'status'" + sortDirectionWithSpacePrefix;
+		return "subscription->>'status'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionType.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/SubscriptionType.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Subscription;
 import org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType;
 
@@ -23,13 +22,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class SubscriptionType extends AbstractTokenParameter<Subscription>
 {
 	public static final String PARAMETER_NAME = "type";
-	private static final String RESOURCE_COLUMN = "subscription";
 
 	private SubscriptionChannelType channelType;
 
 	public SubscriptionType()
 	{
-		super(PARAMETER_NAME);
+		super(Subscription.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -67,9 +65,15 @@ public class SubscriptionType extends AbstractTokenParameter<Subscription>
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->'channel'->>'type' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "subscription->'channel'->>'type' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "subscription->'channel'->>'type' <> ?";
 	}
 
 	@Override
@@ -92,20 +96,15 @@ public class SubscriptionType extends AbstractTokenParameter<Subscription>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Subscription resource)
 	{
-		if (!(resource instanceof Subscription))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((Subscription) resource).getChannel().getType(), channelType);
-		else
-			return Objects.equals(((Subscription) resource).getChannel().getType(), channelType);
+		return valueAndType.negated ^ (resource.hasChannel() && resource.getChannel().hasType()
+				&& Objects.equals(resource.getChannel().getType(), channelType));
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->'channel'->>'type'" + sortDirectionWithSpacePrefix;
+		return "subscription->'channel'->>'type'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskAuthoredOn.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskAuthoredOn.java
@@ -13,6 +13,7 @@ public class TaskAuthoredOn extends AbstractDateTimeParameter<Task>
 
 	public TaskAuthoredOn()
 	{
-		super(PARAMETER_NAME, "task->>'authoredOn'");
+		super(Task.class, PARAMETER_NAME, "task->>'authoredOn'",
+				fromDateTime(Task::hasAuthoredOnElement, Task::getAuthoredOnElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskIdentifier.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Task;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/Task-identifier", type = SearchParamType.TOKEN, documentation = "Search for a task instance by its business identifier")
 public class TaskIdentifier extends AbstractIdentifierParameter<Task>
 {
-	private static final String RESOURCE_COLUMN = "task";
-
 	public TaskIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof Task))
-			return false;
-
-		Task t = (Task) resource;
-
-		return identifierMatches(t.getIdentifier());
+		super(Task.class, "task", listMatcher(Task::hasIdentifier, Task::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskModified.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskModified.java
@@ -13,6 +13,7 @@ public class TaskModified extends AbstractDateTimeParameter<Task>
 
 	public TaskModified()
 	{
-		super(PARAMETER_NAME, "task->>'lastModified'");
+		super(Task.class, PARAMETER_NAME, "task->>'lastModified'",
+				fromDateTime(Task::hasLastModifiedElement, Task::getLastModifiedElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/TaskStatus.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Task;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
@@ -22,13 +21,12 @@ import dev.dsf.fhir.search.parameters.basic.TokenSearchType;
 public class TaskStatus extends AbstractTokenParameter<Task>
 {
 	public static final String PARAMETER_NAME = "status";
-	private static final String RESOURCE_COLUMN = "task";
 
 	private Task.TaskStatus status;
 
 	public TaskStatus()
 	{
-		super(PARAMETER_NAME);
+		super(Task.class, PARAMETER_NAME);
 	}
 
 	@Override
@@ -66,9 +64,15 @@ public class TaskStatus extends AbstractTokenParameter<Task>
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return RESOURCE_COLUMN + "->>'status' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return "task->>'status' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return "task->>'status' <> ?";
 	}
 
 	@Override
@@ -91,20 +95,14 @@ public class TaskStatus extends AbstractTokenParameter<Task>
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(Task resource)
 	{
-		if (!(resource instanceof Task))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((Task) resource).getStatus(), status);
-		else
-			return Objects.equals(((Task) resource).getStatus(), status);
+		return valueAndType.negated ^ (resource.hasStatus() && Objects.equals(resource.getStatus(), status));
 	}
 
 	@Override
 	protected String getSortSql(String sortDirectionWithSpacePrefix)
 	{
-		return RESOURCE_COLUMN + "->>'status'" + sortDirectionWithSpacePrefix;
+		return "task->>'status'" + sortDirectionWithSpacePrefix;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetDate.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetDate.java
@@ -13,6 +13,7 @@ public class ValueSetDate extends AbstractDateTimeParameter<ValueSet>
 
 	public ValueSetDate()
 	{
-		super(PARAMETER_NAME, "value_set->>'date'");
+		super(ValueSet.class, PARAMETER_NAME, "value_set->>'date'",
+				fromDateTime(ValueSet::hasDateElement, ValueSet::getDateElement));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetIdentifier.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetIdentifier.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ValueSet;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractIdentifierParameter;
 @SearchParameterDefinition(name = AbstractIdentifierParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-identifier", type = SearchParamType.TOKEN, documentation = "External identifier for the value set")
 public class ValueSetIdentifier extends AbstractIdentifierParameter<ValueSet>
 {
-	private static final String RESOURCE_COLUMN = "value_set";
-
 	public ValueSetIdentifier()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	public boolean matches(Resource resource)
-	{
-		if (!(resource instanceof ValueSet))
-			return false;
-
-		ValueSet v = (ValueSet) resource;
-
-		return identifierMatches(v.getIdentifier());
+		super(ValueSet.class, "value_set", listMatcher(ValueSet::hasIdentifier, ValueSet::getIdentifier));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetName.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetName.java
@@ -1,0 +1,16 @@
+package dev.dsf.fhir.search.parameters;
+
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.ValueSet;
+
+import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
+import dev.dsf.fhir.search.parameters.basic.AbstractNameParameter;
+
+@SearchParameterDefinition(name = AbstractNameParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/conformance-name", type = SearchParamType.STRING, documentation = "Computationally friendly name of the value set")
+public class ValueSetName extends AbstractNameParameter<ValueSet>
+{
+	public ValueSetName()
+	{
+		super(ValueSet.class, "value_set", ValueSet::hasName, ValueSet::getName);
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetStatus.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetStatus.java
@@ -9,10 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractStatusParameter;
 @SearchParameterDefinition(name = AbstractStatusParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-status", type = SearchParamType.TOKEN, documentation = "The current status of the value set")
 public class ValueSetStatus extends AbstractStatusParameter<ValueSet>
 {
-	private static final String RESOURCE_COLUMN = "value_set";
-
 	public ValueSetStatus()
 	{
-		super(RESOURCE_COLUMN, ValueSet.class);
+		super(ValueSet.class, "value_set");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetUrl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetUrl.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ValueSet;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,16 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractUrlAndVersionParameter;
 @SearchParameterDefinition(name = AbstractUrlAndVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-url", type = SearchParamType.URI, documentation = "The uri that identifies the value set")
 public class ValueSetUrl extends AbstractUrlAndVersionParameter<ValueSet>
 {
-	private static final String RESOURCE_COLUMN = "value_set";
-
 	public ValueSetUrl()
 	{
-		super(RESOURCE_COLUMN);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof ValueSet;
+		super(ValueSet.class, "value_set");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetVersion.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/ValueSetVersion.java
@@ -1,7 +1,6 @@
 package dev.dsf.fhir.search.parameters;
 
 import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
-import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ValueSet;
 
 import dev.dsf.fhir.search.SearchQueryParameter.SearchParameterDefinition;
@@ -10,21 +9,8 @@ import dev.dsf.fhir.search.parameters.basic.AbstractVersionParameter;
 @SearchParameterDefinition(name = AbstractVersionParameter.PARAMETER_NAME, definition = "http://hl7.org/fhir/SearchParameter/ValueSet-version", type = SearchParamType.TOKEN, documentation = "The business version of the value set")
 public class ValueSetVersion extends AbstractVersionParameter<ValueSet>
 {
-	private static final String RESOURCE_COLUMN = "value_set";
-
 	public ValueSetVersion()
 	{
-		this(RESOURCE_COLUMN);
-	}
-
-	public ValueSetVersion(String resourceColumn)
-	{
-		super(resourceColumn);
-	}
-
-	@Override
-	protected boolean instanceOf(Resource resource)
-	{
-		return resource instanceof ValueSet;
+		super(ValueSet.class, "value_set");
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractActiveParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractActiveParameter.java
@@ -1,0 +1,51 @@
+package dev.dsf.fhir.search.parameters.basic;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.hl7.fhir.r4.model.Resource;
+
+import dev.dsf.fhir.function.BiFunctionWithSqlException;
+
+public class AbstractActiveParameter<R extends Resource> extends AbstractBooleanParameter<R>
+{
+	public static final String PARAMETER_NAME = "active";
+
+	private final String resourceColumn;
+
+	public AbstractActiveParameter(Class<R> resourceType, String resourceColumn, Predicate<R> hasBoolean,
+			Function<R, Boolean> getBoolean)
+	{
+		super(resourceType, PARAMETER_NAME, hasBoolean, getBoolean);
+
+		this.resourceColumn = resourceColumn;
+	}
+
+	@Override
+	public String getFilterQuery()
+	{
+		return "(" + resourceColumn + "->>'active')::BOOLEAN = ?";
+	}
+
+	@Override
+	public int getSqlParameterCount()
+	{
+		return 1;
+	}
+
+	@Override
+	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
+			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
+	{
+		statement.setBoolean(parameterIndex, value);
+	}
+
+	@Override
+	protected String getSortSql(String sortDirectionWithSpacePrefix)
+	{
+		return "(" + resourceColumn + "->>'active')::BOOLEAN" + sortDirectionWithSpacePrefix;
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractBooleanParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractBooleanParameter.java
@@ -1,19 +1,28 @@
 package dev.dsf.fhir.search.parameters.basic;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
-import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameterError;
 import dev.dsf.fhir.search.SearchQueryParameterError.SearchQueryParameterErrorType;
 
-public abstract class AbstractBooleanParameter<R extends DomainResource> extends AbstractSearchParameter<R>
+public abstract class AbstractBooleanParameter<R extends Resource> extends AbstractSearchParameter<R>
 {
+	private final Predicate<R> hasBoolean;
+	private final Function<R, Boolean> getBoolean;
+
 	protected Boolean value;
 
-	public AbstractBooleanParameter(String parameterName)
+	public AbstractBooleanParameter(Class<R> resourceType, String parameterName, Predicate<R> hasBoolean,
+			Function<R, Boolean> getBoolean)
 	{
-		super(parameterName);
+		super(resourceType, parameterName);
+
+		this.hasBoolean = hasBoolean;
+		this.getBoolean = getBoolean;
 	}
 
 	@Override
@@ -55,5 +64,11 @@ public abstract class AbstractBooleanParameter<R extends DomainResource> extends
 	public String getBundleUriQueryParameterValue()
 	{
 		return String.valueOf(value);
+	}
+
+	@Override
+	protected boolean resourceMatches(R resource)
+	{
+		return hasBoolean.test(resource) && getBoolean.apply(resource) == value;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractCanonicalUrlParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractCanonicalUrlParameter.java
@@ -42,9 +42,9 @@ public abstract class AbstractCanonicalUrlParameter<R extends Resource> extends 
 
 	protected CanonicalUrlAndSearchType valueAndType;
 
-	public AbstractCanonicalUrlParameter(String parameterName)
+	public AbstractCanonicalUrlParameter(Class<R> resourceType, String parameterName)
 	{
-		super(parameterName);
+		super(resourceType, parameterName);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractDateTimeParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractDateTimeParameter.java
@@ -12,9 +12,13 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
@@ -82,15 +86,44 @@ public abstract class AbstractDateTimeParameter<R extends Resource> extends Abst
 	private static final DateTimeFormatter YEAR_FORMAT = DateTimeFormatter.ofPattern("yyyy");
 	private static final DateTimeFormatter YEAR_MONTH_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM");
 
+	private final String timestampColumn;
+	private final Function<R, Optional<java.util.Date>> getDate;
+
 	protected DateTimeValueAndTypeAndSearchType valueAndType;
 
-	private final String timestampColumn;
-
-	public AbstractDateTimeParameter(String parameterName, String timestampColumn)
+	public AbstractDateTimeParameter(Class<R> resourceType, String parameterName, String timestampColumn,
+			Function<R, Optional<java.util.Date>> getDate)
 	{
-		super(parameterName);
+		super(resourceType, parameterName);
 
 		this.timestampColumn = timestampColumn;
+		this.getDate = getDate;
+	}
+
+	protected static <R extends Resource> Function<R, Optional<java.util.Date>> fromInstant(Predicate<R> hasInstant,
+			Function<R, InstantType> getInstant)
+	{
+		return r ->
+		{
+			if (hasInstant.test(r))
+				return getInstant.andThen(Optional::of).apply(r).filter(InstantType::hasValue)
+						.map(InstantType::getValue);
+			else
+				return Optional.empty();
+		};
+	}
+
+	protected static <R extends Resource> Function<R, Optional<java.util.Date>> fromDateTime(Predicate<R> hasInstant,
+			Function<R, org.hl7.fhir.r4.model.DateTimeType> getDateTime)
+	{
+		return r ->
+		{
+			if (hasInstant.test(r))
+				return getDateTime.andThen(Optional::of).apply(r).filter(org.hl7.fhir.r4.model.DateTimeType::hasValue)
+						.map(org.hl7.fhir.r4.model.DateTimeType::getValue);
+			else
+				return Optional.empty();
+		};
 	}
 
 	@Override
@@ -207,8 +240,6 @@ public abstract class AbstractDateTimeParameter<R extends Resource> extends Abst
 			case LOCAL_DATE -> ((LocalDate) value.value).format(DATE_FORMAT);
 			case YEAR_PERIOD -> ((LocalDatePair) value.value).startInclusive.format(YEAR_FORMAT);
 			case YEAR_MONTH_PERIOD -> ((LocalDatePair) value.value).startInclusive.format(YEAR_MONTH_FORMAT);
-			default -> throw new IllegalArgumentException(
-					"Unexpected " + DateTimeType.class.getName() + " value: " + value.type);
 		};
 	}
 
@@ -220,8 +251,6 @@ public abstract class AbstractDateTimeParameter<R extends Resource> extends Abst
 			case ZONED_DATE_TIME -> getDateTimeQuery(valueAndType.searchType.operator);
 			case LOCAL_DATE -> getDateQuery(valueAndType.searchType.operator);
 			case YEAR_MONTH_PERIOD, YEAR_PERIOD -> getDatePairQuery();
-			default -> throw new IllegalArgumentException(
-					"Unexpected " + DateTimeType.class.getName() + " value: " + valueAndType.type);
 		};
 	}
 
@@ -247,8 +276,6 @@ public abstract class AbstractDateTimeParameter<R extends Resource> extends Abst
 		{
 			case ZONED_DATE_TIME, LOCAL_DATE -> 1;
 			case YEAR_MONTH_PERIOD, YEAR_PERIOD -> 2;
-			default -> throw new IllegalArgumentException(
-					"Unexpected " + DateTimeType.class.getName() + " value: " + valueAndType.type);
 		};
 	}
 
@@ -280,76 +307,50 @@ public abstract class AbstractDateTimeParameter<R extends Resource> extends Abst
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(R resource)
 	{
-		ZonedDateTime lastUpdated = toZonedDateTime(resource.getMeta().getLastUpdated());
-		return lastUpdated != null && matches(lastUpdated, valueAndType);
+		return getDate.apply(resource).map(this::matches).orElse(false);
 	}
 
-	private ZonedDateTime toZonedDateTime(java.util.Date date)
+	private boolean matches(java.util.Date date)
 	{
-		if (date == null)
-			return null;
-
-		return ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+		return matches(ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()), valueAndType);
 	}
 
-	private boolean matches(ZonedDateTime lastUpdated, DateTimeValueAndTypeAndSearchType value)
+	private boolean matches(ZonedDateTime zonedDateTime, DateTimeValueAndTypeAndSearchType value)
 	{
-		switch (value.type)
+		return switch (value.type)
 		{
-			case ZONED_DATE_TIME:
-				return matches(lastUpdated, (ZonedDateTime) value.value, value.searchType);
-			case LOCAL_DATE:
-				return matches(lastUpdated.toLocalDate(), (LocalDate) value.value, value.searchType);
-			case YEAR_MONTH_PERIOD:
-			case YEAR_PERIOD:
-				return matches(lastUpdated.toLocalDate(), (LocalDatePair) value.value);
-			default:
-				throw notDefined();
-		}
+			case ZONED_DATE_TIME -> matches(zonedDateTime, (ZonedDateTime) value.value, value.searchType);
+			case LOCAL_DATE -> matches(zonedDateTime.toLocalDate(), (LocalDate) value.value, value.searchType);
+			case YEAR_MONTH_PERIOD, YEAR_PERIOD -> matches(zonedDateTime.toLocalDate(), (LocalDatePair) value.value);
+		};
 	}
 
 	private boolean matches(ZonedDateTime lastUpdated, ZonedDateTime value, DateTimeSearchType type)
 	{
-		switch (type)
+		return switch (type)
 		{
-			case EQ:
-				return lastUpdated.equals(value);
-			case GT:
-				return lastUpdated.isAfter(value);
-			case GE:
-				return lastUpdated.isAfter(value) || lastUpdated.equals(value);
-			case LT:
-				return lastUpdated.isBefore(value);
-			case LE:
-				return lastUpdated.isBefore(value) || lastUpdated.equals(value);
-			case NE:
-				return !lastUpdated.isEqual(value);
-			default:
-				throw notDefined();
-		}
+			case EQ -> lastUpdated.equals(value);
+			case GT -> lastUpdated.isAfter(value);
+			case GE -> lastUpdated.isAfter(value) || lastUpdated.equals(value);
+			case LT -> lastUpdated.isBefore(value);
+			case LE -> lastUpdated.isBefore(value) || lastUpdated.equals(value);
+			case NE -> !lastUpdated.isEqual(value);
+		};
 	}
 
 	private boolean matches(LocalDate lastUpdated, LocalDate value, DateTimeSearchType type)
 	{
-		switch (type)
+		return switch (type)
 		{
-			case EQ:
-				return lastUpdated.equals(value);
-			case GT:
-				return lastUpdated.isAfter(value);
-			case GE:
-				return lastUpdated.isAfter(value) || lastUpdated.equals(value);
-			case LT:
-				return lastUpdated.isBefore(value);
-			case LE:
-				return lastUpdated.isBefore(value) || lastUpdated.equals(value);
-			case NE:
-				return !lastUpdated.isEqual(value);
-			default:
-				throw notDefined();
-		}
+			case EQ -> lastUpdated.equals(value);
+			case GT -> lastUpdated.isAfter(value);
+			case GE -> lastUpdated.isAfter(value) || lastUpdated.equals(value);
+			case LT -> lastUpdated.isBefore(value);
+			case LE -> lastUpdated.isBefore(value) || lastUpdated.equals(value);
+			case NE -> !lastUpdated.isEqual(value);
+		};
 	}
 
 	private boolean matches(LocalDate lastUpdated, LocalDatePair value)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractNameOrAliasParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractNameOrAliasParameter.java
@@ -1,0 +1,110 @@
+package dev.dsf.fhir.search.parameters.basic;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
+
+import dev.dsf.fhir.function.BiFunctionWithSqlException;
+
+//TODO
+public class AbstractNameOrAliasParameter<R extends Resource> extends AbstractStringParameter<R>
+{
+	public static final String PARAMETER_NAME = "name";
+
+	private final String resourceColumn;
+	private final Predicate<R> hasName;
+	private final Function<R, String> getName;
+	private final Predicate<R> hasAlias;
+	private final Function<R, List<StringType>> getAlias;
+
+	public AbstractNameOrAliasParameter(Class<R> resourceType, String resourceColumn, Predicate<R> hasName,
+			Function<R, String> getName, Predicate<R> hasAlias, Function<R, List<StringType>> getAlias)
+	{
+		super(resourceType, PARAMETER_NAME);
+
+		this.resourceColumn = resourceColumn;
+		this.hasName = hasName;
+		this.getName = getName;
+		this.hasAlias = hasAlias;
+		this.getAlias = getAlias;
+	}
+
+	@Override
+	public String getFilterQuery()
+	{
+		return switch (valueAndType.type)
+		{
+			case STARTS_WITH,
+					CONTAINS ->
+				"(lower(" + resourceColumn
+						+ "->>'name') LIKE ? OR EXISTS (SELECT 1 FROM (SELECT jsonb_array_elements_text("
+						+ resourceColumn + "->'alias') AS alias) AS aliases WHERE alias LIKE ?))";
+
+			case EXACT -> "(" + resourceColumn + "->>'name' = ? OR " + resourceColumn + "->'alias' ?? ?)";
+		};
+	}
+
+	@Override
+	public int getSqlParameterCount()
+	{
+		return 2;
+	}
+
+	@Override
+	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
+			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
+	{
+		switch (valueAndType.type)
+		{
+			case STARTS_WITH:
+				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
+				return;
+
+			case CONTAINS:
+				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
+				return;
+
+			case EXACT:
+				statement.setString(parameterIndex, valueAndType.value);
+				return;
+		}
+	}
+
+	@Override
+	protected boolean resourceMatches(R resource)
+	{
+		return (hasName.test(resource) && nameMatches(getName.apply(resource)))
+				|| (hasAlias.test(resource) && aliasMatches(resource));
+	}
+
+	private boolean aliasMatches(R resource)
+	{
+		return getAlias.apply(resource).stream().filter(StringType::hasValue).map(StringType::getValue)
+				.anyMatch(this::nameMatches);
+	}
+
+	private boolean nameMatches(String name)
+	{
+		return switch (valueAndType.type)
+		{
+			case STARTS_WITH -> name.toLowerCase().startsWith(valueAndType.value.toLowerCase());
+			case CONTAINS -> name.toLowerCase().contains(valueAndType.value.toLowerCase());
+			case EXACT -> Objects.equals(name, valueAndType.value);
+		};
+	}
+
+	@Override
+	protected String getSortSql(String sortDirectionWithSpacePrefix)
+	{
+		return "(SELECT array_agg(name) FROM (SELECT " + resourceColumn
+				+ "->>'name' AS name UNION SELECT jsonb_array_elements_text(" + resourceColumn
+				+ "->'alias') AS name) AS names)" + sortDirectionWithSpacePrefix;
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractNameParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractNameParameter.java
@@ -1,0 +1,89 @@
+package dev.dsf.fhir.search.parameters.basic;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.hl7.fhir.r4.model.Resource;
+
+import dev.dsf.fhir.function.BiFunctionWithSqlException;
+
+public class AbstractNameParameter<R extends Resource> extends AbstractStringParameter<R>
+{
+	public static final String PARAMETER_NAME = "name";
+
+	private final String resourceColumn;
+	private final Predicate<R> hasName;
+	private final Function<R, String> getName;
+
+	public AbstractNameParameter(Class<R> resourceType, String resourceColumn, Predicate<R> hasName,
+			Function<R, String> getName)
+	{
+		super(resourceType, PARAMETER_NAME);
+
+		this.resourceColumn = resourceColumn;
+		this.hasName = hasName;
+		this.getName = getName;
+	}
+
+	@Override
+	public String getFilterQuery()
+	{
+		return switch (valueAndType.type)
+		{
+			case STARTS_WITH, CONTAINS -> "lower(" + resourceColumn + "->>'name') LIKE ?";
+			case EXACT -> resourceColumn + "->>'name' = ?";
+		};
+	}
+
+	@Override
+	public int getSqlParameterCount()
+	{
+		return 1;
+	}
+
+	@Override
+	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
+			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
+	{
+		switch (valueAndType.type)
+		{
+			case STARTS_WITH:
+				statement.setString(parameterIndex, valueAndType.value.toLowerCase() + "%");
+				return;
+
+			case CONTAINS:
+				statement.setString(parameterIndex, "%" + valueAndType.value.toLowerCase() + "%");
+				return;
+
+			case EXACT:
+				statement.setString(parameterIndex, valueAndType.value);
+				return;
+		}
+	}
+
+	@Override
+	protected boolean resourceMatches(R resource)
+	{
+		return hasName.test(resource) && nameMatches(getName.apply(resource));
+	}
+
+	private boolean nameMatches(String name)
+	{
+		return switch (valueAndType.type)
+		{
+			case STARTS_WITH -> name.toLowerCase().startsWith(valueAndType.value.toLowerCase());
+			case CONTAINS -> name.toLowerCase().contains(valueAndType.value.toLowerCase());
+			case EXACT -> Objects.equals(name, valueAndType.value);
+		};
+	}
+
+	@Override
+	protected String getSortSql(String sortDirectionWithSpacePrefix)
+	{
+		return resourceColumn + "->>'name'" + sortDirectionWithSpacePrefix;
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractReferenceParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractReferenceParameter.java
@@ -173,16 +173,14 @@ public abstract class AbstractReferenceParameter<R extends DomainResource> exten
 		}
 	}
 
-	private final Class<R> resourceType;
 	private final List<String> targetResourceTypeNames;
 
 	protected ReferenceValueAndSearchType valueAndType;
 
 	public AbstractReferenceParameter(Class<R> resourceType, String parameterName, String... targetResourceTypeNames)
 	{
-		super(parameterName);
+		super(resourceType, parameterName);
 
-		this.resourceType = resourceType;
 		this.targetResourceTypeNames = Arrays.asList(targetResourceTypeNames);
 	}
 
@@ -208,8 +206,6 @@ public abstract class AbstractReferenceParameter<R extends DomainResource> exten
 			case ID, URL, RESOURCE_NAME_AND_ID -> parameterName;
 			case TYPE_AND_ID, TYPE_AND_RESOURCE_NAME_AND_ID -> parameterName + ":" + valueAndType.resourceName;
 			case IDENTIFIER -> parameterName + PARAMETER_NAME_IDENTIFIER_MODIFIER;
-			default -> throw new IllegalArgumentException(
-					"Unexpected " + ReferenceSearchType.class.getName() + " value: " + valueAndType.type);
 		};
 	}
 
@@ -228,11 +224,7 @@ public abstract class AbstractReferenceParameter<R extends DomainResource> exten
 				case CODE_AND_SYSTEM -> valueAndType.identifier.systemValue + "|" + valueAndType.identifier.codeValue;
 				case CODE_AND_NO_SYSTEM_PROPERTY -> "|" + valueAndType.identifier.codeValue;
 				case SYSTEM -> valueAndType.identifier.systemValue + "|";
-				default -> throw new IllegalArgumentException(
-						"Unexpected " + TokenSearchType.class.getName() + " value: " + valueAndType.identifier.type);
 			};
-			default -> throw new IllegalArgumentException(
-					"Unexpected " + ReferenceSearchType.class.getName() + " value: " + valueAndType.type);
 		};
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractSearchParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractSearchParameter.java
@@ -13,10 +13,12 @@ import dev.dsf.fhir.search.parameters.SearchQuerySortParameter;
 public abstract class AbstractSearchParameter<R extends Resource>
 		implements SearchQueryParameter<R>, SearchQuerySortParameter
 {
+	protected final Class<R> resourceType;
 	protected final String parameterName;
 
-	public AbstractSearchParameter(String parameterName)
+	public AbstractSearchParameter(Class<R> resourceType, String parameterName)
 	{
+		this.resourceType = resourceType;
 		this.parameterName = parameterName;
 	}
 
@@ -52,4 +54,12 @@ public abstract class AbstractSearchParameter<R extends Resource>
 	}
 
 	protected abstract String getSortSql(String sortDirectionWithSpacePrefix);
+
+	@Override
+	public final boolean matches(Resource resource)
+	{
+		return resource != null && resourceType.isInstance(resource) && resourceMatches(resourceType.cast(resource));
+	}
+
+	protected abstract boolean resourceMatches(R resource);
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractSingleIdentifierParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractSingleIdentifierParameter.java
@@ -1,0 +1,79 @@
+package dev.dsf.fhir.search.parameters.basic;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.BiPredicate;
+
+import org.hl7.fhir.r4.model.Resource;
+
+import dev.dsf.fhir.function.BiFunctionWithSqlException;
+
+public class AbstractSingleIdentifierParameter<R extends Resource> extends AbstractIdentifierParameter<R>
+{
+	public AbstractSingleIdentifierParameter(Class<R> resourceType, String resourceColumn,
+			BiPredicate<TokenValueAndSearchType, R> identifierMatches)
+	{
+		super(resourceType, resourceColumn, identifierMatches);
+	}
+
+	@Override
+	protected String getPositiveFilterQuery()
+	{
+		return switch (valueAndType.type)
+		{
+			case CODE, CODE_AND_SYSTEM, SYSTEM -> resourceColumn + "->'identifier' = ?::jsonb";
+			case CODE_AND_NO_SYSTEM_PROPERTY -> resourceColumn + "->'identifier'->>'value' = ? AND NOT ("
+					+ resourceColumn + "->'identifier' ?? 'system')";
+		};
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return switch (valueAndType.type)
+		{
+			case CODE, CODE_AND_SYSTEM, SYSTEM -> resourceColumn + "->'identifier' <> ?::jsonb";
+			case CODE_AND_NO_SYSTEM_PROPERTY ->
+				resourceColumn + "->'identifier'->>'value' <> ? OR (" + resourceColumn + "->'identifier' ?? 'system')";
+		};
+	}
+
+	@Override
+	public int getSqlParameterCount()
+	{
+		return 1;
+	}
+
+	@Override
+	public void modifyStatement(int parameterIndex, int subqueryParameterIndex, PreparedStatement statement,
+			BiFunctionWithSqlException<String, Object[], Array> arrayCreator) throws SQLException
+	{
+		switch (valueAndType.type)
+		{
+			case CODE:
+				statement.setString(parameterIndex, "{\"value\": \"" + valueAndType.codeValue + "\"}");
+				return;
+
+			case CODE_AND_SYSTEM:
+				statement.setString(parameterIndex, "{\"value\": \"" + valueAndType.codeValue + "\", \"system\": \""
+						+ valueAndType.systemValue + "\"}");
+				return;
+
+			case CODE_AND_NO_SYSTEM_PROPERTY:
+				statement.setString(parameterIndex, valueAndType.codeValue);
+				return;
+
+			case SYSTEM:
+				statement.setString(parameterIndex, "{\"system\": \"" + valueAndType.systemValue + "\"}");
+				return;
+		}
+	}
+
+	@Override
+	protected String getSortSql(String sortDirectionWithSpacePrefix)
+	{
+		return "(" + resourceColumn + "->'identifier'->>'system')::text || (" + resourceColumn
+				+ "->'identifier'->>'value')::text" + sortDirectionWithSpacePrefix;
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStatusParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStatusParameter.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.MetadataResource;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameterError;
@@ -20,16 +19,14 @@ public class AbstractStatusParameter<R extends MetadataResource> extends Abstrac
 	public static final String PARAMETER_NAME = "status";
 
 	private final String resourceColumn;
-	private final Class<R> resourceType;
 
 	private PublicationStatus status;
 
-	public AbstractStatusParameter(String resourceColumn, Class<R> resourceType)
+	public AbstractStatusParameter(Class<R> resourceType, String resourceColumn)
 	{
-		super(PARAMETER_NAME);
+		super(resourceType, PARAMETER_NAME);
 
 		this.resourceColumn = resourceColumn;
-		this.resourceType = resourceType;
 	}
 
 	@Override
@@ -67,9 +64,15 @@ public class AbstractStatusParameter<R extends MetadataResource> extends Abstrac
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return resourceColumn + "->>'status' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return resourceColumn + "->>'status' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return resourceColumn + "->>'status' <> ?";
 	}
 
 	@Override
@@ -92,15 +95,9 @@ public class AbstractStatusParameter<R extends MetadataResource> extends Abstrac
 	}
 
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(R resource)
 	{
-		if (!resourceType.isInstance(resource))
-			return false;
-
-		if (valueAndType.negated)
-			return !Objects.equals(((MetadataResource) resource).getStatus(), status);
-		else
-			return Objects.equals(((MetadataResource) resource).getStatus(), status);
+		return valueAndType.negated ^ Objects.equals(resource.getStatus(), status);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStringParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractStringParameter.java
@@ -2,11 +2,11 @@ package dev.dsf.fhir.search.parameters.basic;
 
 import java.util.List;
 
-import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.search.SearchQueryParameterError;
 
-public abstract class AbstractStringParameter<R extends DomainResource> extends AbstractSearchParameter<R>
+public abstract class AbstractStringParameter<R extends Resource> extends AbstractSearchParameter<R>
 {
 	protected enum StringSearchType
 	{
@@ -39,9 +39,9 @@ public abstract class AbstractStringParameter<R extends DomainResource> extends 
 
 	protected StringValueAndSearchType valueAndType;
 
-	public AbstractStringParameter(String parameterName)
+	public AbstractStringParameter(Class<R> resourceType, String parameterName)
 	{
-		super(parameterName);
+		super(resourceType, parameterName);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractVersionParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractVersionParameter.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.hl7.fhir.r4.model.MetadataResource;
-import org.hl7.fhir.r4.model.Resource;
 
 import dev.dsf.fhir.function.BiFunctionWithSqlException;
 import dev.dsf.fhir.search.SearchQueryParameterError;
@@ -21,9 +20,9 @@ public abstract class AbstractVersionParameter<R extends MetadataResource> exten
 
 	private String version;
 
-	public AbstractVersionParameter(String resourceColumn)
+	public AbstractVersionParameter(Class<R> resourceType, String resourceColumn)
 	{
-		super(PARAMETER_NAME);
+		super(resourceType, PARAMETER_NAME);
 
 		this.resourceColumn = resourceColumn;
 	}
@@ -48,9 +47,15 @@ public abstract class AbstractVersionParameter<R extends MetadataResource> exten
 	}
 
 	@Override
-	public String getFilterQuery()
+	protected String getPositiveFilterQuery()
 	{
-		return resourceColumn + "->>'version' " + (valueAndType.negated ? "<>" : "=") + " ?";
+		return resourceColumn + "->>'version' = ?";
+	}
+
+	@Override
+	protected String getNegatedFilterQuery()
+	{
+		return resourceColumn + "->>'version' <> ?";
 	}
 
 	@Override
@@ -66,20 +71,10 @@ public abstract class AbstractVersionParameter<R extends MetadataResource> exten
 		statement.setString(parameterIndex, version);
 	}
 
-	protected abstract boolean instanceOf(Resource resource);
-
 	@Override
-	public boolean matches(Resource resource)
+	protected boolean resourceMatches(R resource)
 	{
-		if (!instanceOf(resource))
-			return false;
-
-		MetadataResource mRes = (MetadataResource) resource;
-
-		if (valueAndType.negated)
-			return !Objects.equals(mRes.getVersion(), version);
-		else
-			return Objects.equals(mRes.getVersion(), version);
+		return valueAndType.negated ^ (resource.hasVersion() && Objects.equals(resource.getVersion(), version));
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ReferenceResolverImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ReferenceResolverImpl.java
@@ -26,7 +26,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import dev.dsf.common.auth.conf.Identity;
 import dev.dsf.fhir.client.ClientProvider;
 import dev.dsf.fhir.client.FhirWebserviceClient;
-import dev.dsf.fhir.dao.NamingSystemDao;
 import dev.dsf.fhir.dao.ResourceDao;
 import dev.dsf.fhir.dao.provider.DaoProvider;
 import dev.dsf.fhir.help.ExceptionHandler;
@@ -82,43 +81,37 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		Objects.requireNonNull(reference, "reference");
 		Objects.requireNonNull(connection, "connection");
 
-		ReferenceType type = reference.getType(serverBase);
-		switch (type)
+		return switch (reference.getType(serverBase))
 		{
-			case LITERAL_EXTERNAL:
-			case RELATED_ARTEFACT_LITERAL_EXTERNAL_URL:
-			case ATTACHMENT_LITERAL_EXTERNAL_URL:
-				return literalExternalReferenceCanBeCheckedAndResolved(reference);
-			case LOGICAL:
-				return logicalReferenceCanBeCheckedAndResolved(reference, connection);
-			default:
-				return true;
-		}
+			case LITERAL_EXTERNAL, RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, ATTACHMENT_LITERAL_EXTERNAL_URL ->
+				literalExternalReferenceCanBeCheckedAndResolved(reference);
+
+			case LOGICAL -> logicalReferenceCanBeCheckedAndResolved(reference, connection);
+
+			default -> true;
+		};
 	}
 
 	private boolean logicalReferenceCanBeCheckedAndResolved(ResourceReference reference, Connection connection)
 	{
-		ReferenceType type = reference.getType(serverBase);
-		if (!ReferenceType.LOGICAL.equals(type))
+		if (!ReferenceType.LOGICAL.equals(reference.getType(serverBase)))
 			throw new IllegalArgumentException("Not a logical reference");
 
-		NamingSystemDao namingSystemDao = daoProvider.getNamingSystemDao();
-
-		return exceptionHandler
-				.handleSqlException(() -> namingSystemDao.existsWithUniqueIdUriEntryResolvable(connection,
+		return exceptionHandler.handleSqlException(
+				() -> daoProvider.getNamingSystemDao().existsWithUniqueIdUriEntryResolvable(connection,
 						reference.getReference().getIdentifier().getSystem()));
 	}
 
 	private boolean literalExternalReferenceCanBeCheckedAndResolved(ResourceReference reference)
 	{
-		ReferenceType type = reference.getType(serverBase);
 		if (!EnumSet.of(ReferenceType.LITERAL_EXTERNAL, ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL,
-				ReferenceType.ATTACHMENT_LITERAL_EXTERNAL_URL).contains(type))
+				ReferenceType.ATTACHMENT_LITERAL_EXTERNAL_URL).contains(reference.getType(serverBase)))
+		{
 			throw new IllegalArgumentException(
 					"Not a literal external reference, related artifact literal external url or attachment literal external url");
+		}
 
-		String remoteServerBase = reference.getServerBase(serverBase);
-		return clientProvider.endpointExists(remoteServerBase);
+		return clientProvider.endpointExists(reference.getServerBase(serverBase));
 	}
 
 	@Override
@@ -129,23 +122,16 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		Objects.requireNonNull(connection, "connection");
 
 		ReferenceType type = reference.getType(serverBase);
-		switch (type)
+		return switch (type)
 		{
-			case LITERAL_INTERNAL:
-				return resolveLiteralInternalReference(reference, connection);
-			case LITERAL_EXTERNAL:
-			case RELATED_ARTEFACT_LITERAL_EXTERNAL_URL:
-			case ATTACHMENT_LITERAL_EXTERNAL_URL:
-				return resolveLiteralExternalReference(reference);
-			case CONDITIONAL:
-			case RELATED_ARTEFACT_CONDITIONAL_URL:
-			case ATTACHMENT_CONDITIONAL_URL:
-				return resolveConditionalReference(identity, reference, connection);
-			case LOGICAL:
-				return resolveLogicalReference(identity, reference, connection);
-			default:
-				throw new IllegalArgumentException("Reference of type " + type + " not supported");
-		}
+			case LITERAL_INTERNAL -> resolveLiteralInternalReference(reference, connection);
+			case LITERAL_EXTERNAL, RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, ATTACHMENT_LITERAL_EXTERNAL_URL ->
+				resolveLiteralExternalReference(reference);
+			case CONDITIONAL, RELATED_ARTEFACT_CONDITIONAL_URL, ATTACHMENT_CONDITIONAL_URL ->
+				resolveConditionalReference(identity, reference, connection);
+			case LOGICAL -> resolveLogicalReference(identity, reference, connection);
+			default -> throw new IllegalArgumentException("Reference of type " + type + " not supported");
+		};
 	}
 
 	private void throwIfReferenceTypeUnexpected(ReferenceType type, ReferenceType expected)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
@@ -208,6 +208,7 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 		}
 	}
 
+	@Override
 	public List<IBaseResource> fetchAllConformanceResources()
 	{
 		if (!fetchAllConformanceResourcesDone.get())

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/PropertiesConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/PropertiesConfig.java
@@ -119,6 +119,12 @@ public class PropertiesConfig implements InitializingBean
 	@Value("#{'${dev.dsf.proxy.noProxy:}'.trim().split('(,[ ]?)|(\\n)')}")
 	private List<String> proxyNoProxy;
 
+	@Value("${dev.dsf.server.auth.oidc.authorization.code.flow:false}")
+	private boolean oidcAuthorizationCodeFlowEnabled;
+
+	@Value("${dev.dsf.server.auth.oidc.bearer.token:false}")
+	private boolean oidcBearerTokenEnabled;
+
 	@Bean // static in order to initialize before @Configuration classes
 	public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer(
 			ConfigurableEnvironment environment)
@@ -268,6 +274,16 @@ public class PropertiesConfig implements InitializingBean
 	public int getJettyStatusConnectorPort()
 	{
 		return jettyStatusConnectorPort;
+	}
+
+	public boolean getOidcAuthorizationCodeFlowEnabled()
+	{
+		return oidcAuthorizationCodeFlowEnabled;
+	}
+
+	public boolean getOidcBearerTokenEnabled()
+	{
+		return oidcBearerTokenEnabled;
 	}
 
 	@Bean

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/WebserviceConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/WebserviceConfig.java
@@ -896,7 +896,8 @@ public class WebserviceConfig
 	{
 		return new ConformanceServiceImpl(propertiesConfig.getServerBaseUrl(), propertiesConfig.getDefaultPageCount(),
 				buildInfoReaderConfig.buildInfoReader(), helperConfig.parameterConverter(),
-				validationConfig.validationSupport());
+				validationConfig.validationSupport(),
+				propertiesConfig.getOidcAuthorizationCodeFlowEnabled() || propertiesConfig.getOidcBearerTokenEnabled());
 	}
 
 	@Bean

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/subscription/WebSocketSubscriptionManagerImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/subscription/WebSocketSubscriptionManagerImpl.java
@@ -89,10 +89,7 @@ public class WebSocketSubscriptionManagerImpl
 		@Override
 		public int hashCode()
 		{
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((sessionId == null) ? 0 : sessionId.hashCode());
-			return result;
+			return Objects.hash(sessionId);
 		}
 
 		@Override
@@ -100,19 +97,10 @@ public class WebSocketSubscriptionManagerImpl
 		{
 			if (this == obj)
 				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
+			if (obj == null || getClass() != obj.getClass())
 				return false;
 			SessionIdAndRemoteAsync other = (SessionIdAndRemoteAsync) obj;
-			if (sessionId == null)
-			{
-				if (other.sessionId != null)
-					return false;
-			}
-			else if (!sessionId.equals(other.sessionId))
-				return false;
-			return true;
+			return Objects.equals(sessionId, other.sessionId);
 		}
 	}
 
@@ -411,7 +399,7 @@ public class WebSocketSubscriptionManagerImpl
 	public void close(String sessionId)
 	{
 		logger.debug("Removing websocket session {}", sessionId);
-		asyncRemotesBySubscriptionIdPart.removeWhereValueMatches(list -> list.isEmpty(),
+		asyncRemotesBySubscriptionIdPart.removeWhereValueMatches(List::isEmpty,
 				list -> list.remove(new SessionIdAndRemoteAsync(null, sessionId, null)));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractResourceDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractResourceDaoTest.java
@@ -276,7 +276,7 @@ public abstract class AbstractResourceDaoTest<D extends Resource, C extends Reso
 		boolean deleted = dao.delete(UUID.fromString(createdResource.getIdElement().getIdPart()));
 		assertTrue(deleted);
 
-		D updatedResource = dao.update(updateResource(createdResource), (long) ResourceDao.FIRST_VERSION + 1L);
+		D updatedResource = dao.update(updateResource(createdResource), ResourceDao.FIRST_VERSION + 1L);
 		assertNotNull(updatedResource);
 		assertNotNull(updatedResource.getIdElement());
 		assertNotNull(updatedResource.getIdElement().getIdPart());

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/BinaryDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/BinaryDaoTest.java
@@ -525,7 +525,8 @@ public class BinaryDaoTest extends AbstractResourceDaoTest<Binary, BinaryDao> im
 				ResearchStudy::getIdElement);
 	}
 
-	private void testReadAccessTriggerSecurityContextOrganization1() throws SQLException, Exception
+	private void testReadAccessTriggerSecurityContextOrganization(Function<ResearchStudy, IdType> securityContext)
+			throws SQLException, Exception
 	{
 		Organization org = new Organization();
 		org.setActive(true);
@@ -539,7 +540,7 @@ public class BinaryDaoTest extends AbstractResourceDaoTest<Binary, BinaryDao> im
 				.create(rS);
 
 		Binary b = createResource();
-		b.setSecurityContext(new Reference(createdRs.getIdElement().toUnqualifiedVersionless()));
+		b.setSecurityContext(new Reference(securityContext.apply(createdRs)));
 		Binary createdB = dao.create(b);
 
 		assertReadAccessEntryCount(4, 1, createdRs, READ_ACCESS_TAG_VALUE_LOCAL);
@@ -551,13 +552,13 @@ public class BinaryDaoTest extends AbstractResourceDaoTest<Binary, BinaryDao> im
 	@Test
 	public void testReadAccessTriggerSecurityContextOrganization() throws Exception
 	{
-		testReadAccessTriggerSecurityContextOrganization1();
+		testReadAccessTriggerSecurityContextOrganization(rs -> rs.getIdElement().toUnqualifiedVersionless());
 	}
 
 	@Test
 	public void testReadAccessTriggerSecurityContextVersionSpecificOrganization() throws Exception
 	{
-		testReadAccessTriggerSecurityContextOrganization1();
+		testReadAccessTriggerSecurityContextOrganization(ResearchStudy::getIdElement);
 	}
 
 	@Test

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/BinaryDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/BinaryDaoTest.java
@@ -515,18 +515,17 @@ public class BinaryDaoTest extends AbstractResourceDaoTest<Binary, BinaryDao> im
 	public void testReadAccessTriggerSecurityContextVersionSpecificAll() throws Exception
 	{
 		testReadAccessTriggerSecurityContext(READ_ACCESS_TAG_VALUE_ALL, new ReadAccessHelperImpl()::addAll,
-				rs -> rs.getIdElement());
+				ResearchStudy::getIdElement);
 	}
 
 	@Test
 	public void testReadAccessTriggerSecurityContextVersionSpecificLocal() throws Exception
 	{
 		testReadAccessTriggerSecurityContext(READ_ACCESS_TAG_VALUE_LOCAL, new ReadAccessHelperImpl()::addLocal,
-				rs -> rs.getIdElement());
+				ResearchStudy::getIdElement);
 	}
 
-	private void testReadAccessTriggerSecurityContextOrganization(Function<ResearchStudy, IdType> securityContext)
-			throws SQLException, Exception
+	private void testReadAccessTriggerSecurityContextOrganization1() throws SQLException, Exception
 	{
 		Organization org = new Organization();
 		org.setActive(true);
@@ -552,13 +551,13 @@ public class BinaryDaoTest extends AbstractResourceDaoTest<Binary, BinaryDao> im
 	@Test
 	public void testReadAccessTriggerSecurityContextOrganization() throws Exception
 	{
-		testReadAccessTriggerSecurityContextOrganization(rs -> rs.getIdElement().toUnqualifiedVersionless());
+		testReadAccessTriggerSecurityContextOrganization1();
 	}
 
 	@Test
 	public void testReadAccessTriggerSecurityContextVersionSpecificOrganization() throws Exception
 	{
-		testReadAccessTriggerSecurityContextOrganization(rs -> rs.getIdElement());
+		testReadAccessTriggerSecurityContextOrganization1();
 	}
 
 	@Test
@@ -678,7 +677,7 @@ public class BinaryDaoTest extends AbstractResourceDaoTest<Binary, BinaryDao> im
 	@Test
 	public void testReadAccessTriggerSecurityContextVersionSpecificRole() throws Exception
 	{
-		testReadAccessTriggerSecurityContextRole(r -> r.getIdElement());
+		testReadAccessTriggerSecurityContextRole(ResearchStudy::getIdElement);
 	}
 
 	@Test

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
@@ -1,6 +1,8 @@
 package dev.dsf.fhir.dao;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/DefaultProfileValidationSupportTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/DefaultProfileValidationSupportTest.java
@@ -1,6 +1,7 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/IdTypeTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/IdTypeTest.java
@@ -1,6 +1,8 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Task;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/MetaTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/MetaTest.java
@@ -1,6 +1,7 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.junit.Test;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/ParserTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/ParserTest.java
@@ -1,6 +1,8 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.InputStream;
 import java.nio.file.Files;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/SerializationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/SerializationTest.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Task;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/SubscriptionTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/SubscriptionTest.java
@@ -1,6 +1,7 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.hl7.fhir.r4.model.Subscription;
 import org.hl7.fhir.r4.model.Subscription.SubscriptionChannelComponent;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/TaskTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/hapi/TaskTest.java
@@ -1,6 +1,6 @@
 package dev.dsf.fhir.hapi;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.UUID;
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -2356,7 +2356,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		assertTrue(searchBundle.getEntry().stream()
 				.allMatch(c -> c.getResource() != null && c.getResource() instanceof Binary));
 
-		String actualIds = searchBundle.getEntry().stream().map(c -> c.getResource())
+		String actualIds = searchBundle.getEntry().stream().map(BundleEntryComponent::getResource)
 				.map(r -> "Binary/" + r.getIdElement().getIdPart() + "/_history/" + r.getMeta().getVersionId()).sorted()
 				.collect(Collectors.joining(", "));
 		String expectedIds = Arrays.asList(b1, b2, b3, b4).stream().map(b -> b.getIdElement().getValueAsString())
@@ -2425,7 +2425,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		assertTrue(searchBundle.getEntry().stream()
 				.allMatch(c -> c.getResource() != null && c.getResource() instanceof Binary));
 
-		String actualIds = searchBundle.getEntry().stream().map(c -> c.getResource())
+		String actualIds = searchBundle.getEntry().stream().map(BundleEntryComponent::getResource)
 				.map(r -> "Binary/" + r.getIdElement().getIdPart() + "/_history/" + r.getMeta().getVersionId()).sorted()
 				.collect(Collectors.joining(", "));
 		String expectedIds = Arrays.asList(b2, b3, b5).stream().map(b -> b.getIdElement().getValueAsString()).sorted()

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/NamingSystemIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/NamingSystemIntegrationTest.java
@@ -1,7 +1,7 @@
 package dev.dsf.fhir.integration;
 
 import static org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Date;
 

--- a/dsf-fhir/dsf-fhir-validation/src/main/java/dev/dsf/fhir/validation/ValueSetExpanderImpl.java
+++ b/dsf-fhir/dsf-fhir-validation/src/main/java/dev/dsf/fhir/validation/ValueSetExpanderImpl.java
@@ -30,6 +30,7 @@ public class ValueSetExpanderImpl implements ValueSetExpander
 		return workerContext;
 	}
 
+	@Override
 	public ValueSetExpansionOutcome expand(ValueSet valueSet)
 	{
 		Objects.requireNonNull(valueSet, "valueSet");

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/ActivityDefinitionProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/ActivityDefinitionProfileTest.java
@@ -52,7 +52,7 @@ public class ActivityDefinitionProfileTest
 					"dsf-practitioner-role-1.0.0.xml", "dsf-process-authorization-recipient-1.0.0.xml",
 					"dsf-process-authorization-requester-1.0.0.xml"));
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	private ActivityDefinition createActivityDefinition()

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/CodeSystemProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/CodeSystemProfileTest.java
@@ -34,7 +34,7 @@ public class CodeSystemProfileTest
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml", "dsf-organization-role-1.0.0.xml"),
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml", "dsf-organization-role-1.0.0.xml"));
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	private CodeSystem createCodeSystem()

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/EndpointProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/EndpointProfileTest.java
@@ -29,7 +29,7 @@ public class EndpointProfileTest
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml", "urn_ietf_bcp_13.xml"),
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml", "valueset-mimetypes.xml"));
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/OrganizationAffiliationProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/OrganizationAffiliationProfileTest.java
@@ -28,7 +28,7 @@ public class OrganizationAffiliationProfileTest
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml", "dsf-organization-role-1.0.0.xml"),
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml", "dsf-organization-role-1.0.0.xml"));
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/OrganizationProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/OrganizationProfileTest.java
@@ -32,7 +32,7 @@ public class OrganizationProfileTest
 					"dsf-extension-read-access-organization-1.0.0.xml"),
 			Arrays.asList("dsf-read-access-tag-1.0.0.xml"), Arrays.asList("dsf-read-access-tag-1.0.0.xml"));
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireProfileTest.java
@@ -27,7 +27,7 @@ public class QuestionnaireProfileTest
 	public static final ValidationSupportRule validationRule = new ValidationSupportRule(
 			Arrays.asList("dsf-questionnaire-1.0.0.xml"), Collections.emptyList(), Collections.emptyList());
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireResponseProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/QuestionnaireResponseProfileTest.java
@@ -38,7 +38,7 @@ public class QuestionnaireResponseProfileTest
 	public static final ValidationSupportRule validationRule = new ValidationSupportRule(
 			Arrays.asList("dsf-questionnaire-response-1.0.0.xml"), Collections.emptyList(), Collections.emptyList());
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test

--- a/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/TaskProfileTest.java
+++ b/dsf-fhir/dsf-fhir-validation/src/test/java/dev/dsf/fhir/profiles/TaskProfileTest.java
@@ -31,7 +31,7 @@ public class TaskProfileTest
 			List.of("dsf-task-base-1.0.0.xml"), List.of("dsf-bpmn-message-1.0.0.xml"),
 			List.of("dsf-bpmn-message-1.0.0.xml"));
 
-	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
+	private final ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/FhirWebserviceClientJersey.java
@@ -112,8 +112,7 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 
 	private String toString(OperationOutcome outcome)
 	{
-		return outcome == null ? ""
-				: outcome.getIssue().stream().map(i -> toString(i)).collect(Collectors.joining("\n"));
+		return outcome == null ? "" : outcome.getIssue().stream().map(this::toString).collect(Collectors.joining("\n"));
 	}
 
 	private String toString(OperationOutcomeIssueComponent issue)
@@ -133,19 +132,19 @@ public class FhirWebserviceClientJersey extends AbstractJerseyClient implements 
 	private PreferReturn toPreferReturn(PreferReturnType returnType, Class<? extends Resource> resourceType,
 			Response response)
 	{
-		switch (returnType)
+		return switch (returnType)
 		{
-			case REPRESENTATION:
+			case REPRESENTATION ->
+			{
 				// TODO remove workaround if HAPI bug fixed
 				Resource resource = referenceCleaner.cleanReferenceResourcesIfBundle(response.readEntity(resourceType));
-				return PreferReturn.resource(resource);
-			case MINIMAL:
-				return PreferReturn.minimal(response.getLocation());
-			case OPERATION_OUTCOME:
-				return PreferReturn.outcome(response.readEntity(OperationOutcome.class));
-			default:
+				yield PreferReturn.resource(resource);
+			}
+			case MINIMAL -> PreferReturn.minimal(response.getLocation());
+			case OPERATION_OUTCOME -> PreferReturn.outcome(response.readEntity(OperationOutcome.class));
+			default ->
 				throw new RuntimeException(PreferReturn.class.getName() + " value " + returnType + " not supported");
-		}
+		};
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/dev/dsf/fhir/client/WebsocketClientTyrus.java
@@ -154,13 +154,7 @@ public class WebsocketClientTyrus implements WebsocketClient
 
 			connection = manager.connectToServer(endpoint, config, wsUri);
 		}
-		catch (DeploymentException e)
-		{
-			logger.debug("Error while connecting to server", e);
-
-			throw new RuntimeException(e);
-		}
-		catch (IOException e)
+		catch (DeploymentException | IOException e)
 		{
 			logger.debug("Error while connecting to server", e);
 
@@ -175,6 +169,7 @@ public class WebsocketClientTyrus implements WebsocketClient
 
 		ClientEndpointConfig.Configurator configurator = new ClientEndpointConfig.Configurator()
 		{
+			@Override
 			public void beforeRequest(Map<String, java.util.List<String>> headers)
 			{
 				headers.put(HttpHeaders.USER_AGENT, Collections.singletonList(userAgentValue));

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/BundleGenerator.java
@@ -203,22 +203,15 @@ public class BundleGenerator
 				return Integer.MIN_VALUE;
 			else
 			{
-				switch (e.getResource().getClass().getAnnotation(ResourceDef.class).name())
+				return switch (e.getResource().getClass().getAnnotation(ResourceDef.class).name())
 				{
-					case "CodeSystem":
-						return 1;
-					case "NamingSystem":
-						return 2;
-					case "ValueSet":
-						return 3;
-					case "StructureDefinition":
-						return 4;
-					case "Subscription":
-						return 5;
-
-					default:
-						return Integer.MAX_VALUE;
-				}
+					case "CodeSystem" -> 1;
+					case "NamingSystem" -> 2;
+					case "ValueSet" -> 3;
+					case "StructureDefinition" -> 4;
+					case "Subscription" -> 5;
+					default -> Integer.MAX_VALUE;
+				};
 			}
 		};
 	}
@@ -268,7 +261,7 @@ public class BundleGenerator
 	{
 		SnapshotGenerator generator = new SnapshotGenerator(fhirContext, validationSupport);
 
-		bundle.getEntry().stream().map(e -> e.getResource()).filter(r -> r instanceof StructureDefinition)
+		bundle.getEntry().stream().map(BundleEntryComponent::getResource).filter(r -> r instanceof StructureDefinition)
 				.map(r -> (StructureDefinition) r).sorted(Comparator.comparing(StructureDefinition::getUrl).reversed())
 				.filter(s -> !s.hasSnapshot()).forEach(s -> generator.generateSnapshot(s));
 	}
@@ -277,8 +270,8 @@ public class BundleGenerator
 	{
 		ValueSetExpander valueSetExpander = new ValueSetExpander(fhirContext, validationSupport);
 
-		bundle.getEntry().stream().map(e -> e.getResource()).filter(r -> r instanceof ValueSet).map(r -> (ValueSet) r)
-				.filter(v -> !v.hasExpansion()).forEach(v -> valueSetExpander.expand(v));
+		bundle.getEntry().stream().map(BundleEntryComponent::getResource).filter(r -> r instanceof ValueSet)
+				.map(r -> (ValueSet) r).filter(v -> !v.hasExpansion()).forEach(v -> valueSetExpander.expand(v));
 	}
 
 	public static void main(String[] args) throws Exception

--- a/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/ValidationSupportWithCustomResources.java
+++ b/dsf-tools/dsf-tools-bundle-generator/src/main/java/dev/dsf/tools/generator/ValidationSupportWithCustomResources.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -25,7 +26,7 @@ public class ValidationSupportWithCustomResources implements IValidationSupport
 	{
 		this.context = context;
 
-		bundle.getEntry().stream().map(e -> e.getResource())
+		bundle.getEntry().stream().map(BundleEntryComponent::getResource)
 				.filter(r -> r instanceof StructureDefinition || r instanceof CodeSystem || r instanceof ValueSet)
 				.forEach(r ->
 				{

--- a/dsf-tools/dsf-tools-db-migration/src/main/java/dev/dsf/tools/db/DbMigrator.java
+++ b/dsf-tools/dsf-tools-db-migration/src/main/java/dev/dsf/tools/db/DbMigrator.java
@@ -28,7 +28,6 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.exception.LiquibaseException;
 import liquibase.ui.LoggerUIService;
 
 public final class DbMigrator
@@ -148,11 +147,7 @@ public final class DbMigrator
 					logger.warn("Error while accessing db: {}", e.getMessage());
 					throw new DbMigratorExceptions(e);
 				}
-				catch (LiquibaseException e)
-				{
-					logger.warn("Error while running liquibase: {}", e.getMessage());
-					throw new DbMigratorExceptions(e);
-				}
+				// no special case for LiquibaseException
 				catch (Exception e)
 				{
 					logger.warn("Error while running liquibase: {}", e.getMessage());

--- a/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
+++ b/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
@@ -68,6 +68,7 @@ public class DocumentationGenerator extends AbstractMojo
 	@Parameter(property = "workingPackages", required = true)
 	private List<String> workingPackages;
 
+	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException
 	{
 		workingPackages.forEach(this::generateDocumentation);

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/java/dev/dsf/tools/generator/CertificateGenerator.java
@@ -298,15 +298,11 @@ public class CertificateGenerator
 	{
 		try
 		{
-			switch (certificateType)
+			return switch (certificateType)
 			{
-				case CLIENT:
-					return ca.signWebClientCertificate(certificateRequest);
-				case SERVER:
-					return ca.signWebServerCertificate(certificateRequest);
-				default:
-					throw new RuntimeException("Unknown certificate type " + certificateType);
-			}
+				case CLIENT -> ca.signWebClientCertificate(certificateRequest);
+				case SERVER -> ca.signWebServerCertificate(certificateRequest);
+			};
 		}
 		catch (InvalidKeyException | NoSuchAlgorithmException | InvalidKeySpecException | OperatorCreationException
 				| CertificateException | IllegalStateException | IOException e)
@@ -346,16 +342,12 @@ public class CertificateGenerator
 	{
 		try
 		{
-			switch (certificateType)
+			return switch (certificateType)
 			{
-				case CLIENT:
-					return CertificationRequestBuilder.createClientCertificationRequest(subject, keyPair);
-				case SERVER:
-					return CertificationRequestBuilder.createServerCertificationRequest(subject, keyPair, null,
-							dnsNames);
-				default:
-					throw new RuntimeException("Unknown certificate type " + certificateType);
-			}
+				case CLIENT -> CertificationRequestBuilder.createClientCertificationRequest(subject, keyPair);
+				case SERVER ->
+					CertificationRequestBuilder.createServerCertificationRequest(subject, keyPair, null, dnsNames);
+			};
 		}
 		catch (NoSuchAlgorithmException | OperatorCreationException | IllegalStateException | IOException e)
 		{


### PR DESCRIPTION
* Removed some duplicate code from query parameter classes.
* Implemented a few new "name" query parameters.
* Added security OAuth entry to CapabilityStatement (/metadata) if OAuth
is enabled.
* Simplified some lambda expressions and switched to methods handles
where possible.
* Removed not needed casts.
* Removed explicit generic types, where types can be inferred.
* Combined some if/else-if statements.
* Added missing @OverRide annotations.
* Added final to class fields where applicable.
* Introduced switch-expressions where possible, remove default case in
switch-expressions if all cases covered.
* Regenerated equals and hashCode implementation based on Objects...
methods.
* Other minor code cleanup.

closes #142 