### PR TITLE
Issue/265 documentation generator secret file

### DIFF
--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractJettyConfig.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/config/AbstractJettyConfig.java
@@ -123,7 +123,7 @@ public abstract class AbstractJettyConfig
 	@Value("${dev.dsf.server.certificate.key.password:#{null}}")
 	private char[] serverCertificateKeyFilePassword;
 
-	@Documentation(description = "Set to `true` to enable OIDC authorization code flow", recommendation = "Requires *DEV_DSF_SERVER_AUTH_OIDC_PROVIDER_REALM_BASE_URL*, *DEV_DSF_SERVER_AUTH_OIDC_CLIENT_ID* and *DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET* to be specified")
+	@Documentation(description = "Set to `true` to enable OIDC authorization code flow", recommendation = "Requires *DEV_DSF_SERVER_AUTH_OIDC_PROVIDER_REALM_BASE_URL*, *DEV_DSF_SERVER_AUTH_OIDC_CLIENT_ID* and *DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET* or *DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE* to be specified")
 	@Value("${dev.dsf.server.auth.oidc.authorization.code.flow:false}")
 	private boolean oidcAuthorizationCodeFlowEnabled;
 

--- a/dsf-fhir/dsf-fhir-validation/src/main/resources/fhir/StructureDefinition/dsf-activity-definition-1.0.0.xml.post
+++ b/dsf-fhir/dsf-fhir-validation/src/main/resources/fhir/StructureDefinition/dsf-activity-definition-1.0.0.xml.post
@@ -1,1 +1,1 @@
-url=http://dsf.dev/fhir/StructureDefinition/code-system&version=1.0.0
+url=http://dsf.dev/fhir/StructureDefinition/activity-definition&version=1.0.0

--- a/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
+++ b/dsf-tools/dsf-tools-documentation-generator/src/main/java/dev/dsf/tools/generator/DocumentationGenerator.java
@@ -223,7 +223,7 @@ public class DocumentationGenerator extends AbstractMojo
 			String property = getDocumentationString("Property", initialProperty);
 
 			String initialEnvironment = initialProperty.replace(".", "_").toUpperCase();
-			String environment = initialProperty.endsWith(".password")
+			String environment = initialProperty.endsWith(".password") || initialProperty.endsWith(".secret")
 					? String.format("%s or %s_FILE", initialEnvironment, initialEnvironment)
 					: initialEnvironment;
 
@@ -262,7 +262,7 @@ public class DocumentationGenerator extends AbstractMojo
 			String property = getDocumentationString("Property", initialProperty);
 
 			String initialEnvironment = initialProperty.replace(".", "_").toUpperCase();
-			String environment = initialProperty.endsWith(".password")
+			String environment = initialProperty.endsWith(".password") || initialProperty.endsWith(".secret")
 					? String.format("%s or %s_FILE", initialEnvironment, initialEnvironment)
 					: initialEnvironment;
 


### PR DESCRIPTION
* DocumentationGenerator now generates "or ..._FILE" headings also for properties ending in .secret
* Update the recommendation for dev.dsf.server.auth.oidc.authorization.code.flow to reflect the generator change.
* Includes cherry-picked commit 5b75ce3 from #282

closes #265 