### PR TITLE
Issue/279 bpe websocket not connected

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CheckReferencesCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CheckReferencesCommand.java
@@ -2,7 +2,6 @@ package dev.dsf.fhir.dao.command;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.EnumSet;
 import java.util.Map;
 
 import org.hl7.fhir.r4.model.Bundle;
@@ -10,10 +9,6 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r4.model.Task;
-import org.hl7.fhir.r4.model.Task.TaskStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import dev.dsf.common.auth.conf.Identity;
 import dev.dsf.fhir.dao.ResourceDao;
@@ -24,27 +19,27 @@ import dev.dsf.fhir.prefer.PreferReturnType;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.service.ResourceReference;
-import dev.dsf.fhir.service.ResourceReference.ReferenceType;
 import dev.dsf.fhir.validation.SnapshotGenerator;
+import dev.dsf.fhir.validation.ValidationRules;
 import jakarta.ws.rs.WebApplicationException;
 
 public class CheckReferencesCommand<R extends Resource, D extends ResourceDao<R>>
 		extends AbstractCommandWithResource<R, D> implements Command
 {
-	private static final Logger logger = LoggerFactory.getLogger(CheckReferencesCommand.class);
-
 	private final HTTPVerb verb;
+	private final ValidationRules validationRules;
 
 	public CheckReferencesCommand(int index, Identity identity, PreferReturnType returnType, Bundle bundle,
 			BundleEntryComponent entry, String serverBase, AuthorizationHelper authorizationHelper, R resource,
 			HTTPVerb verb, D dao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
 			ResponseGenerator responseGenerator, ReferenceExtractor referenceExtractor,
-			ReferenceResolver referenceResolver)
+			ReferenceResolver referenceResolver, ValidationRules validationRules)
 	{
 		super(4, index, identity, returnType, bundle, entry, serverBase, authorizationHelper, resource, dao,
 				exceptionHandler, parameterConverter, responseGenerator, referenceExtractor, referenceResolver);
 
 		this.verb = verb;
+		this.validationRules = validationRules;
 	}
 
 	@Override
@@ -55,25 +50,12 @@ public class CheckReferencesCommand<R extends Resource, D extends ResourceDao<R>
 		referencesHelper.checkReferences(idTranslationTable, connection, this::checkReferenceAfterUpdate);
 	}
 
-	// See also TaskServiceImpl#checkReferenceAfterUpdate
-	// See also AbstractResourceServiceImpl#checkReferenceAfterUpdate
-	// See also AbstractResourceServiceImpl#checkReferenceAfterCreate
 	private boolean checkReferenceAfterUpdate(ResourceReference ref)
 	{
-		if (resource instanceof Task task && HTTPVerb.PUT.equals(verb))
+		if (HTTPVerb.PUT.equals(verb))
 		{
-			if (EnumSet.of(TaskStatus.COMPLETED, TaskStatus.FAILED).contains(task.getStatus()))
-			{
-				ReferenceType refType = ref.getType(serverBase);
-				if ("Task.input".equals(ref.getLocation()) && ReferenceType.LITERAL_EXTERNAL.equals(refType))
-				{
-					logger.warn("Skipping check of {} reference '{}' at {} in resource with {}, version {}", refType,
-							ref.getReference().getReference(), "Task.input", resource.getIdElement().getIdPart(),
-							// we are checking against the pre-update resource
-							resource.getIdElement().getVersionIdPartAsLong() + 1);
-					return false;
-				}
-			}
+			// version -1 as we are checking against the pre-update resource
+			return validationRules.checkReferenceAfterUpdate(resource, ref, v -> v - 1);
 		}
 
 		return true;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/CommandConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/CommandConfig.java
@@ -59,7 +59,7 @@ public class CommandConfig
 				helperConfig.responseGenerator(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
 				eventConfig.eventManager(), eventConfig.eventGenerator(), authorizationConfig.authorizationHelper(),
 				validationConfig.validationHelper(), snapshotConfig.snapshotGenerator(),
-				this::transactionResourceFactory);
+				validationConfig.validationRules(), this::transactionResourceFactory);
 	}
 
 	@Bean
@@ -70,7 +70,7 @@ public class CommandConfig
 
 		ValidationHelper validationHelper = new ValidationHelperImpl(
 				new ResourceValidatorImpl(fhirConfig.fhirContext(), validationSupport),
-				helperConfig.responseGenerator());
+				helperConfig.responseGenerator(), validationConfig.validationRules());
 
 		SnapshotGenerator snapshotGenerator = new SnapshotGeneratorImpl(fhirConfig.fhirContext(), validationSupport);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/ValidationConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/ValidationConfig.java
@@ -20,6 +20,7 @@ import dev.dsf.fhir.service.ValidationSupportWithFetchFromDb;
 import dev.dsf.fhir.service.ValidationSupportWithFetchFromDbWithTransaction;
 import dev.dsf.fhir.validation.ResourceValidator;
 import dev.dsf.fhir.validation.ResourceValidatorImpl;
+import dev.dsf.fhir.validation.ValidationRules;
 
 @Configuration
 public class ValidationConfig
@@ -32,6 +33,9 @@ public class ValidationConfig
 
 	@Autowired
 	private HelperConfig helperConfig;
+
+	@Autowired
+	private PropertiesConfig propertiesConfig;
 
 	@Bean
 	public IValidationSupport validationSupport()
@@ -60,9 +64,15 @@ public class ValidationConfig
 	}
 
 	@Bean
+	public ValidationRules validationRules()
+	{
+		return new ValidationRules(propertiesConfig.getServerBaseUrl());
+	}
+
+	@Bean
 	public ValidationHelper validationHelper()
 	{
-		return new ValidationHelperImpl(resourceValidator(), helperConfig.responseGenerator());
+		return new ValidationHelperImpl(resourceValidator(), helperConfig.responseGenerator(), validationRules());
 	}
 
 	@Bean

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/WebserviceConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/WebserviceConfig.java
@@ -182,7 +182,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
 				daoConfig.activityDefinitionDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.activityDefinitionAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.activityDefinitionAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private ActivityDefinitionServiceImpl activityDefinitionServiceImpl()
@@ -193,7 +194,8 @@ public class WebserviceConfig
 				helperConfig.exceptionHandler(), eventConfig.eventGenerator(), helperConfig.responseGenerator(),
 				helperConfig.parameterConverter(), referenceConfig.referenceExtractor(),
 				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
-				authorizationConfig.authorizationRuleProvider(), historyConfig.historyService());
+				authorizationConfig.authorizationRuleProvider(), historyConfig.historyService(),
+				validationConfig.validationRules());
 	}
 
 	@Bean
