### PR TITLE
Issue/230 Org OrgAff Update Performance

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-server-jetty/pom.xml
+++ b/dsf-bpe/dsf-bpe-server-jetty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/pom.xml
+++ b/dsf-bpe/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-common/dsf-common-auth/pom.xml
+++ b/dsf-common/dsf-common-auth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-common/dsf-common-config/pom.xml
+++ b/dsf-common/dsf-common-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-common/dsf-common-db/pom.xml
+++ b/dsf-common/dsf-common-db/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-common/dsf-common-documentation/pom.xml
+++ b/dsf-common/dsf-common-documentation/pom.xml
@@ -6,6 +6,6 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/dsf-common/dsf-common-jetty/pom.xml
+++ b/dsf-common/dsf-common-jetty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-common/dsf-common-status/pom.xml
+++ b/dsf-common/dsf-common-status/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-common/dsf-common-ui/pom.xml
+++ b/dsf-common/dsf-common-ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-common-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/dsf-common/pom.xml
+++ b/dsf-common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<modules>

--- a/dsf-fhir/dsf-fhir-auth/pom.xml
+++ b/dsf-fhir/dsf-fhir-auth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
+++ b/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-server-jetty/pom.xml
+++ b/dsf-fhir/dsf-fhir-server-jetty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/db/db.changelog.xml
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/db/db.changelog.xml
@@ -38,4 +38,6 @@
 
 	<include file="db/db.read_access.changelog-1.5.0.xml" />
 
+	<include file="db/db.read_access.changelog-1.6.0.xml" />
+
 </databaseChangeLog>

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/db/db.read_access.changelog-1.6.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/db/db.read_access.changelog-1.6.0.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+	<property name="json" value="JSONB" dbms="postgresql" />
+	<property name="json" value="varchar(5000)" dbms="h2" />
+
+	<changeSet author="hhund" id="db.read_access.changelog-1.6.0.all_read_access_resources">
+		<createView viewName="all_read_access_resources" replaceIfExists="true">
+			SELECT
+				id
+				, version
+				, type
+				, resource
+			FROM (
+			SELECT activity_definition_id AS id, version, 'ActivityDefinition'::text AS type, activity_definition AS resource FROM current_activity_definitions
+			UNION
+			SELECT binary_id AS id, version, 'Binary'::text AS type, binary_json AS resource FROM current_binaries
+			UNION
+			SELECT bundle_id AS id, version, 'Bundle'::text AS type, bundle AS resource FROM current_bundles
+			UNION
+			SELECT code_system_id AS id, version, 'CodeSystem'::text AS type, code_system AS resource FROM current_code_systems
+			UNION
+			SELECT document_reference_id AS id, version, 'DocumentReference'::text AS type, document_reference AS resource FROM current_document_references
+			UNION
+			SELECT endpoint_id AS id, version, 'Endpoint'::text AS type, endpoint AS resource FROM current_endpoints
+			UNION
+			SELECT group_id AS id, version, 'Group'::text AS type, group_json AS resource FROM current_groups
+			UNION
+			SELECT healthcare_service_id AS id, version, 'HealthcareService'::text AS type, healthcare_service AS resource FROM current_healthcare_services
+			UNION
+			SELECT library_id AS id, version, 'Library'::text AS type, library AS resource FROM current_libraries
+			UNION
+			SELECT location_id AS id, version, 'Location'::text AS type, location AS resource FROM current_locations
+			UNION
+			SELECT measure_report_id AS id, version, 'MeasureReport'::text AS type, measure_report AS resource FROM current_measure_reports
+			UNION
+			SELECT measure_id AS id, version, 'Measure'::text AS type, measure AS resource FROM current_measures
+			UNION
+			SELECT naming_system_id AS id, version, 'NamingSystem'::text AS type, naming_system AS resource FROM current_naming_systems
+			UNION
+			SELECT organization_id AS id, version, 'Organization'::text AS type, organization AS resource FROM current_organizations
+			UNION
+			SELECT organization_affiliation_id AS id, version, 'OrganizationAffiliation'::text AS type, organization_affiliation AS resource FROM current_organization_affiliations
+			UNION
+			SELECT patient_id AS id, version, 'Patient'::text AS type, patient AS resource FROM current_patients
+			UNION
+			SELECT practitioner_role_id AS id, version, 'PractitionerRole'::text AS type, practitioner_role AS resource FROM current_practitioner_roles
+			UNION
+			SELECT practitioner_id AS id, version, 'Practitioner'::text AS type, practitioner AS resource FROM current_practitioners
+			UNION
+			SELECT provenance_id AS id, version, 'Provenance'::text AS type, provenance AS resource FROM current_provenances
+			UNION
+			SELECT questionnaire_id AS id, version, 'Questionnaire'::text AS type, questionnaire AS resource FROM current_questionnaires
+			UNION
+			SELECT research_study_id AS id, version, 'ResearchStudy'::text AS type, research_study AS resource FROM current_research_studies
+			UNION
+			SELECT structure_definition_id AS id, version, 'StructureDefinition'::text AS type, structure_definition AS resource FROM current_structure_definitions
+			UNION
+			SELECT subscription_id AS id, version, 'Subscription'::text AS type, subscription AS resource FROM current_subscriptions
+			UNION
+			SELECT value_set_id AS id, version, 'ValueSet'::text AS type, value_set AS resource FROM current_value_sets
+			) AS current_all_read_access
+		</createView>
+		<sql dbms="postgresql">
+			ALTER TABLE all_read_access_resources OWNER TO ${db.liquibase_user};
+			GRANT ALL ON TABLE all_read_access_resources TO ${db.liquibase_user};
+			GRANT SELECT ON TABLE all_read_access_resources TO ${db.server_users_group};
+		</sql>
+	</changeSet>
+</databaseChangeLog>

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/db/trigger_functions/on_organization_affiliations_insert.sql
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/db/trigger_functions/on_organization_affiliations_insert.sql
@@ -1,5 +1,6 @@
 CREATE OR REPLACE FUNCTION on_organization_affiliations_insert() RETURNS TRIGGER AS $$
 DECLARE
