### PR TITLE
Issue/272 subscriptions

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PropertiesConfig.java
@@ -126,7 +126,7 @@ public class PropertiesConfig implements InitializingBean
 	private long websocketRetrySleepMillis;
 
 	@Documentation(description = "Directory containing the DSF BPE process plugins for deployment on startup of the DSF BPE server", recommendation = "Change only if you don't use the provided directory structure from the installation guide or made changes to tit")
-	@Value("${dev.dsf.bpe.process.plugin.directroy:process}")
+	@Value("${dev.dsf.bpe.process.plugin.directory:process}")
 	private String processPluginDirectory;
 
 	@Documentation(description = "List of process names that should be excluded from deployment during startup of the DSF BPE server; comma or space separated list, YAML block scalars supported", recommendation = "Only deploy processes that can be started depending on your organization's roles in the Allow-List", example = "dsfdev_updateAllowList|1.0, another_process|x.y")

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/PropertiesConfig.java
@@ -110,11 +110,11 @@ public class PropertiesConfig implements InitializingBean
 	private boolean webserviceClientLocalVerbose;
 
 	@Documentation(description = "Subscription to receive notifications about task resources from the DSF FHIR server")
-	@Value("${dev.dsf.bpe.fhir.task.subscription.search.parameter:?criteria=Task%3Fstatus%3Drequested&status=active&type=websocket&payload=application/fhir%2Bjson}")
+	@Value("${dev.dsf.bpe.fhir.task.subscription.search.parameter:?criteria:exact=Task%3Fstatus%3Drequested&status=active&type=websocket&payload=application/fhir%2Bjson}")
 	private String taskSubscriptionSearchParameter;
 
 	@Documentation(description = "Subscription to receive notifications about questionnaire response resources from the DSF FHIR server")