@@ -208,7 +210,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.binaryDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.binaryAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.binaryAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private BinaryService binaryServiceImpl()
@@ -219,7 +222,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -234,7 +237,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.bundleDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.bundleAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.bundleAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private BundleService bundleServiceImpl()
@@ -245,7 +249,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -260,7 +264,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.codeSystemDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.codeSystemAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.codeSystemAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private CodeSystemServiceImpl codeSystemServiceImpl()
@@ -271,7 +276,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -286,7 +291,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
 				daoConfig.documentReferenceDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.documentReferenceAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.documentReferenceAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private DocumentReferenceServiceImpl documentReferenceServiceImpl()
@@ -297,7 +303,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -312,7 +318,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.endpointDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.endpointAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.endpointAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private EndpointServiceImpl endpointServiceImpl()
@@ -323,7 +330,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -338,7 +345,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.groupDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.groupAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.groupAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private GroupServiceImpl groupServiceImpl()
@@ -349,7 +357,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -364,7 +372,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
 				daoConfig.healthcareServiceDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.healthcareServiceAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.healthcareServiceAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private HealthcareServiceServiceImpl healthcareServiceServiceImpl()
@@ -375,7 +384,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -390,7 +399,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.libraryDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.libraryAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.libraryAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private LibraryServiceImpl libraryServiceImpl()
@@ -401,7 +411,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -416,7 +426,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.locationDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.locationAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.locationAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private LocationServiceImpl locationServiceImpl()
@@ -427,7 +438,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -448,7 +459,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.measureDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.measureAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.measureAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private MeasureServiceImpl measureServiceImpl()
@@ -459,7 +471,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -474,7 +486,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.measureReportDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.measureReportAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.measureReportAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private MeasureReportServiceImpl measureReportServiceImpl()
@@ -485,7 +498,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -500,7 +513,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.namingSystemDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.namingSystemAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.namingSystemAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private NamingSystemService namingSystemServiceImpl()
@@ -511,7 +525,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -526,7 +540,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.organizationDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.organizationAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.organizationAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private OrganizationServiceImpl organizationServiceImpl()
@@ -537,7 +552,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -553,7 +568,8 @@ public class WebserviceConfig
 				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
 				referenceConfig.referenceExtractor(), daoConfig.organizationAffiliationDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.organizationAffiliationAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.organizationAffiliationAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private OrganizationAffiliationServiceImpl organizationAffiliationServiceImpl()
@@ -565,7 +581,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -580,7 +596,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.patientDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.patientAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.patientAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private PatientServiceImpl patientServiceImpl()
@@ -591,7 +608,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -606,7 +623,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
 				daoConfig.practitionerRoleDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.practitionerRoleAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.practitionerRoleAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private PractitionerRoleServiceImpl practitionerRoleServiceImpl()
@@ -617,7 +635,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -632,7 +650,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.practitionerDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.practitionerAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.practitionerAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private PractitionerServiceImpl practitionerServiceImpl()
@@ -643,7 +662,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -658,7 +677,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.provenanceDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.provenanceAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.provenanceAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private ProvenanceServiceImpl provenanceServiceImpl()
@@ -669,7 +689,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -684,7 +704,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.questionnaireDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.questionnaireAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.questionnaireAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private QuestionnaireServiceImpl questionnaireServiceImpl()
@@ -695,7 +716,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -711,7 +732,8 @@ public class WebserviceConfig
 				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
 				referenceConfig.referenceExtractor(), daoConfig.questionnaireResponseDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.questionnaireResponseAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.questionnaireResponseAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private QuestionnaireResponseServiceImpl questionnaireResponseServiceImpl()
@@ -722,7 +744,8 @@ public class WebserviceConfig
 				helperConfig.exceptionHandler(), eventConfig.eventGenerator(), helperConfig.responseGenerator(),
 				helperConfig.parameterConverter(), referenceConfig.referenceExtractor(),
 				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
-				authorizationConfig.authorizationRuleProvider(), historyConfig.historyService());
+				authorizationConfig.authorizationRuleProvider(), historyConfig.historyService(),
+				validationConfig.validationRules());
 	}
 
 	@Bean
@@ -737,7 +760,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.researchStudyDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.researchStudyAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.researchStudyAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private ResearchStudyServiceImpl researchStudyServiceImpl()
@@ -748,7 +772,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -764,7 +788,8 @@ public class WebserviceConfig
 				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
 				referenceConfig.referenceExtractor(), daoConfig.structureDefinitionDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.structureDefinitionAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.structureDefinitionAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private StructureDefinitionServiceImpl structureDefinitionServiceImpl()
@@ -776,7 +801,7 @@ public class WebserviceConfig
 				helperConfig.parameterConverter(), referenceConfig.referenceExtractor(),
 				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
 				authorizationConfig.authorizationRuleProvider(), daoConfig.structureDefinitionSnapshotDao(),
-				snapshotConfig.snapshotGenerator(), historyConfig.historyService());
+				snapshotConfig.snapshotGenerator(), historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -791,7 +816,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.subscriptionDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.subscriptionAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.subscriptionAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private SubscriptionServiceImpl subscriptionServiceImpl()
@@ -802,7 +828,7 @@ public class WebserviceConfig
 				eventConfig.eventGenerator(), helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -817,7 +843,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.taskDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.taskAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.taskAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private TaskServiceImpl taskServiceImpl()
@@ -828,7 +855,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean
@@ -843,7 +870,8 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(), daoConfig.valueSetDao(),
 				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.valueSetAuthorizationRule(), validationConfig.resourceValidator());
+				authorizationConfig.valueSetAuthorizationRule(), validationConfig.resourceValidator(),
+				validationConfig.validationRules());
 	}
 
 	private ValueSetServiceImpl valueSetServiceImpl()
@@ -854,7 +882,7 @@ public class WebserviceConfig
 				helperConfig.responseGenerator(), helperConfig.parameterConverter(),
 				referenceConfig.referenceExtractor(), referenceConfig.referenceResolver(),
 				referenceConfig.referenceCleaner(), authorizationConfig.authorizationRuleProvider(),