+	organization_affiliation_exists_active_roles JSONB := (SELECT organization_affiliation->'code' FROM organization_affiliations WHERE organization_affiliation_id = NEW.organization_affiliation_id AND version = NEW.version - 1 AND deleted IS NULL AND organization_affiliation->>'active' = 'true');
 	reference_regex TEXT := '((http|https):\/\/([A-Za-z0-9\-\\\.\:\%\$]*\/)+)?(Account|ActivityDefinition|AdverseEvent|AllergyIntolerance|Appointment|AppointmentResponse|AuditEvent|Basic|Binary|BiologicallyDerivedProduct|BodyStructure|Bundle|CapabilityStatement|CarePlan|CareTeam|CatalogEntry|ChargeItem|ChargeItemDefinition|Claim|ClaimResponse|ClinicalImpression|CodeSystem|Communication|CommunicationRequest|CompartmentDefinition|Composition|ConceptMap|Condition|Consent|Contract|Coverage|CoverageEligibilityRequest|CoverageEligibilityResponse|DetectedIssue|Device|DeviceDefinition|DeviceMetric|DeviceRequest|DeviceUseStatement|DiagnosticReport|DocumentManifest|DocumentReference|EffectEvidenceSynthesis|Encounter|Endpoint|EnrollmentRequest|EnrollmentResponse|EpisodeOfCare|EventDefinition|Evidence|EvidenceVariable|ExampleScenario|ExplanationOfBenefit|FamilyMemberHistory|Flag|Goal|GraphDefinition|Group|GuidanceResponse|HealthcareService|ImagingStudy|Immunization|ImmunizationEvaluation|ImmunizationRecommendation|ImplementationGuide|InsurancePlan|Invoice|Library|Linkage|List|Location|Measure|MeasureReport|Media|Medication|MedicationAdministration|MedicationDispense|MedicationKnowledge|MedicationRequest|MedicationStatement|MedicinalProduct|MedicinalProductAuthorization|MedicinalProductContraindication|MedicinalProductIndication|MedicinalProductIngredient|MedicinalProductInteraction|MedicinalProductManufactured|MedicinalProductPackaged|MedicinalProductPharmaceutical|MedicinalProductUndesirableEffect|MessageDefinition|MessageHeader|MolecularSequence|NamingSystem|NutritionOrder|Observation|ObservationDefinition|OperationDefinition|OperationOutcome|Organization|OrganizationAffiliation|Patient|PaymentNotice|PaymentReconciliation|Person|PlanDefinition|Practitioner|PractitionerRole|Procedure|Provenance|Questionnaire|QuestionnaireResponse|RelatedPerson|RequestGroup|ResearchDefinition|ResearchElementDefinition|ResearchStudy|ResearchSubject|RiskAssessment|RiskEvidenceSynthesis|Schedule|SearchParameter|ServiceRequest|Slot|Specimen|SpecimenDefinition|StructureDefinition|StructureMap|Subscription|Substance|SubstanceNucleicAcid|SubstancePolymer|SubstanceProtein|SubstanceReferenceInformation|SubstanceSourceMaterial|SubstanceSpecification|SupplyDelivery|SupplyRequest|Task|TerminologyCapabilities|TestReport|TestScript|ValueSet|VerificationResult|VisionPrescription)\/([A-Za-z0-9\-\.]{1,64})(\/_history\/([A-Za-z0-9\-\.]{1,64}))?';
 	parent_organization_identifier TEXT;
 	member_organization_id UUID;
@@ -8,16 +9,22 @@ DECLARE
 	delete_count INT;
 BEGIN
 	PERFORM on_resources_insert(NEW.organization_affiliation_id, NEW.version, NEW.organization_affiliation);
-	
-	DELETE FROM read_access
-	WHERE access_type = 'ROLE'
-	AND organization_affiliation_id = NEW.organization_affiliation_id;
 