-	@Value("${dev.dsf.bpe.fhir.questionnaire.response.subscription.search.parameter:?criteria=QuestionnaireResponse%3Fstatus%3Dcompleted&status=active&type=websocket&payload=application/fhir%2Bjson}")
+	@Value("${dev.dsf.bpe.fhir.questionnaire.response.subscription.search.parameter:?criteria:exact=QuestionnaireResponse%3Fstatus%3Dcompleted&status=active&type=websocket&payload=application/fhir%2Bjson}")
 	private String questionnaireResponseSubscriptionSearchParameter;
 
 	@Documentation(description = "Number of retries until a websocket connection can be established with the DSF FHIR server, `-1` means infinite number of retries")

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
@@ -128,7 +128,7 @@ public class SubscriptionAuthorizationRule extends AbstractMetaTagAuthorizationR
 	@Override
 	protected boolean resourceExists(Connection connection, Subscription newResource)
 	{
-		Map<String, List<String>> queryParameters = Map.of("criteria",
+		Map<String, List<String>> queryParameters = Map.of("criteria:exact",
 				Collections.singletonList(newResource.getCriteria()), "type",
 				Collections.singletonList(newResource.getChannel().getType().toCode()), "payload",
 				Collections.singletonList(newResource.getChannel().getPayload()));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/SubscriptionAuthorizationRule.java
@@ -3,9 +3,7 @@ package dev.dsf.fhir.authorization;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -25,7 +23,6 @@ import dev.dsf.fhir.dao.SubscriptionDao;
 import dev.dsf.fhir.dao.provider.DaoProvider;
 import dev.dsf.fhir.help.ParameterConverter;
 import dev.dsf.fhir.search.PageAndCount;
-import dev.dsf.fhir.search.PartialResult;
 import dev.dsf.fhir.search.SearchQuery;
 import dev.dsf.fhir.search.SearchQueryParameterError;
 import dev.dsf.fhir.service.ReferenceResolver;
@@ -128,26 +125,10 @@ public class SubscriptionAuthorizationRule extends AbstractMetaTagAuthorizationR
 	@Override
 	protected boolean resourceExists(Connection connection, Subscription newResource)
 	{
-		Map<String, List<String>> queryParameters = Map.of("criteria:exact",
-				Collections.singletonList(newResource.getCriteria()), "type",
-				Collections.singletonList(newResource.getChannel().getType().toCode()), "payload",
-				Collections.singletonList(newResource.getChannel().getPayload()));
-		SubscriptionDao dao = getDao();
-		SearchQuery<Subscription> query = dao.createSearchQueryWithoutUserFilter(PageAndCount.exists())
-				.configureParameters(queryParameters);
-
-		List<SearchQueryParameterError> uQp = query.getUnsupportedQueryParameters();
-		if (!uQp.isEmpty())
-		{
-			logger.warn("Unable to search for Subscription: Unsupported query parameters: {}", uQp);
-
-			throw new IllegalStateException("Unable to search for Subscription: Unsupported query parameters");
-		}
-
 		try
 		{
-			PartialResult<Subscription> result = dao.searchWithTransaction(connection, query);
-			return result.getTotal() >= 1;
+			return getDao().existsByCriteriaChannelTypeAndChannelPayload(newResource.getCriteria(),
+					newResource.getChannel().getType().toCode(), newResource.getChannel().getPayload());
 		}
 		catch (SQLException e)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/SubscriptionDao.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/SubscriptionDao.java
@@ -9,4 +9,7 @@ import org.hl7.fhir.r4.model.Subscription.SubscriptionStatus;
 public interface SubscriptionDao extends ResourceDao<Subscription>
 {
 	List<Subscription> readByStatus(SubscriptionStatus status) throws SQLException;
+
+	boolean existsByCriteriaChannelTypeAndChannelPayload(String criteria, String channelType, String channelPayload)
+			throws SQLException;
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/SubscriptionDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/SubscriptionDaoJdbc.java
@@ -66,4 +66,28 @@ public class SubscriptionDaoJdbc extends AbstractResourceDaoJdbc<Subscription> i
 			}
 		}
 	}
+
+	@Override
+	public boolean existsByCriteriaChannelTypeAndChannelPayload(String criteria, String channelType,
+			String channelPayload) throws SQLException
+	{
+		try (Connection connection = getDataSource().getConnection();
+				PreparedStatement statement = connection
+						.prepareStatement("SELECT count(*) FROM current_subscriptions WHERE "
+								+ "subscription->>'criteria' = ? AND subscription->'channel'->>'type' = ? AND "
+								+ (channelPayload == null ? "NOT subscription->'channel' ?? 'payload'"
+										: "subscription->'channel'->>'payload' = ?")))
+		{
+			statement.setString(1, criteria);
+			statement.setString(2, channelType);
+
+			if (channelPayload != null)
+				statement.setString(3, channelPayload);
+
+			try (ResultSet result = statement.executeQuery())
+			{
+				return result.next() && result.getInt(1) > 0;
+			}
+		}
+	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/service/ValidationSupportWithCache.java
@@ -266,7 +266,7 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 	@Override
 	public IBaseResource fetchStructureDefinition(String url)
 	{
-		logger.trace("Fetiching structure-definition '{}'", url);
+		logger.trace("Fetching structure-definition '{}'", url);
 
 		if (url == null || url.isBlank())
 			return null;
@@ -283,7 +283,7 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 	@Override
 	public IBaseResource fetchCodeSystem(String url)
 	{
-		logger.trace("Fetiching code-system '{}'", url);
+		logger.trace("Fetching code-system '{}'", url);
 
 		if (url == null || url.isBlank())
 			return null;
@@ -300,7 +300,7 @@ public class ValidationSupportWithCache implements IValidationSupport, EventHand
 	@Override
 	public IBaseResource fetchValueSet(String url)
 	{
-		logger.trace("Fetiching value-set '{}'", url);
+		logger.trace("Fetching value-set '{}'", url);
 
 		if (url == null || url.isBlank())
 			return null;

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/db/unique_trigger_functions/subscriptions_unique.sql
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/db/unique_trigger_functions/subscriptions_unique.sql
@@ -1,10 +1,11 @@
 CREATE OR REPLACE FUNCTION subscriptions_unique() RETURNS TRIGGER AS $$
 BEGIN
-	PERFORM pg_advisory_xact_lock(hashtext((NEW.subscription->>'criteria') || (NEW.subscription->'channel'->>'type') || (NEW.subscription->'channel'->>'payload')));
+	PERFORM pg_advisory_xact_lock(hashtext((NEW.subscription->>'criteria') || (NEW.subscription->'channel'->>'type')));
 	IF EXISTS (SELECT 1 FROM current_subscriptions WHERE subscription_id <> NEW.subscription_id
 		AND subscription->>'criteria' = NEW.subscription->>'criteria'
 		AND subscription->'channel'->>'type' = NEW.subscription->'channel'->>'type'
-		AND subscription->'channel'->>'payload' = NEW.subscription->'channel'->>'payload') THEN
+		AND ((subscription->'channel'->>'payload' = NEW.subscription->'channel'->>'payload')
+			OR (NOT subscription->'channel' ? 'payload' AND NOT NEW.subscription->'channel' ? 'payload'))) THEN
 		RAISE EXCEPTION 'Conflict: Not inserting Subscription with criteria %, channel.type % and channel.payload %, resource already exists with given criteria, channel type and channel payload',
 			NEW.subscription->>'criteria', NEW.subscription->'channel'->>'type', NEW.subscription->'channel'->>'payload' USING ERRCODE = 'unique_violation';
 	ELSE

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/ParallelCreateIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/ParallelCreateIntegrationTest.java
@@ -311,17 +311,33 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsViaTransactionBundle() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadViaTransactionBundle() throws Exception
 	{
-		Bundle bundle = createBundle(BundleType.TRANSACTION, createSubscription(), null, 2);
+		Bundle bundle = createBundle(BundleType.TRANSACTION, createSubscription(true), null, 2);
 
 		expectForbidden(() -> getWebserviceClient().postBundle(bundle));
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsViaBatchBundle() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadViaBatchBundle() throws Exception
 	{
-		Bundle bundle = createBundle(BundleType.BATCH, createSubscription(), null, 2);
+		Bundle bundle = createBundle(BundleType.BATCH, createSubscription(true), null, 2);
+
+		checkReturnBatchBundle(getWebserviceClient().postBundle(bundle));
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadViaTransactionBundle() throws Exception
+	{
+		Bundle bundle = createBundle(BundleType.TRANSACTION, createSubscription(false), null, 2);
+
+		expectForbidden(() -> getWebserviceClient().postBundle(bundle));
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadViaBatchBundle() throws Exception
+	{
+		Bundle bundle = createBundle(BundleType.BATCH, createSubscription(false), null, 2);
 
 		checkReturnBatchBundle(getWebserviceClient().postBundle(bundle));
 	}
@@ -585,9 +601,9 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsViaTransactionBundleWithIfNoneExists() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadViaTransactionBundleWithIfNoneExists() throws Exception
 	{
-		Bundle bundle = createBundle(BundleType.TRANSACTION, createSubscription(),
+		Bundle bundle = createBundle(BundleType.TRANSACTION, createSubscription(true),
 				(s, r) -> r
 						.setIfNoneExist("criteria=" + s.getCriteria() + "&type=" + s.getChannel().getType().toCode()),
 				2);
@@ -596,9 +612,31 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsViaBatchBundleWithIfNoneExists() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadViaBatchBundleWithIfNoneExists() throws Exception
 	{
-		Bundle bundle = createBundle(BundleType.BATCH, createSubscription(),
+		Bundle bundle = createBundle(BundleType.BATCH, createSubscription(true),
+				(s, r) -> r
+						.setIfNoneExist("criteria=" + s.getCriteria() + "&type=" + s.getChannel().getType().toCode()),
+				2);
+
+		testCreateDuplicatesViaBundleWithIfNoneExists(bundle, BundleType.BATCHRESPONSE);
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadViaTransactionBundleWithIfNoneExists() throws Exception
+	{
+		Bundle bundle = createBundle(BundleType.TRANSACTION, createSubscription(false),
+				(s, r) -> r
+						.setIfNoneExist("criteria=" + s.getCriteria() + "&type=" + s.getChannel().getType().toCode()),
+				2);
+
+		testCreateDuplicatesViaBundleWithIfNoneExists(bundle, BundleType.TRANSACTIONRESPONSE);
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadViaBatchBundleWithIfNoneExists() throws Exception
+	{
+		Bundle bundle = createBundle(BundleType.BATCH, createSubscription(false),
 				(s, r) -> r
 						.setIfNoneExist("criteria=" + s.getCriteria() + "&type=" + s.getChannel().getType().toCode()),
 				2);
@@ -825,16 +863,27 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsParallelDirect() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadParallelDirect() throws Exception
 	{
 		testCreateDuplicatesParallel(() ->
 		{
-			Subscription returnS = getWebserviceClient().create(createSubscription());
+			Subscription returnS = getWebserviceClient().create(createSubscription(true));
 			assertNotNull(returnS);
 		}, SubscriptionDao.class,
 				s -> SUBSCRIPTION_CRITERIA.equals(s.getCriteria())
 						&& SUBSCRIPTION_CHANNEL_TYPE.equals(s.getChannel().getType())
 						&& SUBSCRIPTION_CHANNEL_PAYLOAD.equals(s.getChannel().getPayload()));
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadParallelDirect() throws Exception
+	{
+		testCreateDuplicatesParallel(() ->
+		{
+			Subscription returnS = getWebserviceClient().create(createSubscription(false));
+			assertNotNull(returnS);
+		}, SubscriptionDao.class, s -> SUBSCRIPTION_CRITERIA.equals(s.getCriteria())
+				&& SUBSCRIPTION_CHANNEL_TYPE.equals(s.getChannel().getType()) && s.getChannel().getPayload() == null);
 	}
 
 	@Test
@@ -1235,12 +1284,12 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsParallelTransactionBundle() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadParallelTransactionBundle() throws Exception
 	{
 		testCreateDuplicatesParallel(() ->
 		{
 			Bundle returnBundle = getWebserviceClient()
-					.postBundle(createBundle(BundleType.TRANSACTION, createSubscription(), null, 1));
+					.postBundle(createBundle(BundleType.TRANSACTION, createSubscription(true), null, 1));
 			assertNotNull(returnBundle);
 		}, SubscriptionDao.class,
 				s -> SUBSCRIPTION_CRITERIA.equals(s.getCriteria())
@@ -1249,12 +1298,12 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateDuplicateSubscriptionsParallelBatchBundle() throws Exception
+	public void testCreateDuplicateSubscriptionsWithPayloadParallelBatchBundle() throws Exception
 	{
 		testCreateDuplicatesParallel(() ->
 		{
 			Bundle returnBundle = getWebserviceClient()
-					.postBundle(createBundle(BundleType.BATCH, createSubscription(), null, 1));
+					.postBundle(createBundle(BundleType.BATCH, createSubscription(true), null, 1));
 			assertNotNull(returnBundle);
 
 			assertNotNull(returnBundle.getEntry());
@@ -1268,6 +1317,38 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 				s -> SUBSCRIPTION_CRITERIA.equals(s.getCriteria())
 						&& SUBSCRIPTION_CHANNEL_TYPE.equals(s.getChannel().getType())
 						&& SUBSCRIPTION_CHANNEL_PAYLOAD.equals(s.getChannel().getPayload()));
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadParallelTransactionBundle() throws Exception
+	{
+		testCreateDuplicatesParallel(() ->
+		{
+			Bundle returnBundle = getWebserviceClient()
+					.postBundle(createBundle(BundleType.TRANSACTION, createSubscription(false), null, 1));
+			assertNotNull(returnBundle);
+		}, SubscriptionDao.class, s -> SUBSCRIPTION_CRITERIA.equals(s.getCriteria())
+				&& SUBSCRIPTION_CHANNEL_TYPE.equals(s.getChannel().getType()) && s.getChannel().getPayload() == null);
+	}
+
+	@Test
+	public void testCreateDuplicateSubscriptionsWithoutPayloadParallelBatchBundle() throws Exception
+	{
+		testCreateDuplicatesParallel(() ->
+		{
+			Bundle returnBundle = getWebserviceClient()
+					.postBundle(createBundle(BundleType.BATCH, createSubscription(false), null, 1));
+			assertNotNull(returnBundle);
+
+			assertNotNull(returnBundle.getEntry());
+			assertEquals(1, returnBundle.getEntry().size());
+			assertNotNull(returnBundle.getEntry().get(0).getResponse());
+			assertNotNull(returnBundle.getEntry().get(0).getResponse().getStatus());
+
+			if ("403 Forbidden".equals(returnBundle.getEntry().get(0).getResponse().getStatus()))
+				throw new WebApplicationException(403);
+		}, SubscriptionDao.class, s -> SUBSCRIPTION_CRITERIA.equals(s.getCriteria())
+				&& SUBSCRIPTION_CHANNEL_TYPE.equals(s.getChannel().getType()) && s.getChannel().getPayload() == null);
 	}
 
 	@Test
@@ -1574,11 +1655,14 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 		return sD;
 	}
 
-	private Subscription createSubscription()
+	private Subscription createSubscription(boolean withPayload)
 	{
 		Subscription s = new Subscription().setStatus(SubscriptionStatus.ACTIVE).setReason("some reason")
-				.setCriteria(SUBSCRIPTION_CRITERIA).setChannel(new SubscriptionChannelComponent()
-						.setType(SUBSCRIPTION_CHANNEL_TYPE).setPayload(SUBSCRIPTION_CHANNEL_PAYLOAD));
+				.setCriteria(SUBSCRIPTION_CRITERIA)
+				.setChannel(new SubscriptionChannelComponent().setType(SUBSCRIPTION_CHANNEL_TYPE));
+
+		if (withPayload)
+			s.getChannel().setPayload(SUBSCRIPTION_CHANNEL_PAYLOAD);
 
 		getReadAccessHelper().addAll(s);
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/SubscriptionIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/SubscriptionIntegrationTest.java
@@ -62,6 +62,35 @@ public class SubscriptionIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
+	public void testCreateOkNoPayloadAllreadyExistsWithPayload() throws Exception
+	{
+		Subscription t = newSubscription("Task?status=completed");
+
+		SubscriptionDao dao = getSpringWebApplicationContext().getBean(SubscriptionDao.class);
+		dao.create(t);
+
+		t = newSubscription("Task?status=completed");
+		t.getChannel().setPayload(null);
+
+		Subscription created = getWebserviceClient().create(t);
+		assertNotNull(created);
+		assertTrue(created.getIdElement().hasValue());
+		assertEquals("1", created.getMeta().getVersionId());
+	}
+
+	@Test
+	public void testCreateNotOkNoPayloadAllreadyExistsWithoutPayload() throws Exception
+	{
+		Subscription t = newSubscription("Task?status=completed");
+		t.getChannel().setPayload(null);
+
+		SubscriptionDao dao = getSpringWebApplicationContext().getBean(SubscriptionDao.class);
+		dao.create(t);
+
+		expectForbidden(() -> getWebserviceClient().create(t));
+	}
+
+	@Test
 	public void testCreateInvalid() throws Exception
 	{
 		Subscription noStatus = newSubscription("Task?status=completed");

--- a/dsf-fhir/dsf-fhir-validation/src/main/resources/fhir/Subscription/dsf-bpmn-questionnaire-response-subscription.xml.post
+++ b/dsf-fhir/dsf-fhir-validation/src/main/resources/fhir/Subscription/dsf-bpmn-questionnaire-response-subscription.xml.post
@@ -1,1 +1,1 @@
-criteria=QuestionnaireResponse%3Fstatus%3Dcompleted&status=active&type=websocket&payload=application/fhir%2Bjson
+criteria:exact=QuestionnaireResponse%3Fstatus%3Dcompleted&status=active&type=websocket&payload=application/fhir%2Bjson

--- a/dsf-fhir/dsf-fhir-validation/src/main/resources/fhir/Subscription/dsf-bpmn-task-subscription.xml.post
+++ b/dsf-fhir/dsf-fhir-validation/src/main/resources/fhir/Subscription/dsf-bpmn-task-subscription.xml.post
@@ -1,1 +1,1 @@
-criteria=Task%3Fstatus%3Drequested&status=active&type=websocket&payload=application/fhir%2Bjson
+criteria:exact=Task%3Fstatus%3Drequested&status=active&type=websocket&payload=application/fhir%2Bjson

--- a/dsf-tools/dsf-tools-test-data-generator/src/main/resources/config-templates/java-test-bpe-config.properties
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/resources/config-templates/java-test-bpe-config.properties
@@ -29,7 +29,7 @@ dev.dsf.bpe.fhir.server.base.url=https://localhost:8001/fhir
 #dev.dsf.bpe.fhir.task.subscription.retry.max=-1
 #dev.dsf.bpe.fhir.task.subscription.retry.sleep=5000
 
-#dev.dsf.bpe.process.plugin.directroy=process
+#dev.dsf.bpe.process.plugin.directory=process
 #dev.dsf.bpe.process.excluded=
 #dev.dsf.bpe.process.retired=
 #dev.dsf.bpe.process.fhir.server.retry.max=-1


### PR DESCRIPTION
* Fixes wrong usage of `Subscription.criteria` search parameter by adding the `:exact` modifier.
* Fixes `SubscriptionAuthorizationRule` and DB unique function to handle Subscription resources without `channel.payload` property correctly.

closes #272 