-				historyConfig.historyService());
+				historyConfig.historyService(), validationConfig.validationRules());
 	}
 
 	@Bean

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/validation/ValidationRules.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/validation/ValidationRules.java
@@ -1,0 +1,83 @@
+package dev.dsf.fhir.validation;
+
+import java.util.function.Function;
+
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.Task.TaskStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.dsf.fhir.service.ResourceReference;
+import dev.dsf.fhir.service.ResourceReference.ReferenceType;
+
+public class ValidationRules
+{
+	private static final Logger logger = LoggerFactory.getLogger(ValidationRules.class);
+
+	private final String serverBase;
+
+	public ValidationRules(String serverBase)
+	{
+		this.serverBase = serverBase;
+	}
+
+	public boolean checkReferenceAfterCreate(Resource created, ResourceReference ref)
+	{
+		return checkReferenceAfterCreate(created, ref, Function.identity());
+	}
+
+	public boolean checkReferenceAfterCreate(Resource created, ResourceReference ref,
+			Function<Long, Long> logMessageVersionModifier)
+	{
+		return true;
+	}
+
+	public boolean checkReferenceAfterUpdate(Resource updated, ResourceReference ref)
+	{
+		return checkReferenceAfterUpdate(updated, ref, Function.identity());
+	}
+
+	public boolean checkReferenceAfterUpdate(Resource updated, ResourceReference ref,
+			Function<Long, Long> logMessageVersionModifier)
+	{
+		if (updated instanceof Task t)
+		{
+			ReferenceType refType = ref.getType(serverBase);
+
+			if (TaskStatus.FAILED.equals(t.getStatus()))
+			{
+				logger.debug("Skipping check of {} reference at {} in resource with {}, version {}", refType,
+						ref.getLocation(), t.getIdElement().getIdPart(), t.getIdElement().getVersionIdPartAsLong());
+
+				return false;
+			}
+
+			if (TaskStatus.COMPLETED.equals(t.getStatus()) && "Task.input".equals(ref.getLocation())
+					&& ReferenceType.LITERAL_EXTERNAL.equals(refType))
+			{
+				logger.debug("Skipping check of reference at {} in resource with id {}, version {}", "Task.input",
+						t.getIdElement().getIdPart(),
+						logMessageVersionModifier.apply(t.getIdElement().getVersionIdPartAsLong()));
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public boolean failOnErrorOrFatalBeforeCreate(Resource resource)
+	{
+		return true;
+	}
+
+	public boolean failOnErrorOrFatalBeforeUpdate(Resource resource)
+	{
+		if (resource instanceof Task t && TaskStatus.FAILED.equals(t.getStatus()))
+			return false;
+
+		return true;
+	}
+}
+

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ActivityDefinitionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ActivityDefinitionServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ActivityDefinitionService;
 
 public class ActivityDefinitionServiceImpl extends
@@ -24,10 +25,11 @@ public class ActivityDefinitionServiceImpl extends
 			ExceptionHandler exceptionHandler, EventGenerator eventGenerator, ResponseGenerator responseGenerator,
 			ParameterConverter parameterConverter, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService)
+			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService,
+			ValidationRules validationRules)
 	{
 		super(path, ActivityDefinition.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/BinaryServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/BinaryServiceImpl.java
@@ -18,6 +18,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.BinaryService;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -31,11 +32,11 @@ public class BinaryServiceImpl extends AbstractResourceServiceImpl<BinaryDao, Bi
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Binary.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/BundleServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/BundleServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.BundleService;
 
 public class BundleServiceImpl extends AbstractResourceServiceImpl<BundleDao, Bundle> implements BundleService
@@ -23,10 +24,10 @@ public class BundleServiceImpl extends AbstractResourceServiceImpl<BundleDao, Bu
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Bundle.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/CodeSystemServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/CodeSystemServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.CodeSystemService;
 
 public class CodeSystemServiceImpl extends AbstractResourceServiceImpl<CodeSystemDao, CodeSystem>
@@ -24,10 +25,10 @@ public class CodeSystemServiceImpl extends AbstractResourceServiceImpl<CodeSyste
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, CodeSystem.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/DocumentReferenceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/DocumentReferenceServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.DocumentReferenceService;
 
 public class DocumentReferenceServiceImpl extends AbstractResourceServiceImpl<DocumentReferenceDao, DocumentReference>
@@ -24,10 +25,10 @@ public class DocumentReferenceServiceImpl extends AbstractResourceServiceImpl<Do
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, DocumentReference.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/EndpointServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/EndpointServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.EndpointService;
 
 public class EndpointServiceImpl extends AbstractResourceServiceImpl<EndpointDao, Endpoint> implements EndpointService
@@ -23,10 +24,10 @@ public class EndpointServiceImpl extends AbstractResourceServiceImpl<EndpointDao
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Endpoint.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/GroupServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/GroupServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.GroupService;
 
 public class GroupServiceImpl extends AbstractResourceServiceImpl<GroupDao, Group> implements GroupService
@@ -23,10 +24,10 @@ public class GroupServiceImpl extends AbstractResourceServiceImpl<GroupDao, Grou
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Group.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/HealthcareServiceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/HealthcareServiceServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.HealthcareServiceService;
 
 public class HealthcareServiceServiceImpl extends AbstractResourceServiceImpl<HealthcareServiceDao, HealthcareService>
@@ -24,10 +25,10 @@ public class HealthcareServiceServiceImpl extends AbstractResourceServiceImpl<He
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, HealthcareService.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/LibraryServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/LibraryServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.LibraryService;
 
 public class LibraryServiceImpl extends AbstractResourceServiceImpl<LibraryDao, Library> implements LibraryService
@@ -23,10 +24,10 @@ public class LibraryServiceImpl extends AbstractResourceServiceImpl<LibraryDao, 
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Library.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/LocationServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/LocationServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.LocationService;
 
 public class LocationServiceImpl extends AbstractResourceServiceImpl<LocationDao, Location> implements LocationService
@@ -23,10 +24,10 @@ public class LocationServiceImpl extends AbstractResourceServiceImpl<LocationDao
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Location.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/MeasureReportServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/MeasureReportServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.MeasureReportService;
 
 public class MeasureReportServiceImpl extends AbstractResourceServiceImpl<MeasureReportDao, MeasureReport>
@@ -24,10 +25,10 @@ public class MeasureReportServiceImpl extends AbstractResourceServiceImpl<Measur
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, MeasureReport.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/MeasureServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/MeasureServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.MeasureService;
 
 public class MeasureServiceImpl extends AbstractResourceServiceImpl<MeasureDao, Measure> implements MeasureService
@@ -23,10 +24,10 @@ public class MeasureServiceImpl extends AbstractResourceServiceImpl<MeasureDao, 
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Measure.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/NamingSystemServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/NamingSystemServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.NamingSystemService;
 
 public class NamingSystemServiceImpl extends AbstractResourceServiceImpl<NamingSystemDao, NamingSystem>
@@ -24,10 +25,10 @@ public class NamingSystemServiceImpl extends AbstractResourceServiceImpl<NamingS
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, NamingSystem.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/OrganizationAffiliationServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/OrganizationAffiliationServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.OrganizationAffiliationService;
 
 public class OrganizationAffiliationServiceImpl
@@ -25,10 +26,11 @@ public class OrganizationAffiliationServiceImpl
 			ExceptionHandler exceptionHandler, EventGenerator eventGenerator, ResponseGenerator responseGenerator,
 			ParameterConverter parameterConverter, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService)
+			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService,
+			ValidationRules validationRules)
 	{
 		super(path, OrganizationAffiliation.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/OrganizationServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/OrganizationServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.OrganizationService;
 
 public class OrganizationServiceImpl extends AbstractResourceServiceImpl<OrganizationDao, Organization>
@@ -24,10 +25,10 @@ public class OrganizationServiceImpl extends AbstractResourceServiceImpl<Organiz
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Organization.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/PatientServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/PatientServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.PatientService;
 
 public class PatientServiceImpl extends AbstractResourceServiceImpl<PatientDao, Patient> implements PatientService
@@ -23,10 +24,10 @@ public class PatientServiceImpl extends AbstractResourceServiceImpl<PatientDao, 
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Patient.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/PractitionerRoleServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/PractitionerRoleServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.PractitionerRoleService;
 
 public class PractitionerRoleServiceImpl extends AbstractResourceServiceImpl<PractitionerRoleDao, PractitionerRole>
@@ -24,10 +25,10 @@ public class PractitionerRoleServiceImpl extends AbstractResourceServiceImpl<Pra
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, PractitionerRole.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/PractitionerServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/PractitionerServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.PractitionerService;
 
 public class PractitionerServiceImpl extends AbstractResourceServiceImpl<PractitionerDao, Practitioner>
@@ -24,10 +25,10 @@ public class PractitionerServiceImpl extends AbstractResourceServiceImpl<Practit
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Practitioner.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ProvenanceServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ProvenanceServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ProvenanceService;
 
 public class ProvenanceServiceImpl extends AbstractResourceServiceImpl<ProvenanceDao, Provenance>
@@ -24,10 +25,10 @@ public class ProvenanceServiceImpl extends AbstractResourceServiceImpl<Provenanc
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Provenance.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/QuestionnaireResponseServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/QuestionnaireResponseServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.QuestionnaireResponseService;
 
 public class QuestionnaireResponseServiceImpl
@@ -25,10 +26,11 @@ public class QuestionnaireResponseServiceImpl
 			ExceptionHandler exceptionHandler, EventGenerator eventGenerator, ResponseGenerator responseGenerator,
 			ParameterConverter parameterConverter, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService)
+			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService,
+			ValidationRules validationRules)
 	{
 		super(path, QuestionnaireResponse.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/QuestionnaireServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/QuestionnaireServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.QuestionnaireService;
 
 public class QuestionnaireServiceImpl extends AbstractResourceServiceImpl<QuestionnaireDao, Questionnaire>
@@ -24,10 +25,11 @@ public class QuestionnaireServiceImpl extends AbstractResourceServiceImpl<Questi
 			ExceptionHandler exceptionHandler, EventGenerator eventGenerator, ResponseGenerator responseGenerator,
 			ParameterConverter parameterConverter, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService)
+			AuthorizationRuleProvider authorizationRuleProvider, HistoryService historyService,
+			ValidationRules validationRules)
 	{
 		super(path, Questionnaire.class, serverBase, defaultPageCount, questionnaireDao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ResearchStudyServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ResearchStudyServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ResearchStudyService;
 
 public class ResearchStudyServiceImpl extends AbstractResourceServiceImpl<ResearchStudyDao, ResearchStudy>
@@ -24,10 +25,10 @@ public class ResearchStudyServiceImpl extends AbstractResourceServiceImpl<Resear
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, ResearchStudy.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/StructureDefinitionServiceImpl.java
@@ -42,6 +42,7 @@ import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
 import dev.dsf.fhir.validation.SnapshotGenerator;
 import dev.dsf.fhir.validation.SnapshotGenerator.SnapshotWithValidationMessages;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.StructureDefinitionService;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -63,11 +64,11 @@ public class StructureDefinitionServiceImpl extends
 			ParameterConverter parameterConverter, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			AuthorizationRuleProvider authorizationRuleProvider, StructureDefinitionDao structureDefinitionSnapshotDao,
-			SnapshotGenerator sanapshotGenerator, HistoryService historyService)
+			SnapshotGenerator sanapshotGenerator, HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, StructureDefinition.class, serverBase, defaultPageCount, dao, validator, eventHandler,
 				exceptionHandler, eventGenerator, responseGenerator, parameterConverter, referenceExtractor,
-				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService);
+				referenceResolver, referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 
 		this.snapshotDao = structureDefinitionSnapshotDao;
 		this.snapshotGenerator = sanapshotGenerator;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/SubscriptionServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/SubscriptionServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.SubscriptionService;
 
 public class SubscriptionServiceImpl extends AbstractResourceServiceImpl<SubscriptionDao, Subscription>
@@ -24,10 +25,10 @@ public class SubscriptionServiceImpl extends AbstractResourceServiceImpl<Subscri
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Subscription.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/TaskServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/TaskServiceImpl.java
@@ -1,11 +1,6 @@
 package dev.dsf.fhir.webservice.impl;
 
-import java.util.EnumSet;
-
 import org.hl7.fhir.r4.model.Task;
-import org.hl7.fhir.r4.model.Task.TaskStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import dev.dsf.fhir.authorization.AuthorizationRuleProvider;
 import dev.dsf.fhir.dao.TaskDao;
@@ -18,43 +13,21 @@ import dev.dsf.fhir.history.HistoryService;
 import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
-import dev.dsf.fhir.service.ResourceReference;
-import dev.dsf.fhir.service.ResourceReference.ReferenceType;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.TaskService;
 
 public class TaskServiceImpl extends AbstractResourceServiceImpl<TaskDao, Task> implements TaskService
 {
-	private static final Logger logger = LoggerFactory.getLogger(TaskServiceImpl.class);
-
 	public TaskServiceImpl(String path, String serverBase, int defaultPageCount, TaskDao dao,
 			ResourceValidator validator, EventHandler eventHandler, ExceptionHandler exceptionHandler,
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, Task.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
-	}
-
-	// See also CheckReferencesCommand#checkReferenceAfterUpdate
-	@Override
-	protected boolean checkReferenceAfterUpdate(Task updated, ResourceReference ref)
-	{
-		if (EnumSet.of(TaskStatus.COMPLETED, TaskStatus.FAILED).contains(updated.getStatus()))
-		{
-			ReferenceType refType = ref.getType(serverBase);
-			if ("Task.input".equals(ref.getLocation()) && ReferenceType.LITERAL_EXTERNAL.equals(refType))
-			{
-				logger.warn("Skipping check of {} reference '{}' at {} in resource with {}, version {}", refType,
-						ref.getReference().getReference(), "Task.input", updated.getIdElement().getIdPart(),
-						updated.getIdElement().getVersionIdPart());
-				return false;
-			}
-		}
-
-		return super.checkReferenceAfterUpdate(updated, ref);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ValueSetServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/ValueSetServiceImpl.java
@@ -14,6 +14,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ValueSetService;
 
 public class ValueSetServiceImpl extends AbstractResourceServiceImpl<ValueSetDao, ValueSet> implements ValueSetService
@@ -23,10 +24,10 @@ public class ValueSetServiceImpl extends AbstractResourceServiceImpl<ValueSetDao
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
 			ReferenceExtractor referenceExtractor, ReferenceResolver referenceResolver,
 			ReferenceCleaner referenceCleaner, AuthorizationRuleProvider authorizationRuleProvider,
-			HistoryService historyService)
+			HistoryService historyService, ValidationRules validationRules)
 	{
 		super(path, ValueSet.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
-				referenceCleaner, authorizationRuleProvider, historyService);
+				referenceCleaner, authorizationRuleProvider, historyService, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -38,6 +39,7 @@ import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.service.ResourceReference;
 import dev.dsf.fhir.service.ResourceReference.ReferenceType;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.BasicResourceService;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -61,12 +63,13 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 	protected final ParameterConverter parameterConverter;
 	protected final AuthorizationRule<R> authorizationRule;
 	protected final ResourceValidator resourceValidator;
+	protected final ValidationRules validationRules;
 
 	public AbstractResourceServiceSecure(S delegate, String serverBase, ResponseGenerator responseGenerator,
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, Class<R> resourceType, D dao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<R> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver);
 
@@ -79,6 +82,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		this.parameterConverter = parameterConverter;
 		this.authorizationRule = authorizationRule;
 		this.resourceValidator = resourceValidator;
+		this.validationRules = validationRules;
 	}
 
 	@Override
@@ -95,6 +99,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		Objects.requireNonNull(parameterConverter, "parameterConverter");
 		Objects.requireNonNull(authorizationRule, "authorizationRule");
 		Objects.requireNonNull(resourceValidator, "resourceValidator");
+		Objects.requireNonNull(validationRules, "validationRules");
 	}
 
 	private String toValidationLogMessage(ValidationResult validationResult)