-	GET DIAGNOSTICS delete_count = ROW_COUNT;
-	RAISE NOTICE 'Existing rows deleted from read_access for created/updated organization-affiliation: %', delete_count;
-	
-	RAISE NOTICE 'NEW.organization_affiliation->>''active'' = ''%''', NEW.organization_affiliation->>'active';
-	IF (NEW.organization_affiliation->>'active' = 'true') THEN
+	IF ((NEW.organization_affiliation->>'active' = 'false') AND organization_affiliation_exists_active_roles IS NOT NULL)
+	OR ((NEW.organization_affiliation->>'active' = 'true') AND organization_affiliation_exists_active_roles IS NOT NULL AND NEW.organization_affiliation->'code' <> organization_affiliation_exists_active_roles) THEN
+		RAISE NOTICE 'new organization_affiliation inactive and old organization_affiliation exists and active -> delete';
+
+		DELETE FROM read_access
+		WHERE access_type = 'ROLE'
+		AND organization_affiliation_id = NEW.organization_affiliation_id;
+
+		GET DIAGNOSTICS delete_count = ROW_COUNT;
+		RAISE NOTICE 'Existing rows deleted from read_access for created/updated organization-affiliation: %', delete_count;
+
+	ELSIF ((NEW.organization_affiliation->>'active' = 'true') AND NOT organization_affiliation_exists_active_roles IS NOT NULL)
+	OR ((NEW.organization_affiliation->>'active' = 'true') AND organization_affiliation_exists_active_roles IS NOT NULL AND NEW.organization_affiliation->'code' <> organization_affiliation_exists_active_roles) THEN
+		RAISE NOTICE 'new organization_affiliation active and old organization_affiliation not exist or inactive -> insert';
+
 		parent_organization_identifier := jsonb_path_query(organization, '$.identifier[*] ? (@.system == "http://dsf.dev/sid/organization-identifier")')->>'value'
 			FROM current_organizations
 			WHERE organization_id = (regexp_match(NEW.organization_affiliation->'organization'->>'reference', reference_regex))[5]::uuid
@@ -43,7 +50,7 @@ BEGIN
 						id
 						, version
 						, resource