@@ -105,16 +110,17 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 				.collect(Collectors.joining(", ", "[", "]"));
 	}
 
-	private Response withResourceValidation(R resource, UriInfo uri, HttpHeaders headers, String method,
-			Supplier<Response> delegate)
+	private Response withResourceValidation(R resource, Predicate<R> failValidationOnErrorOrFatal, UriInfo uri,
+			HttpHeaders headers, String method, Supplier<Response> delegate)
 	{
 		// FIXME hapi parser bug workaround
 		referenceCleaner.cleanReferenceResourcesIfBundle(resource);
 
 		ValidationResult validationResult = resourceValidator.validate(resource);
 
-		if (validationResult.getMessages().stream().anyMatch(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
-				|| ResultSeverityEnum.FATAL.equals(m.getSeverity())))
+		if (failValidationOnErrorOrFatal.test(resource) && validationResult.getMessages().stream()
+				.anyMatch(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
+						|| ResultSeverityEnum.FATAL.equals(m.getSeverity())))
 		{
 			logger.warn("{} of {} unauthorized, resource not valid: {}", method, resource.fhirType(),
 					toValidationLogMessage(validationResult));
@@ -127,8 +133,13 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		else
 		{
 			if (!validationResult.getMessages().isEmpty())
-				logger.warn("Resource {} validated with messages: {}", resource.fhirType(),
-						toValidationLogMessage(validationResult));
+				logger.warn("Resource {} validated with messages: {}{}", resource.fhirType(),
+						toValidationLogMessage(validationResult),
+						(validationResult.getMessages().stream()
+								.anyMatch(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
+										|| ResultSeverityEnum.FATAL.equals(m.getSeverity()))
+												? ", ignoring error and fatal messages"
+												: ""));
 
 			return delegate.get();
 		}
@@ -148,29 +159,31 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		}
 		else
 		{
-			return withResourceValidation(resource, uri, headers, "Create", () ->
-			{
-				audit.info("Create of resource {} allowed for user '{}', reason: {}", resourceTypeName,
-						getCurrentIdentity().getName(), reasonCreateAllowed.get());
+			return withResourceValidation(resource, validationRules::failOnErrorOrFatalBeforeCreate, uri, headers,
+					"Create", () ->
+					{
+						audit.info("Create of resource {} allowed for user '{}', reason: {}", resourceTypeName,
+								getCurrentIdentity().getName(), reasonCreateAllowed.get());
 
-				Response created = logResultStatus(() -> delegate.create(resource, uri, headers),
-						status -> audit.info("Create of resource {} for user '{}' successful, status: {} {}",
-								resourceTypeName, getCurrentIdentity().getName(), status.getStatusCode(),
-								status.getReasonPhrase()),
-						status -> audit.info("Create of resource {} for user '{}' failed, status: {} {}",
-								resourceTypeName, getCurrentIdentity().getName(), status.getStatusCode(),
-								status.getReasonPhrase()));
+						Response created = logResultStatus(() -> delegate.create(resource, uri, headers),
+								status -> audit.info("Create of resource {} for user '{}' successful, status: {} {}",
+										resourceTypeName, getCurrentIdentity().getName(), status.getStatusCode(),
+										status.getReasonPhrase()),
+								status -> audit.info("Create of resource {} for user '{}' failed, status: {} {}",
+										resourceTypeName, getCurrentIdentity().getName(), status.getStatusCode(),
+										status.getReasonPhrase()));
 
-				if (created.hasEntity() && !resourceType.isInstance(created.getEntity())
-						&& !(created.getEntity() instanceof OperationOutcome))
-					logger.warn("Create returned with entity of type {}", created.getEntity().getClass().getName());
-				else if (!created.hasEntity()
-						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
-					logger.warn("Create returned with status {} {}, but no entity",
-							created.getStatusInfo().getStatusCode(), created.getStatusInfo().getReasonPhrase());
+						if (created.hasEntity() && !resourceType.isInstance(created.getEntity())
+								&& !(created.getEntity() instanceof OperationOutcome))
+							logger.warn("Create returned with entity of type {}",
+									created.getEntity().getClass().getName());
+						else if (!created.hasEntity()
+								&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
+							logger.warn("Create returned with status {} {}, but no entity",
+									created.getStatusInfo().getStatusCode(), created.getStatusInfo().getReasonPhrase());
 
-				return created;
-			});
+						return created;
+					});
 		}
 	}
 
@@ -411,28 +424,33 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 		}
 		else
 		{
-			return withResourceValidation(newResource, uri, headers, "Update", () ->
-			{
-				audit.info("Update of {}/{}/_history/{} allowed for identity '{}', reason: {}", resourceTypeName,
-						resourceId, resourceVersion, getCurrentIdentity().getName(), reasonUpdateAllowed.get());
-				Response updated = logResultStatus(() -> delegate.update(id, newResource, uri, headers),
-						status -> audit.info("Update of {}/{}/_history/{} for identity '{}' successful, status: {} {}",
+			return withResourceValidation(newResource, validationRules::failOnErrorOrFatalBeforeUpdate, uri, headers,
+					"Update", () ->
+					{
+						audit.info("Update of {}/{}/_history/{} allowed for identity '{}', reason: {}",
 								resourceTypeName, resourceId, resourceVersion, getCurrentIdentity().getName(),
-								status.getStatusCode(), status.getReasonPhrase()),
-						status -> audit.info("Update of {}/{}/_history/{} for identity '{}' failed, status: {} {}",
-								resourceTypeName, resourceId, resourceVersion, getCurrentIdentity().getName(),
-								status.getStatusCode(), status.getReasonPhrase()));
+								reasonUpdateAllowed.get());
+						Response updated = logResultStatus(() -> delegate.update(id, newResource, uri, headers),
+								status -> audit.info(
+										"Update of {}/{}/_history/{} for identity '{}' successful, status: {} {}",
+										resourceTypeName, resourceId, resourceVersion, getCurrentIdentity().getName(),
+										status.getStatusCode(), status.getReasonPhrase()),
+								status -> audit.info(
+										"Update of {}/{}/_history/{} for identity '{}' failed, status: {} {}",
+										resourceTypeName, resourceId, resourceVersion, getCurrentIdentity().getName(),
+										status.getStatusCode(), status.getReasonPhrase()));
 
-				if (updated.hasEntity() && !resourceType.isInstance(updated.getEntity())
-						&& !(updated.getEntity() instanceof OperationOutcome))
-					logger.warn("Update returned with entity of type {}", updated.getEntity().getClass().getName());
-				else if (!updated.hasEntity()
-						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
-					logger.warn("Update returned with status {} {}, but no entity",
-							updated.getStatusInfo().getStatusCode(), updated.getStatusInfo().getReasonPhrase());
+						if (updated.hasEntity() && !resourceType.isInstance(updated.getEntity())
+								&& !(updated.getEntity() instanceof OperationOutcome))
+							logger.warn("Update returned with entity of type {}",
+									updated.getEntity().getClass().getName());
+						else if (!updated.hasEntity()
+								&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
+							logger.warn("Update returned with status {} {}, but no entity",
+									updated.getStatusInfo().getStatusCode(), updated.getStatusInfo().getReasonPhrase());
 
-				return updated;
-			});
+						return updated;
+					});
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ActivityDefinitionServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ActivityDefinitionServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ActivityDefinitionService;
 
 public class ActivityDefinitionServiceSecure
@@ -21,10 +22,11 @@ public class ActivityDefinitionServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, ActivityDefinitionDao activityDefinitionDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<ActivityDefinition> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<ActivityDefinition> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				ActivityDefinition.class, activityDefinitionDao, exceptionHandler, parameterConverter,
-				authorizationRule, resourceValidator);
+				authorizationRule, resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/BinaryServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/BinaryServiceSecure.java
@@ -13,6 +13,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.BinaryService;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -25,10 +26,11 @@ public class BinaryServiceSecure extends AbstractResourceServiceSecure<BinaryDao
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, BinaryDao binaryDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Binary> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Binary.class, binaryDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Binary.class, binaryDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/BundleServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/BundleServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.BundleService;
 
 public class BundleServiceSecure extends AbstractResourceServiceSecure<BundleDao, Bundle, BundleService>
@@ -20,9 +21,10 @@ public class BundleServiceSecure extends AbstractResourceServiceSecure<BundleDao
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, BundleDao bundleDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Bundle> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Bundle.class, bundleDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Bundle.class, bundleDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/CodeSystemServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/CodeSystemServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.CodeSystemService;
 
 public class CodeSystemServiceSecure extends AbstractResourceServiceSecure<CodeSystemDao, CodeSystem, CodeSystemService>
@@ -20,10 +21,10 @@ public class CodeSystemServiceSecure extends AbstractResourceServiceSecure<CodeS
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, CodeSystemDao codeSystemDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<CodeSystem> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				CodeSystem.class, codeSystemDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/DocumentReferenceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/DocumentReferenceServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.DocumentReferenceService;
 
 public class DocumentReferenceServiceSecure
@@ -21,10 +22,11 @@ public class DocumentReferenceServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, DocumentReferenceDao documentReferenceDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<DocumentReference> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<DocumentReference> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				DocumentReference.class, documentReferenceDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/EndpointServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/EndpointServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.EndpointService;
 
 public class EndpointServiceSecure extends AbstractResourceServiceSecure<EndpointDao, Endpoint, EndpointService>
@@ -20,10 +21,10 @@ public class EndpointServiceSecure extends AbstractResourceServiceSecure<Endpoin
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, EndpointDao endpointDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Endpoint> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Endpoint.class, endpointDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				Endpoint.class, endpointDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/GroupServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/GroupServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.GroupService;
 
 public class GroupServiceSecure extends AbstractResourceServiceSecure<GroupDao, Group, GroupService>
@@ -20,9 +21,10 @@ public class GroupServiceSecure extends AbstractResourceServiceSecure<GroupDao, 
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, GroupDao groupDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Group> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Group.class, groupDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Group.class, groupDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/HealthcareServiceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/HealthcareServiceServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.HealthcareServiceService;
 
 public class HealthcareServiceServiceSecure
@@ -21,10 +22,11 @@ public class HealthcareServiceServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, HealthcareServiceDao healthcareServiceDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<HealthcareService> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<HealthcareService> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				HealthcareService.class, healthcareServiceDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/LibraryServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/LibraryServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.LibraryService;
 
 public class LibraryServiceSecure extends AbstractResourceServiceSecure<LibraryDao, Library, LibraryService>
@@ -20,9 +21,10 @@ public class LibraryServiceSecure extends AbstractResourceServiceSecure<LibraryD
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, LibraryDao libraryDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Library> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Library.class, libraryDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Library.class, libraryDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/LocationServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/LocationServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.LocationService;
 
 public class LocationServiceSecure extends AbstractResourceServiceSecure<LocationDao, Location, LocationService>
@@ -20,10 +21,10 @@ public class LocationServiceSecure extends AbstractResourceServiceSecure<Locatio
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, LocationDao locationDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Location> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Location.class, locationDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				Location.class, locationDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/MeasureReportServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/MeasureReportServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.MeasureReportService;
 
 public class MeasureReportServiceSecure
@@ -21,10 +22,10 @@ public class MeasureReportServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, MeasureReportDao measureReportDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<MeasureReport> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				MeasureReport.class, measureReportDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/MeasureServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/MeasureServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.MeasureService;
 
 public class MeasureServiceSecure extends AbstractResourceServiceSecure<MeasureDao, Measure, MeasureService>
@@ -20,9 +21,10 @@ public class MeasureServiceSecure extends AbstractResourceServiceSecure<MeasureD
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, MeasureDao measureDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Measure> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Measure.class, measureDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Measure.class, measureDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/NamingSystemServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/NamingSystemServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.NamingSystemService;
 
 public class NamingSystemServiceSecure extends
@@ -20,10 +21,10 @@ public class NamingSystemServiceSecure extends
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, NamingSystemDao naminngSystemDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<NamingSystem> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				NamingSystem.class, naminngSystemDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/OrganizationAffiliationServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/OrganizationAffiliationServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.OrganizationAffiliationService;
 
 public class OrganizationAffiliationServiceSecure extends
@@ -21,10 +22,11 @@ public class OrganizationAffiliationServiceSecure extends
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, OrganizationAffiliationDao organizationDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<OrganizationAffiliation> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<OrganizationAffiliation> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				OrganizationAffiliation.class, organizationDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/OrganizationServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/OrganizationServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.OrganizationService;
 
 public class OrganizationServiceSecure extends
@@ -20,10 +21,10 @@ public class OrganizationServiceSecure extends
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, OrganizationDao organizationDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Organization> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				Organization.class, organizationDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/PatientServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/PatientServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.PatientService;
 
 public class PatientServiceSecure extends AbstractResourceServiceSecure<PatientDao, Patient, PatientService>
@@ -20,9 +21,10 @@ public class PatientServiceSecure extends AbstractResourceServiceSecure<PatientD
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, PatientDao patientDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Patient> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Patient.class, patientDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Patient.class, patientDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/PractitionerRoleServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/PractitionerRoleServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.PractitionerRoleService;
 
 public class PractitionerRoleServiceSecure
@@ -21,10 +22,11 @@ public class PractitionerRoleServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, PractitionerRoleDao practitionerRoleDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<PractitionerRole> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<PractitionerRole> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				PractitionerRole.class, practitionerRoleDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/PractitionerServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/PractitionerServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.PractitionerService;
 
 public class PractitionerServiceSecure extends
@@ -20,10 +21,10 @@ public class PractitionerServiceSecure extends
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, PractitionerDao practitionerDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Practitioner> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				Practitioner.class, practitionerDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ProvenanceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ProvenanceServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ProvenanceService;
 
 public class ProvenanceServiceSecure extends AbstractResourceServiceSecure<ProvenanceDao, Provenance, ProvenanceService>
@@ -20,10 +21,10 @@ public class ProvenanceServiceSecure extends AbstractResourceServiceSecure<Prove
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, ProvenanceDao provenanceDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Provenance> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				Provenance.class, provenanceDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/QuestionnaireResponseServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/QuestionnaireResponseServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.QuestionnaireResponseService;
 
 public class QuestionnaireResponseServiceSecure extends
@@ -21,10 +22,11 @@ public class QuestionnaireResponseServiceSecure extends
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, QuestionnaireResponseDao QuestionnaireResponseDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<QuestionnaireResponse> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<QuestionnaireResponse> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				QuestionnaireResponse.class, QuestionnaireResponseDao, exceptionHandler, parameterConverter,
-				authorizationRule, resourceValidator);
+				authorizationRule, resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/QuestionnaireServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/QuestionnaireServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.QuestionnaireService;
 
 public class QuestionnaireServiceSecure
@@ -21,10 +22,10 @@ public class QuestionnaireServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, QuestionnaireDao questionnaireDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Questionnaire> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				Questionnaire.class, questionnaireDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ResearchStudyServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ResearchStudyServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ResearchStudyService;
 
 public class ResearchStudyServiceSecure
@@ -21,10 +22,10 @@ public class ResearchStudyServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, ResearchStudyDao researchStudyDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<ResearchStudy> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				ResearchStudy.class, researchStudyDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/StructureDefinitionServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/StructureDefinitionServiceSecure.java
@@ -12,6 +12,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.StructureDefinitionService;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -25,11 +26,12 @@ public class StructureDefinitionServiceSecure
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, StructureDefinitionDao structureDefinitionDao,
 			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<StructureDefinition> authorizationRule, ResourceValidator resourceValidator)
+			AuthorizationRule<StructureDefinition> authorizationRule, ResourceValidator resourceValidator,
+			ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				StructureDefinition.class, structureDefinitionDao, exceptionHandler, parameterConverter,
-				authorizationRule, resourceValidator);
+				authorizationRule, resourceValidator, validationRules);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/SubscriptionServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/SubscriptionServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.SubscriptionService;
 
 public class SubscriptionServiceSecure extends