-					FROM all_resources
+					FROM all_read_access_resources
 				) AS r
 				ON r.resource->'meta'->'tag' @> 
 					('[{"extension":[{"url":"http://dsf.dev/fhir/StructureDefinition/extension-read-access-parent-organization-role","extension":[{"url":"parent-organization","valueIdentifier":{"system":"http://dsf.dev/sid/organization-identifier","value":"'
@@ -66,10 +73,8 @@ BEGIN
 			GET DIAGNOSTICS binary_insert_count = ROW_COUNT;
 			RAISE NOTICE 'Rows inserted into read_access based on Binary.securityContext: %', binary_insert_count;
 		END IF;
-
-	ELSIF (NEW.organization_affiliation->>'active' = 'false') THEN
-		RAISE NOTICE 'Not inserting any entries to read_access, created/updated organization-affiliation is not active';
 	END IF;
+	
 	RETURN NEW;
 END;
 $$ LANGUAGE PLPGSQL

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/db/trigger_functions/on_organizations_insert.sql
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/db/trigger_functions/on_organizations_insert.sql
@@ -1,5 +1,6 @@
 CREATE OR REPLACE FUNCTION on_organizations_insert() RETURNS TRIGGER AS $$
 DECLARE
+	organization_exists_active BOOLEAN := EXISTS (SELECT 1 FROM organizations WHERE organization_id = NEW.organization_id AND version = NEW.version - 1 AND deleted IS NULL AND organization->>'active' = 'true');
 	reference_regex TEXT := '((http|https):\/\/([A-Za-z0-9\-\\\.\:\%\$]*\/)+)?(Account|ActivityDefinition|AdverseEvent|AllergyIntolerance|Appointment|AppointmentResponse|AuditEvent|Basic|Binary|BiologicallyDerivedProduct|BodyStructure|Bundle|CapabilityStatement|CarePlan|CareTeam|CatalogEntry|ChargeItem|ChargeItemDefinition|Claim|ClaimResponse|ClinicalImpression|CodeSystem|Communication|CommunicationRequest|CompartmentDefinition|Composition|ConceptMap|Condition|Consent|Contract|Coverage|CoverageEligibilityRequest|CoverageEligibilityResponse|DetectedIssue|Device|DeviceDefinition|DeviceMetric|DeviceRequest|DeviceUseStatement|DiagnosticReport|DocumentManifest|DocumentReference|EffectEvidenceSynthesis|Encounter|Endpoint|EnrollmentRequest|EnrollmentResponse|EpisodeOfCare|EventDefinition|Evidence|EvidenceVariable|ExampleScenario|ExplanationOfBenefit|FamilyMemberHistory|Flag|Goal|GraphDefinition|Group|GuidanceResponse|HealthcareService|ImagingStudy|Immunization|ImmunizationEvaluation|ImmunizationRecommendation|ImplementationGuide|InsurancePlan|Invoice|Library|Linkage|List|Location|Measure|MeasureReport|Media|Medication|MedicationAdministration|MedicationDispense|MedicationKnowledge|MedicationRequest|MedicationStatement|MedicinalProduct|MedicinalProductAuthorization|MedicinalProductContraindication|MedicinalProductIndication|MedicinalProductIngredient|MedicinalProductInteraction|MedicinalProductManufactured|MedicinalProductPackaged|MedicinalProductPharmaceutical|MedicinalProductUndesirableEffect|MessageDefinition|MessageHeader|MolecularSequence|NamingSystem|NutritionOrder|Observation|ObservationDefinition|OperationDefinition|OperationOutcome|Organization|OrganizationAffiliation|Patient|PaymentNotice|PaymentReconciliation|Person|PlanDefinition|Practitioner|PractitionerRole|Procedure|Provenance|Questionnaire|QuestionnaireResponse|RelatedPerson|RequestGroup|ResearchDefinition|ResearchElementDefinition|ResearchStudy|ResearchSubject|RiskAssessment|RiskEvidenceSynthesis|Schedule|SearchParameter|ServiceRequest|Slot|Specimen|SpecimenDefinition|StructureDefinition|StructureMap|Subscription|Substance|SubstanceNucleicAcid|SubstancePolymer|SubstanceProtein|SubstanceReferenceInformation|SubstanceSourceMaterial|SubstanceSpecification|SupplyDelivery|SupplyRequest|Task|TerminologyCapabilities|TestReport|TestScript|ValueSet|VerificationResult|VisionPrescription)\/([A-Za-z0-9\-\.]{1,64})(\/_history\/([A-Za-z0-9\-\.]{1,64}))?';
 	organization_identifier TEXT := jsonb_path_query(NEW.organization, '$.identifier[*]?(@.system == "http://dsf.dev/sid/organization-identifier")')->>'value';
 	organization_insert_count INT;
@@ -9,36 +10,40 @@ DECLARE
 	roles_delete_count INT;
 BEGIN
 	PERFORM on_resources_insert(NEW.organization_id, NEW.version, NEW.organization);
-	
-	DELETE FROM read_access
-	WHERE access_type = 'ORGANIZATION'
-	AND organization_id = NEW.organization_id;
-	
-	GET DIAGNOSTICS delete_count = ROW_COUNT;
-	RAISE NOTICE 'Existing rows deleted from read_access for created/updated organization, ORGANIZATION Tag: %', delete_count;
-	
-	DELETE FROM read_access
-	WHERE access_type = 'ROLE'
-	AND organization_affiliation_id IN (
-		SELECT organization_affiliation_id FROM current_organization_affiliations 
-		WHERE NEW.organization_id = (regexp_match(organization_affiliation->'participatingOrganization'->>'reference', reference_regex))[5]::uuid
-		OR NEW.organization_id = (regexp_match(organization_affiliation->'organization'->>'reference', reference_regex))[5]::uuid
-	); 
 
-	GET DIAGNOSTICS roles_delete_count = ROW_COUNT;
-	RAISE NOTICE 'Existing rows deleted from read_access for created/updated organization, ROLE Tag: %', roles_delete_count;
-	
-	RAISE NOTICE 'NEW.organization->>''active'' = ''%''', NEW.organization->>'active';
-	IF (NEW.organization->>'active' = 'true') THEN
+	IF (NEW.organization->>'active' = 'false') AND organization_exists_active THEN
+		RAISE NOTICE 'new organization inactive and old organization exists and active -> delete';
+
+		DELETE FROM read_access
+		WHERE access_type = 'ORGANIZATION'
+		AND organization_id = NEW.organization_id;
+
+		GET DIAGNOSTICS delete_count = ROW_COUNT;
+		RAISE NOTICE 'Existing rows deleted from read_access for created/updated organization, ORGANIZATION Tag: %', delete_count;
+
+		DELETE FROM read_access
+		WHERE access_type = 'ROLE'
+		AND organization_affiliation_id IN (
+			SELECT organization_affiliation_id FROM current_organization_affiliations 
+			WHERE NEW.organization_id = (regexp_match(organization_affiliation->'participatingOrganization'->>'reference', reference_regex))[5]::uuid
+			OR NEW.organization_id = (regexp_match(organization_affiliation->'organization'->>'reference', reference_regex))[5]::uuid
+		); 
+
+		GET DIAGNOSTICS roles_delete_count = ROW_COUNT;
+		RAISE NOTICE 'Existing rows deleted from read_access for created/updated organization, ROLE Tag: %', roles_delete_count;
+
+	ELSIF (NEW.organization->>'active' = 'true') AND NOT organization_exists_active THEN
+		RAISE NOTICE 'new organization active and old organization not exist or inactive -> insert';
+		
 		INSERT INTO read_access
 			SELECT id, version, 'ORGANIZATION', NEW.organization_id, NULL
-			FROM all_resources
+			FROM all_read_access_resources
 			WHERE jsonb_path_exists(resource,('$.meta.tag[*] ? (@.code == "ORGANIZATION" && @.system == "http://dsf.dev/fhir/CodeSystem/read-access-tag")
 					.extension[*]?(@.url == "http://dsf.dev/fhir/StructureDefinition/extension-read-access-organization")
 					.valueIdentifier[*]?(@.system == "http://dsf.dev/sid/organization-identifier" && @.value == "' || organization_identifier || '")')::jsonpath);
-		
+
 		GET DIAGNOSTICS organization_insert_count = ROW_COUNT;
-		
+
 		WITH temp_role_ids AS (		
 		INSERT INTO read_access 			
 			SELECT r.id, r.version, 'ROLE', member_organization_id, organization_affiliation_id FROM (
@@ -72,7 +77,7 @@ BEGIN
 				WHERE parent_organization_organization_id = NEW.organization_id OR member_organization_id = NEW.organization_id
 				) AS oa
 				LEFT JOIN (
-					SELECT id, version, resource FROM all_resources
+					SELECT id, version, resource FROM all_read_access_resources
 				) AS r
 				ON r.resource->'meta'->'tag' @> 
 					('[{"extension":[{"url":"http://dsf.dev/fhir/StructureDefinition/extension-read-access-parent-organization-role","extension":[{"url":"parent-organization","valueIdentifier":{"system":"http://dsf.dev/sid/organization-identifier","value":"'
@@ -101,10 +106,8 @@ BEGIN
 
 		GET DIAGNOSTICS binary_insert_count = ROW_COUNT;
 		RAISE NOTICE 'Rows inserted into read_access based on Binary.securityContext: %', binary_insert_count;
-
-	ELSIF (NEW.organization->>'active' = 'false') THEN
-		RAISE NOTICE 'Not inserting any entries to read_access, created/updated organization is not active';
 	END IF;
+
 	RETURN NEW;
 END;
 $$ LANGUAGE PLPGSQL

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractReadAccessDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractReadAccessDaoTest.java
@@ -560,7 +560,7 @@ public abstract class AbstractReadAccessDaoTest<D extends Resource, C extends Re
 
 		createdAff.getCodeFirstRep().getCodingFirstRep().setCode("HRP");
 		OrganizationAffiliation updatedAff = organizationAffiliationDao.update(createdAff);
-		
+
 		assertReadAccessEntryCount(1, 1, v1, READ_ACCESS_TAG_VALUE_LOCAL);
 		assertReadAccessEntryCount(1, 0, v1, READ_ACCESS_TAG_VALUE_ROLE, createdMemberOrg, updatedAff);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractReadAccessDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/AbstractReadAccessDaoTest.java
@@ -523,6 +523,49 @@ public abstract class AbstractReadAccessDaoTest<D extends Resource, C extends Re
 	}
 
 	@Test
+	public void testReadAccessTriggerRoleUpdateRoleChange() throws Exception
+	{
+		final OrganizationAffiliationDaoJdbc organizationAffiliationDao = new OrganizationAffiliationDaoJdbc(
+				defaultDataSource, permanentDeleteDataSource, fhirContext);
+
+		Organization parentOrg = new Organization();
+		parentOrg.setActive(true);
+		parentOrg.addIdentifier().setSystem(ORGANIZATION_IDENTIFIER_SYSTEM).setValue("parent.com");
+
+		Organization memberOrg = new Organization();
+		memberOrg.setActive(true);
+		memberOrg.addIdentifier().setSystem(ORGANIZATION_IDENTIFIER_SYSTEM).setValue("member.com");
+
+		OrganizationDao orgDao = new OrganizationDaoJdbc(defaultDataSource, permanentDeleteDataSource, fhirContext);
+		Organization createdParentOrg = orgDao.create(parentOrg);
+		Organization createdMemberOrg = orgDao.create(memberOrg);
+
+		OrganizationAffiliation aff = new OrganizationAffiliation();
+		aff.setActive(true);
+		aff.getCodeFirstRep().getCodingFirstRep().setSystem("http://dsf.dev/fhir/CodeSystem/organization-role")
+				.setCode("DIC");
+		aff.getOrganization().setReference("Organization/" + createdParentOrg.getIdElement().getIdPart());
+		aff.getParticipatingOrganization().setReference("Organization/" + createdMemberOrg.getIdElement().getIdPart());
+
+		OrganizationAffiliation createdAff = organizationAffiliationDao.create(aff);
+
+		D d = createResource();
+		readAccessHelper.addRole(d, "parent.com", "http://dsf.dev/fhir/CodeSystem/organization-role", "DIC");
+
+		D v1 = getDao().create(d);
+		assertEquals(1L, (long) v1.getIdElement().getVersionIdPartAsLong());
+
+		assertReadAccessEntryCount(2, 1, v1, READ_ACCESS_TAG_VALUE_LOCAL);
+		assertReadAccessEntryCount(2, 1, v1, READ_ACCESS_TAG_VALUE_ROLE, createdMemberOrg, createdAff);
+
+		createdAff.getCodeFirstRep().getCodingFirstRep().setCode("HRP");
+		OrganizationAffiliation updatedAff = organizationAffiliationDao.update(createdAff);
+		
+		assertReadAccessEntryCount(1, 1, v1, READ_ACCESS_TAG_VALUE_LOCAL);
+		assertReadAccessEntryCount(1, 0, v1, READ_ACCESS_TAG_VALUE_ROLE, createdMemberOrg, updatedAff);
+	}
+
+	@Test
 	public void testReadAccessTriggerRoleUpdateMemberOrganizationNonActive() throws Exception
 	{
 		final OrganizationAffiliationDaoJdbc organizationAffiliationDao = new OrganizationAffiliationDaoJdbc(

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationAffiliationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationAffiliationDaoTest.java
@@ -349,8 +349,8 @@ public class OrganizationAffiliationDaoTest
 			{
 				String line = generateLine();
 
-				if (len != TASK_ROW_LINE_LENGTH)
-					throw new IllegalArgumentException("Buffer length " + TASK_ROW_LINE_LENGTH + " expected");
+				if (line.length() != TASK_ROW_LINE_LENGTH)
+					throw new IllegalArgumentException("Line length " + TASK_ROW_LINE_LENGTH + " expected");
 
 				System.arraycopy(line.toCharArray(), 0, cbuf, 0, TASK_ROW_LINE_LENGTH);
 				currentTask++;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationAffiliationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationAffiliationDaoTest.java
@@ -324,12 +324,12 @@ public class OrganizationAffiliationDaoTest
 		}
 	}
 
-	private class TaskAsCsvGeneratorReader extends Reader
+	private static class TaskAsCsvGeneratorReader extends Reader
 	{
 		public static final int TASK_ROW_LINE_LENGTH = 1615;
 
+		private final int maxTasks;
 		private int currentTask;
-		private int maxTasks;
 
 		public TaskAsCsvGeneratorReader(int maxTasks)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationAffiliationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationAffiliationDaoTest.java
@@ -326,7 +326,7 @@ public class OrganizationAffiliationDaoTest
 
 	private class TaskAsCsvGeneratorReader extends Reader
 	{
-		public static final int LINE_LENGHT = 1615;
+		public static final int TASK_ROW_LINE_LENGTH = 1615;
 
 		private int currentTask;
 		private int maxTasks;
@@ -339,23 +339,23 @@ public class OrganizationAffiliationDaoTest
 		@Override
 		public int read(char[] cbuf, int off, int len) throws IOException
 		{
-			if (len != LINE_LENGHT)
-				throw new IllegalArgumentException("Buffer length " + LINE_LENGHT + " expected, not " + len);
-			if (off % LINE_LENGHT != 0)
-				throw new IllegalArgumentException("Buffer offset mod " + LINE_LENGHT + " == 0 expected, not "
-						+ (off & LINE_LENGHT) + " (off = " + off + ")");
+			if (len != TASK_ROW_LINE_LENGTH)
+				throw new IllegalArgumentException("Buffer length " + TASK_ROW_LINE_LENGTH + " expected, not " + len);
+			if (off % TASK_ROW_LINE_LENGTH != 0)
+				throw new IllegalArgumentException("Buffer offset mod " + TASK_ROW_LINE_LENGTH + " == 0 expected, not "
+						+ (off & TASK_ROW_LINE_LENGTH) + " (off = " + off + ")");
 
 			if (currentTask < maxTasks)
 			{
 				String line = generateLine();
 
-				if (len != LINE_LENGHT)
-					throw new IllegalArgumentException("Buffer length " + LINE_LENGHT + " expected");
+				if (len != TASK_ROW_LINE_LENGTH)
+					throw new IllegalArgumentException("Buffer length " + TASK_ROW_LINE_LENGTH + " expected");
 
-				System.arraycopy(line.toCharArray(), 0, cbuf, 0, LINE_LENGHT);
+				System.arraycopy(line.toCharArray(), 0, cbuf, 0, TASK_ROW_LINE_LENGTH);
 				currentTask++;
 
-				return LINE_LENGHT;
+				return TASK_ROW_LINE_LENGTH;
 			}
 			else
 				return -1;
@@ -414,7 +414,7 @@ public class OrganizationAffiliationDaoTest
 			CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
 			TaskAsCsvGeneratorReader taskGenerator = new TaskAsCsvGeneratorReader(taskCount);
 			long insertedRows = copyManager.copyIn("COPY tasks FROM STDIN (FORMAT csv)", taskGenerator,
-					TaskAsCsvGeneratorReader.LINE_LENGHT);
+					TaskAsCsvGeneratorReader.TASK_ROW_LINE_LENGTH);
 
 			assertEquals(taskCount, insertedRows);
 		}

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -17,7 +19,11 @@ import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.Test;
+import org.postgresql.copy.CopyManager;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.util.PGobject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.dsf.fhir.authorization.read.ReadAccessHelper;
 import dev.dsf.fhir.authorization.read.ReadAccessHelperImpl;
@@ -27,6 +33,8 @@ import dev.dsf.fhir.dao.jdbc.OrganizationDaoJdbc;
 
 public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization, OrganizationDao>
 {
+	private static final Logger logger = LoggerFactory.getLogger(OrganizationDaoTest.class);
+
 	private static final String name = "Demo Organization";
 	private static final boolean active = true;
 
@@ -234,8 +242,8 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 		org.getIdentifierFirstRep().setSystem(ReadAccessHelper.ORGANIZATION_IDENTIFIER_SYSTEM)
 				.setValue("organization.com");
 
-		Organization cretedOrg = dao.create(org);
-		assertNotNull(cretedOrg);
+		Organization createdOrg = dao.create(org);
+		assertNotNull(createdOrg);
 
 		Binary binary = new Binary();
 		binary.setContentType("text/plain");
@@ -246,6 +254,96 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 		Binary createdBinary = binaryDao.create(binary);
 		assertNotNull(createdBinary);
 
-		dao.update(cretedOrg);
+		dao.update(createdOrg);
+	}
+
+	private class TaskAsCsvGeneratorReader extends Reader
+	{
+		public static final int LINE_LENGHT = 1615;
+
+		private int currentTask;
+		private int maxTasks;
+
+		public TaskAsCsvGeneratorReader(int maxTasks)
+		{
+			this.maxTasks = maxTasks;
+		}
+
+		@Override
+		public int read(char[] cbuf, int off, int len) throws IOException
+		{
+			if (len != LINE_LENGHT)
+				throw new IllegalArgumentException("Buffer length " + LINE_LENGHT + " expected, not " + len);
+			if (off % LINE_LENGHT != 0)
+				throw new IllegalArgumentException("Buffer offset mod " + LINE_LENGHT + " == 0 expected, not "
+						+ (off & LINE_LENGHT) + " (off = " + off + ")");
+
+			if (currentTask < maxTasks)
+			{
+				String line = generateLine();
+
+				if (len != LINE_LENGHT)
+					throw new IllegalArgumentException("Buffer length " + LINE_LENGHT + " expected");
+
+				System.arraycopy(line.toCharArray(), 0, cbuf, 0, LINE_LENGHT);
+				currentTask++;
+
+				return LINE_LENGHT;
+			}
+			else
+				return -1;
+		}
+
+		@Override
+		public void close() throws IOException
+		{
+		}
+
+		private String generateLine()
+		{
+			String id = UUID.randomUUID().toString();
+			return "${id},3,,\"{\"\"resourceType\"\":\"\"Task\"\",\"\"id\"\":\"\"${id}\"\",\"\"meta\"\":{\"\"versionId\"\":\"\"3\"\",\"\"lastUpdated\"\":\"\"2024-10-01T18:22:06.765+02:00\"\",\"\"profile\"\":[\"\"http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-execute|1.0\"\"]},\"\"instantiatesCanonical\"\":\"\"http://medizininformatik-initiative.de/bpe/Process/feasibilityExecute|1.0\"\",\"\"status\"\":\"\"completed\"\",\"\"intent\"\":\"\"order\"\",\"\"authoredOn\"\":\"\"2024-10-01T18:22:07+02:00\"\",\"\"requester\"\":{\"\"type\"\":\"\"Organization\"\",\"\"identifier\"\":{\"\"system\"\":\"\"http://dsf.dev/sid/organization-identifier\"\",\"\"value\"\":\"\"organization.com\"\"}},\"\"restriction\"\":{\"\"recipient\"\":[{\"\"type\"\":\"\"Organization\"\",\"\"identifier\"\":{\"\"system\"\":\"\"http://dsf.dev/sid/organization-identifier\"\",\"\"value\"\":\"\"organization.com\"\"}}]},\"\"input\"\":[{\"\"type\"\":{\"\"coding\"\":[{\"\"system\"\":\"\"http://dsf.dev/fhir/CodeSystem/bpmn-message\"\",\"\"code\"\":\"\"message-name\"\"}]},\"\"valueString\"\":\"\"feasibilityExecuteMessage\"\"},{\"\"type\"\":{\"\"coding\"\":[{\"\"system\"\":\"\"http://dsf.dev/fhir/CodeSystem/bpmn-message\"\",\"\"code\"\":\"\"business-key\"\"}]},\"\"valueString\"\":\"\"${business-key}\"\"},{\"\"type\"\":{\"\"coding\"\":[{\"\"system\"\":\"\"http://dsf.dev/fhir/CodeSystem/bpmn-message\"\",\"\"code\"\":\"\"correlation-key\"\"}]},\"\"valueString\"\":\"\"${correlation-key}\"\"},{\"\"type\"\":{\"\"coding\"\":[{\"\"system\"\":\"\"http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility\"\",\"\"code\"\":\"\"measure-reference\"\"}]},\"\"valueReference\"\":{\"\"reference\"\":\"\"https://dsf.fdpg.test.forschen-fuer-gesundheit.de/fhir/Measure/02bb7540-0d99-4c0e-8764-981e545cf646\"\"}}]}\"\n"
+					.replace("${id}", id).replace("${business-key}", UUID.randomUUID().toString())
+					.replace("${correlation-key}", UUID.randomUUID().toString());
+		}
+	}
+
+	@Test
+	public void testBigUpdate() throws Exception
+	{
+		Organization org = new Organization();
+		org.setActive(true);
+		org.getIdentifierFirstRep().setSystem(ReadAccessHelper.ORGANIZATION_IDENTIFIER_SYSTEM)
+				.setValue("organization.com");
+
+		Organization createdOrg = dao.create(org);
+		assertNotNull(createdOrg);
+
+		final int taskCount = 500_000;
+
+		logger.info("Inserting {} Task resources ...", taskCount);
+		try (Connection connection = defaultDataSource.getConnection())
+		{
+			CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
+			TaskAsCsvGeneratorReader taskGenerator = new TaskAsCsvGeneratorReader(taskCount);
+			long insertedRows = copyManager.copyIn("COPY tasks FROM STDIN (FORMAT csv)", taskGenerator,
+					TaskAsCsvGeneratorReader.LINE_LENGHT);
+
+			assertEquals(taskCount, insertedRows);
+		}
+		logger.info("Inserting {} Task resources [Done]", taskCount);
+
+		long t0 = System.currentTimeMillis();
+
+		Organization updatedOrg1 = dao.update(createdOrg);
+		assertNotNull(updatedOrg1);
+
+		Organization updatedOrg2 = dao.update(createdOrg);
+		assertNotNull(updatedOrg2);
+
+		long t1 = System.currentTimeMillis();
+
+		logger.info("Organization updates executed in {} ms", t1 - t0);
+		assertTrue("Organization updates took longer then 200 ms", t1 - t0 <= 200);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
@@ -259,7 +259,7 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 
 	private class TaskAsCsvGeneratorReader extends Reader
 	{
-		public static final int LINE_LENGHT = 1615;
+		public static final int TASK_ROW_LINE_LENGTH = 1615;
 
 		private int currentTask;
 		private int maxTasks;
@@ -272,23 +272,23 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 		@Override
 		public int read(char[] cbuf, int off, int len) throws IOException
 		{
-			if (len != LINE_LENGHT)
-				throw new IllegalArgumentException("Buffer length " + LINE_LENGHT + " expected, not " + len);
-			if (off % LINE_LENGHT != 0)
-				throw new IllegalArgumentException("Buffer offset mod " + LINE_LENGHT + " == 0 expected, not "
-						+ (off & LINE_LENGHT) + " (off = " + off + ")");
+			if (len != TASK_ROW_LINE_LENGTH)
+				throw new IllegalArgumentException("Buffer length " + TASK_ROW_LINE_LENGTH + " expected, not " + len);
+			if (off % TASK_ROW_LINE_LENGTH != 0)
+				throw new IllegalArgumentException("Buffer offset mod " + TASK_ROW_LINE_LENGTH + " == 0 expected, not "
+						+ (off & TASK_ROW_LINE_LENGTH) + " (off = " + off + ")");
 
 			if (currentTask < maxTasks)
 			{
 				String line = generateLine();
 
-				if (len != LINE_LENGHT)
-					throw new IllegalArgumentException("Buffer length " + LINE_LENGHT + " expected");
+				if (len != TASK_ROW_LINE_LENGTH)
+					throw new IllegalArgumentException("Buffer length " + TASK_ROW_LINE_LENGTH + " expected");
 
-				System.arraycopy(line.toCharArray(), 0, cbuf, 0, LINE_LENGHT);
+				System.arraycopy(line.toCharArray(), 0, cbuf, 0, TASK_ROW_LINE_LENGTH);
 				currentTask++;
 
-				return LINE_LENGHT;
+				return TASK_ROW_LINE_LENGTH;
 			}
 			else
 				return -1;
@@ -327,7 +327,7 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 			CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
 			TaskAsCsvGeneratorReader taskGenerator = new TaskAsCsvGeneratorReader(taskCount);
 			long insertedRows = copyManager.copyIn("COPY tasks FROM STDIN (FORMAT csv)", taskGenerator,
-					TaskAsCsvGeneratorReader.LINE_LENGHT);
+					TaskAsCsvGeneratorReader.TASK_ROW_LINE_LENGTH);
 
 			assertEquals(taskCount, insertedRows);
 		}

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
@@ -257,12 +257,12 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 		dao.update(createdOrg);
 	}
 
-	private class TaskAsCsvGeneratorReader extends Reader
+	private static class TaskAsCsvGeneratorReader extends Reader
 	{
 		public static final int TASK_ROW_LINE_LENGTH = 1615;
 
+		private final int maxTasks;
 		private int currentTask;
-		private int maxTasks;
 
 		public TaskAsCsvGeneratorReader(int maxTasks)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/dao/OrganizationDaoTest.java
@@ -282,8 +282,8 @@ public class OrganizationDaoTest extends AbstractReadAccessDaoTest<Organization,
 			{
 				String line = generateLine();
 
-				if (len != TASK_ROW_LINE_LENGTH)
-					throw new IllegalArgumentException("Buffer length " + TASK_ROW_LINE_LENGTH + " expected");
+				if (line.length() != TASK_ROW_LINE_LENGTH)
+					throw new IllegalArgumentException("Line length " + TASK_ROW_LINE_LENGTH + " expected");
 
 				System.arraycopy(line.toCharArray(), 0, cbuf, 0, TASK_ROW_LINE_LENGTH);
 				currentTask++;

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
@@ -104,7 +104,7 @@
 				</configuration>
 				<!-- Workaround for exec maven plugin version 3.1.0 issue -->
 				<!-- https://github.com/mojohaus/exec-maven-plugin/issues/247 -->
-				<!-- <dependencies> <dependency> <groupId>dev.dsf</groupId> <artifactId>dsf-tools-bundle-generator</artifactId> <version>1.5.3-SNAPSHOT</version> </dependency>
+				<!-- <dependencies> <dependency> <groupId>dev.dsf</groupId> <artifactId>dsf-tools-bundle-generator</artifactId> <version>1.6.0-SNAPSHOT</version> </dependency>
 					</dependencies> -->
 			</plugin>
 		</plugins>

--- a/dsf-fhir/dsf-fhir-webservice-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-webservice-client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/dsf-fhir-websocket-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-websocket-client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-fhir/pom.xml
+++ b/dsf-fhir/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-tools/dsf-tools-build-info-reader/pom.xml
+++ b/dsf-tools/dsf-tools-build-info-reader/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-bundle-generator/pom.xml
+++ b/dsf-tools/dsf-tools-bundle-generator/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-db-migration/pom.xml
+++ b/dsf-tools/dsf-tools-db-migration/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-docker-secrets-reader/pom.xml
+++ b/dsf-tools/dsf-tools-docker-secrets-reader/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-documentation-generator/pom.xml
+++ b/dsf-tools/dsf-tools-documentation-generator/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-proxy-test/pom.xml
+++ b/dsf-tools/dsf-tools-proxy-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/dsf-tools-test-data-generator/pom.xml
+++ b/dsf-tools/dsf-tools-test-data-generator/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-tools/pom.xml
+++ b/dsf-tools/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>dev.dsf</groupId>
 	<artifactId>dsf-pom</artifactId>
-	<version>1.5.3-SNAPSHOT</version>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
* Adds `OrganizationAffiliation` role update test case.
* Adds `Organization` and `OrganizationAffiliation` update test cases for database pre filled with 500_000 rows in `tasks` table.
* Adds new `all_read_access_resources` view that contains all resources except `Task` and `QuestionnaireResponse` as read access to both is not configured via meta read-access tags.
* Improves performance of `AFTER INSERT ON organizations` and `AFTER INSERT ON organization_affiliations` trigger.

closes #230 