@@ -20,10 +21,10 @@ public class SubscriptionServiceSecure extends
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, SubscriptionDao subscriptionDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Subscription> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				Subscription.class, subscriptionDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				resourceValidator, validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/TaskServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/TaskServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.TaskService;
 
 public class TaskServiceSecure extends AbstractResourceServiceSecure<TaskDao, Task, TaskService> implements TaskService
@@ -19,9 +20,10 @@ public class TaskServiceSecure extends AbstractResourceServiceSecure<TaskDao, Ta
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, TaskDao taskDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<Task> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				Task.class, taskDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+				Task.class, taskDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ValueSetServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/ValueSetServiceSecure.java
@@ -11,6 +11,7 @@ import dev.dsf.fhir.service.ReferenceCleaner;
 import dev.dsf.fhir.service.ReferenceExtractor;
 import dev.dsf.fhir.service.ReferenceResolver;
 import dev.dsf.fhir.validation.ResourceValidator;
+import dev.dsf.fhir.validation.ValidationRules;
 import dev.dsf.fhir.webservice.specification.ValueSetService;
 
 public class ValueSetServiceSecure extends AbstractResourceServiceSecure<ValueSetDao, ValueSet, ValueSetService>
@@ -20,10 +21,10 @@ public class ValueSetServiceSecure extends AbstractResourceServiceSecure<ValueSe
 			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
 			ReferenceExtractor referenceExtractor, ValueSetDao valueSetDao, ExceptionHandler exceptionHandler,
 			ParameterConverter parameterConverter, AuthorizationRule<ValueSet> authorizationRule,
-			ResourceValidator resourceValidator)
+			ResourceValidator resourceValidator, ValidationRules validationRules)
 	{
 		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
-				ValueSet.class, valueSetDao, exceptionHandler, parameterConverter, authorizationRule,
-				resourceValidator);
+				ValueSet.class, valueSetDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator,
+				validationRules);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-activity-definition2-1.7.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-activity-definition2-1.7.xml
@@ -1,0 +1,32 @@
+<ActivityDefinition xmlns="http://hl7.org/fhir">
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<extension url="http://dsf.dev/fhir/StructureDefinition/extension-process-authorization">
+		<extension url="message-name">
+			<valueString value="test-message" />
+		</extension>
+		<extension url="task-profile">
+			<valueCanonical value="http://dsf.dev/fhir/StructureDefinition/test-task|1.7" />
+		</extension>
+		<extension url="requester">
+			<valueCoding>
+				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization" />
+				<code value="REMOTE_ALL" />
+			</valueCoding>
+		</extension>
+		<extension url="recipient">
+			<valueCoding>
+				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization" />
+				<code value="LOCAL_ALL" />
+			</valueCoding>
+		</extension>
+	</extension>
+	<url value="http://dsf.dev/bpe/Process/test" />
+	<version value="1.7" />
+	<status value="active" />
+	<kind value="Task" />
+</ActivityDefinition>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-task-1.7.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-task-1.7.xml
@@ -1,0 +1,55 @@
+<Task xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="http://dsf.dev/fhir/StructureDefinition/test-task|1.7"></profile>
+	</meta>
+	<instantiatesCanonical value="http://dsf.dev/bpe/Process/test|1.7"></instantiatesCanonical>
+	<status value="requested"></status>
+	<intent value="order"></intent>
+	<requester>
+		<type value="Organization"></type>
+		<identifier>
+			<system value="http://dsf.dev/sid/organization-identifier"></system>
+			<value value="External_Test_Organization"></value>
+		</identifier>
+	</requester>
+	<restriction>
+		<recipient>
+			<type value="Organization"></type>
+			<identifier>
+				<system value="http://dsf.dev/sid/organization-identifier"></system>
+				<value value="Test_Organization"></value>
+			</identifier>
+		</recipient>
+	</restriction>
+	<input>
+		<type>
+			<coding>
+				<system value="http://dsf.dev/fhir/CodeSystem/bpmn-message"></system>
+				<code value="message-name"></code>
+			</coding>
+		</type>
+		<valueString value="test-message"></valueString>
+	</input>
+	<input>
+		<type>
+			<coding>
+				<system value="http://dsf.dev/fhir/CodeSystem/bpmn-message" />
+				<code value="business-key" />
+			</coding>
+		</type>
+		<valueString value="fdc8218e-ef55-4fc6-9c4f-a20883d569cc" />
+	</input>
+	<input>
+		<type>
+			<coding>
+				<system value="http://dsf.dev/fhir/CodeSystem/test" />
+				<version value="1.7" />
+				<code value="binary-ref" />
+			</coding>
+		</type>
+		<valueReference>
+			<reference
+				value="https://localhost:80010/fhir/Binary/941683ea-7670-4d1a-8e0d-75698c433204" />
+		</valueReference>
+	</input>
+</Task>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-task-profile-binary-ref-1.7.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-task-profile-binary-ref-1.7.xml
@@ -1,0 +1,85 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<url value="http://dsf.dev/fhir/StructureDefinition/test-task" />
+	<version value="1.7" />
+	<name value="TestTask" />
+	<status value="active" />
+	<experimental value="false" />
+	<date value="2021-05-17" />
+	<fhirVersion value="4.0.1" />
+	<kind value="resource" />
+	<abstract value="false" />
+	<type value="Task" />
+	<baseDefinition value="http://dsf.dev/fhir/StructureDefinition/task-base" />
+	<derivation value="constraint" />
+	<differential>
+		<element id="Task.instantiatesCanonical">
+			<path value="Task.instantiatesCanonical" />
+			<fixedCanonical value="http://dsf.dev/bpe/Process/test|1.7" />
+		</element>
+		<element id="Task.input">
+			<path value="Task.input"/>
+			<min value="3"/>
+		</element>
+		<element id="Task.input:message-name">
+			<path value="Task.input" />
+			<sliceName value="message-name" />
+		</element>
+		<element id="Task.input:message-name.value[x]">
+			<path value="Task.input.value[x]" />
+			<fixedString value="test-message" />
+		</element>
+		<element id="Task.input:binary-ref">
+			<path value="Task.input" />
+			<sliceName value="binary-ref" />
+			<min value="1" />
+			<max value="1" />
+		</element>
+		<element id="Task.input:binary-ref.type">
+			<path value="Task.input.type" />
+			<binding>
+				<strength value="required" />
+				<valueSet value="http://dsf.dev/fhir/ValueSet/test|1.7" />
+			</binding>
+		</element>
+		<element id="Task.input:binary-ref.type.coding">
+			<path value="Task.input.type.coding" />
+			<min value="1" />
+			<max value="1" />
+		</element>
+		<element id="Task.input:binary-ref.type.coding.system">
+			<path value="Task.input.type.coding.system" />
+			<min value="1" />
+			<fixedUri value="http://dsf.dev/fhir/CodeSystem/test" />
+		</element>
+		<element id="Task.input:binary-ref.type.coding.version">
+			<path value="Task.input.type.coding.version" />
+			<min value="1" />
+			<fixedString value="1.7" />
+		</element>
+		<element id="Task.input:binary-ref.type.coding.code">
+			<path value="Task.input.type.coding.code" />
+			<min value="1" />
+			<fixedCode value="binary-ref" />
+		</element>
+		<element id="Task.input:binary-ref.value[x]">
+			<path value="Task.input.value[x]" />
+			<type>
+				<code value="Reference" />
+			</type>
+		</element>
+		<element id="Task.input:binary-ref.value[x].reference">
+			<path value="Task.input.value[x].reference" />
+			<min value="1" />
+		</element>
+		<element id="Task.input:binary-ref.value[x].identifier">
+			<path value="Task.input.value[x].identifier" />
+			<max value="0" />
+		</element>
+  </differential>
+</StructureDefinition>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/test-codesystem-1.7.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/test-codesystem-1.7.xml
@@ -1,0 +1,26 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<url value="http://dsf.dev/fhir/CodeSystem/test" />
+	<version value="1.7" />
+	<name value="DSF_Test" />
+	<title value="DSF Test" />
+	<status value="draft" />
+	<experimental value="false" />
+	<date value="2025-03-21" />
+	<publisher value="DSF" />
+	<description value="CodeSystem for integration testing" />
+	<caseSensitive value="true" />
+	<hierarchyMeaning value="grouped-by" />
+	<versionNeeded value="false" />
+	<content value="complete" />
+	<concept>
+		<code value="binary-ref" />
+		<display value="Binary Reference" />
+		<definition value="A Binary Test Reference" />
+	</concept>
+</CodeSystem> 

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/test-valueset-1.7.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/test-valueset-1.7.xml
@@ -1,0 +1,24 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<url value="http://dsf.dev/fhir/ValueSet/test" />
+	<version value="1.7" />
+	<name value="DSF_Test" />
+	<title value="DSF Test" />
+	<status value="draft" />
+	<experimental value="false" />
+	<date value="2025-03-21" />
+	<publisher value="DSF" />
+	<description value="ValueSet for integration testing" />
+	<immutable value="true" />
+	<compose>
+		<include>
+			<system value="http://dsf.dev/fhir/CodeSystem/test" />
+			<version value="1.7" />
+		</include>
+	</compose>
+</ValueSet> 


### PR DESCRIPTION
* New tests simulating BPE task handling of Task resources with bad literal external references and for Task resources for missing process plugins.
* Task updates from status `requested` to `failed` now allowed. Validation `error` and `fatal` messages now suppressed and no longer failing the update.

closes #279 for 1.7.1