### PR TITLE
Issue/292 process plugin fhir resource modifier

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/plugin/ProcessPluginImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/plugin/ProcessPluginImpl.java
@@ -44,6 +44,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import dev.dsf.bpe.api.plugin.AbstractProcessPlugin;
+import dev.dsf.bpe.api.plugin.FhirResourceModifier;
 import dev.dsf.bpe.api.plugin.ProcessPlugin;
 import dev.dsf.bpe.api.plugin.ProcessPluginDeploymentListener;
 import dev.dsf.bpe.api.plugin.ProcessPluginFhirConfig;
@@ -327,5 +328,11 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<TaskListener> imple
 			VariableScope variableScope)
 	{
 		return get(TaskListener.class, className, fieldDeclarations);
+	}
+
+	@Override
+	public FhirResourceModifier getFhirResourceModifier()
+	{
+		return FhirResourceModifier.identity();
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/test/java/dev/dsf/bpe/v1/plugin/ProcessPluginImplTest.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/test/java/dev/dsf/bpe/v1/plugin/ProcessPluginImplTest.java
@@ -280,14 +280,7 @@ public class ProcessPluginImplTest
 		ProcessPluginImpl plugin = createPlugin(definition, false);
 
 		assertFalse(plugin.initializeAndValidateResources(null));
-		try
-		{
-			plugin.getApplicationContext();
-			fail("IllegalStateException expected");
-		}
-		catch (IllegalStateException e)
-		{
-		}
+		assertNotNull(plugin.getApplicationContext());
 
 		try
 		{

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/fhir/FhirResourceModifierDelegate.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/fhir/FhirResourceModifierDelegate.java
@@ -1,0 +1,79 @@
+package dev.dsf.bpe.v2.fhir;
+
+import java.util.Objects;
+
+import org.hl7.fhir.r4.model.ActivityDefinition;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.NamingSystem;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.ValueSet;
+
+import dev.dsf.bpe.api.plugin.FhirResourceModifier;
+
+public class FhirResourceModifierDelegate implements FhirResourceModifier
+{
+	private final dev.dsf.bpe.v2.fhir.FhirResourceModifier delegate;
+
+	public FhirResourceModifierDelegate(dev.dsf.bpe.v2.fhir.FhirResourceModifier delegate)
+	{
+		this.delegate = Objects.requireNonNull(delegate, "delegate");
+	}
+
+	@Override
+	public Object modifyActivityDefinition(String filename, Object resource)
+	{
+		return delegate.modifyActivityDefinition(filename, (ActivityDefinition) resource);
+	}
+
+	@Override
+	public Object modifyCodeSystem(String filename, Object resource)
+	{
+		return delegate.modifyCodeSystem(filename, (CodeSystem) resource);
+	}
+
+	@Override
+	public Object modifyLibrary(String filename, Object resource)
+	{
+		return delegate.modifyLibrary(filename, (Library) resource);
+	}
+
+	@Override
+	public Object modifyMeasure(String filename, Object resource)
+	{
+		return delegate.modifyMeasure(filename, (Measure) resource);
+	}
+
+	@Override
+	public Object modifyNamingSystem(String filename, Object resource)
+	{
+		return delegate.modifyNamingSystem(filename, (NamingSystem) resource);
+	}
+
+	@Override
+	public Object modifyQuestionnaire(String filename, Object resource)
+	{
+		return delegate.modifyQuestionnaire(filename, (Questionnaire) resource);
+	}
+
+	@Override
+	public Object modifyStructureDefinition(String filename, Object resource)
+	{
+		return delegate.modifyStructureDefinition(filename, (StructureDefinition) resource);
+	}
+
+	@Override
+	public Object modifyTask(String filename, Object resource)
+	{
+		return delegate.modifyTask(filename, (Task) resource);
+	}
+
+	@Override
+	public Object modifyValueSet(String filename, Object resource)
+	{
+		return delegate.modifyValueSet(filename, (ValueSet) resource);
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/plugin/ProcessPluginImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/plugin/ProcessPluginImpl.java
@@ -50,6 +50,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import dev.dsf.bpe.api.plugin.AbstractProcessPlugin;
+import dev.dsf.bpe.api.plugin.FhirResourceModifier;
+import dev.dsf.bpe.api.plugin.FhirResourceModifiers;
 import dev.dsf.bpe.api.plugin.ProcessPlugin;
 import dev.dsf.bpe.api.plugin.ProcessPluginFhirConfig;
 import dev.dsf.bpe.v2.ProcessPluginApi;
@@ -73,6 +75,7 @@ import dev.dsf.bpe.v2.activity.values.SendTaskValues;
 import dev.dsf.bpe.v2.constants.CodeSystems.BpmnMessage;
 import dev.dsf.bpe.v2.constants.NamingSystems.OrganizationIdentifier;
 import dev.dsf.bpe.v2.constants.NamingSystems.TaskIdentifier;
+import dev.dsf.bpe.v2.fhir.FhirResourceModifierDelegate;
 import dev.dsf.bpe.v2.variables.FhirResourceValues;
 
 public class ProcessPluginImpl extends AbstractProcessPlugin<UserTaskListener> implements ProcessPlugin
@@ -467,5 +470,15 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<UserTaskListener> i
 	{
 		return () -> new RuntimeException(
 				"No or incomplete FHIR Task message activity fields for " + activityName + " (" + className + ")");
+	}
+
+	@Override
+	public FhirResourceModifier getFhirResourceModifier()
+	{
+		List<FhirResourceModifierDelegate> modifiers = getApplicationContext()
+				.getBeansOfType(dev.dsf.bpe.v2.fhir.FhirResourceModifier.class).values().stream()
+				.map(FhirResourceModifierDelegate::new).toList();
+
+		return new FhirResourceModifiers(modifiers);
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/ProcessPluginDefinition.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/ProcessPluginDefinition.java
@@ -21,6 +21,7 @@ import dev.dsf.bpe.v2.activity.MessageSendTask;
 import dev.dsf.bpe.v2.activity.ServiceTask;
 import dev.dsf.bpe.v2.activity.UserTaskListener;
 import dev.dsf.bpe.v2.documentation.ProcessDocumentation;
+import dev.dsf.bpe.v2.fhir.FhirResourceModifier;
 import dev.dsf.bpe.v2.spring.ActivityPrototypeBeanCreator;
 
 /**
@@ -142,6 +143,8 @@ public interface ProcessPluginDefinition
 	 * @see ServiceTask
 	 * @see UserTaskListener
 	 * @see ActivityPrototypeBeanCreator
+	 * @see ProcessPluginDeploymentListener
+	 * @see FhirResourceModifier
 	 * @see ConfigurableBeanFactory#SCOPE_PROTOTYPE
 	 */
 	// TODO javadoc

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/ProcessPluginDefinition.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/ProcessPluginDefinition.java
@@ -147,6 +147,5 @@ public interface ProcessPluginDefinition
 	 * @see FhirResourceModifier
 	 * @see ConfigurableBeanFactory#SCOPE_PROTOTYPE
 	 */
-	// TODO javadoc
 	List<Class<?>> getSpringConfigurations();
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/fhir/AbstractFhirResourceModifier.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/fhir/AbstractFhirResourceModifier.java
@@ -1,0 +1,68 @@
+package dev.dsf.bpe.v2.fhir;
+
+import org.hl7.fhir.r4.model.ActivityDefinition;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.NamingSystem;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.ValueSet;
+
+public abstract class AbstractFhirResourceModifier implements FhirResourceModifier
+{
+	@Override
+	public ActivityDefinition modifyActivityDefinition(String filename, ActivityDefinition resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public CodeSystem modifyCodeSystem(String filename, CodeSystem resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public Library modifyLibrary(String filename, Library resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public Measure modifyMeasure(String filename, Measure resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public NamingSystem modifyNamingSystem(String filename, NamingSystem resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public Questionnaire modifyQuestionnaire(String filename, Questionnaire resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public StructureDefinition modifyStructureDefinition(String filename, StructureDefinition resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public Task modifyTask(String filename, Task resource)
+	{
+		return resource;
+	}
+
+	@Override
+	public ValueSet modifyValueSet(String filename, ValueSet resource)
+	{
+		return resource;
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/fhir/FhirResourceModifier.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/fhir/FhirResourceModifier.java
@@ -15,7 +15,12 @@ import org.springframework.context.annotation.Bean;
  * When implementations of this interface are registered as singleton {@link Bean}, modify methods are called during
  * process plugin loading and before the plugin FHIR resource are stored in the DSF FHIR server.
  * <p>
- * See {@link AbstractFhirResourceModifier} for a no-op base implementation.
+ * Warning: Modifications that are non static i.e. depend on values that can change from one start of the BPE to the
+ * next like environment variables and allow-list entries, require a stop BPE, remove plugin, start BPE, stop BPE, add
+ * plugin and start BPE cycle. Since not many modifications to the FHIR resources of a process plugin keep the plugin
+ * compatible across DSF instances, use this feature with care.
+ * <p>
+ * See {@link AbstractFhirResourceModifier} for a no-modifications base implementation.
  */
 public interface FhirResourceModifier
 {

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/fhir/FhirResourceModifier.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/fhir/FhirResourceModifier.java
@@ -1,0 +1,39 @@
+package dev.dsf.bpe.v2.fhir;
+
+import org.hl7.fhir.r4.model.ActivityDefinition;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.NamingSystem;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * When implementations of this interface are registered as singleton {@link Bean}, modify methods are called during
+ * process plugin loading and before the plugin FHIR resource are stored in the DSF FHIR server.
+ * <p>
+ * See {@link AbstractFhirResourceModifier} for a no-op base implementation.
+ */
+public interface FhirResourceModifier
+{
+	ActivityDefinition modifyActivityDefinition(String filename, ActivityDefinition resource);
+
+	CodeSystem modifyCodeSystem(String filename, CodeSystem resource);
+
+	Library modifyLibrary(String filename, Library resource);
+
+	Measure modifyMeasure(String filename, Measure resource);
+
+	NamingSystem modifyNamingSystem(String filename, NamingSystem resource);
+
+	Questionnaire modifyQuestionnaire(String filename, Questionnaire resource);
+
+	StructureDefinition modifyStructureDefinition(String filename, StructureDefinition resource);
+
+	Task modifyTask(String filename, Task resource);
+
+	ValueSet modifyValueSet(String filename, ValueSet resource);
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/spring/ActivityPrototypeBeanCreator.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/spring/ActivityPrototypeBeanCreator.java
@@ -10,21 +10,28 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import dev.dsf.bpe.v2.activity.Activity;
 
 /**
- * Helper class to register {@link Activity}s as prototype beans.
+ * Helper class to register {@link Activity}s as prototype beans. Must be configured as a <code>static</code>
+ * {@link Bean} inside a {@link Configuration} classes.
  * <p>
  * Usage:
  * <p>
  *
- * {@snippet :
- * &#64;Bean
- * public ActivityPrototypeBeanCreator activityPrototypeBeanCreator()
+ * {@snippet id = "usage" lang = "java" :
+ * &#64;Configuration
+ * public class Config
  * {
- * 	return new ActivityPrototypeBeanCreator(SomeServiceTask.class, AnExecutionListener.class,
- * 			MyMessageIntermediateThrowEvent.class);
+ * 	&#64;Bean
+ * 	public static ActivityPrototypeBeanCreator activityPrototypeBeanCreator()
+ * 	{
+ * 		return new ActivityPrototypeBeanCreator(SomeServiceTask.class, AnExecutionListener.class,
+ * 				MyMessageIntermediateThrowEvent.class);
+ * 	}
  * }
  * }
  */

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/FhirResourceModifier.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/FhirResourceModifier.java
@@ -1,0 +1,84 @@
+package dev.dsf.bpe.api.plugin;
+
+public interface FhirResourceModifier
+{
+	FhirResourceModifier IDENTITY = new FhirResourceModifier()
+	{
+		@Override
+		public Object modifyValueSet(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyTask(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyStructureDefinition(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyQuestionnaire(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyNamingSystem(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyMeasure(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyLibrary(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyCodeSystem(String filename, Object resource)
+		{
+			return resource;
+		}
+
+		@Override
+		public Object modifyActivityDefinition(String filename, Object resource)
+		{
+			return resource;
+		}
+	};
+
+	static FhirResourceModifier identity()
+	{
+		return IDENTITY;
+	}
+
+	Object modifyActivityDefinition(String filename, Object resource);
+
+	Object modifyCodeSystem(String filename, Object resource);
+
+	Object modifyLibrary(String filename, Object resource);
+
+	Object modifyMeasure(String filename, Object resource);
+
+	Object modifyNamingSystem(String filename, Object resource);
+
+	Object modifyQuestionnaire(String filename, Object resource);
+
+	Object modifyStructureDefinition(String filename, Object resource);
+
+	Object modifyTask(String filename, Object resource);
+
+	Object modifyValueSet(String filename, Object resource);
+}

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/FhirResourceModifiers.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/FhirResourceModifiers.java
@@ -1,0 +1,97 @@
+package dev.dsf.bpe.api.plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class FhirResourceModifiers implements FhirResourceModifier
+{
+	private final List<FhirResourceModifier> fhirResourceModifiers = new ArrayList<>();
+
+	public FhirResourceModifiers(Collection<? extends FhirResourceModifier> fhirResourceModifiers)
+	{
+		if (fhirResourceModifiers != null)
+			this.fhirResourceModifiers.addAll(fhirResourceModifiers);
+	}
+
+	@Override
+	public Object modifyActivityDefinition(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyActivityDefinition(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyCodeSystem(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyCodeSystem(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyLibrary(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyLibrary(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyMeasure(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyMeasure(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyNamingSystem(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyNamingSystem(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyQuestionnaire(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyQuestionnaire(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyStructureDefinition(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyStructureDefinition(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyTask(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyTask(filename, resource);
+
+		return resource;
+	}
+
+	@Override
+	public Object modifyValueSet(String filename, Object resource)
+	{
+		for (FhirResourceModifier m : fhirResourceModifiers)
+			resource = m.modifyValueSet(filename, resource);
+
+		return resource;
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/ProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/ProcessPlugin.java
@@ -62,4 +62,6 @@ public interface ProcessPlugin
 
 	TaskListener getTaskListener(String className, List<FieldDeclaration> fieldDeclarations,
 			VariableScope variableScope);
+
+	FhirResourceModifier getFhirResourceModifier();
 }

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/integration/AbstractIntegrationTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/integration/AbstractIntegrationTest.java
@@ -432,7 +432,7 @@ public abstract class AbstractIntegrationTest extends AbstractDbTest
 				dsf-fhir-server:
 				  base-url: '#[fhirBaseUrl]'
 				  test-connection-on-startup: yes
-				  enable-debug-logging: yes
+				  enable-debug-logging: no
 				  cert-auth:
 				    private-key-file: '#[client.key]'
 				    certificate-file: '#[client.crt]'

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/fhir/FhirResourceModifierImpl.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/fhir/FhirResourceModifierImpl.java
@@ -1,0 +1,36 @@
+package dev.dsf.bpe.test.fhir;
+
+import org.hl7.fhir.r4.model.ActivityDefinition;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
+
+import dev.dsf.bpe.test.TestProcessPluginDefinition;
+import dev.dsf.bpe.v2.constants.CodeSystems.ProcessAuthorization;
+import dev.dsf.bpe.v2.fhir.AbstractFhirResourceModifier;
+
+public class FhirResourceModifierImpl extends AbstractFhirResourceModifier
+{
+	@Override
+	public ActivityDefinition modifyActivityDefinition(String filename, ActivityDefinition resource)
+	{
+		if ("fhir/ActivityDefinition/dsf-test.xml".equals(filename))
+			return addProcessAuthorization(resource);
+		else
+			return super.modifyActivityDefinition(filename, resource);
+	}
+
+	private ActivityDefinition addProcessAuthorization(ActivityDefinition resource)
+	{
+		Extension processAuthorization = resource.addExtension();
+		processAuthorization.setUrl("http://dsf.dev/fhir/StructureDefinition/extension-process-authorization");
+		processAuthorization.addExtension().setUrl("message-name").setValue(new StringType("continue-send-test"));
+		processAuthorization.addExtension().setUrl("task-profile")
+				.setValue(new CanonicalType("http://dsf.dev/fhir/StructureDefinition/task-continue-send-test|"
+						+ new TestProcessPluginDefinition().getResourceVersion()));
+		processAuthorization.addExtension().setUrl("requester").setValue(ProcessAuthorization.localAll());
+		processAuthorization.addExtension().setUrl("recipient").setValue(ProcessAuthorization.localAll());
+
+		return resource;
+	}
+}

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/spring/config/Config.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/spring/config/Config.java
@@ -3,6 +3,7 @@ package dev.dsf.bpe.test.spring.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import dev.dsf.bpe.test.fhir.FhirResourceModifierImpl;
 import dev.dsf.bpe.test.listener.StartFieldInjectionTestListener;
 import dev.dsf.bpe.test.listener.StartSendTaskTestListener;
 import dev.dsf.bpe.test.message.ContinueSendTestSend;
@@ -21,13 +22,14 @@ import dev.dsf.bpe.test.service.JsonVariableTestSet;
 import dev.dsf.bpe.test.service.OrganizationProviderTest;
 import dev.dsf.bpe.test.service.ProxyTest;
 import dev.dsf.bpe.test.service.TestActivitySelector;
+import dev.dsf.bpe.v2.fhir.FhirResourceModifier;
 import dev.dsf.bpe.v2.spring.ActivityPrototypeBeanCreator;
 
 @Configuration
 public class Config
 {
 	@Bean
-	public ActivityPrototypeBeanCreator activityPrototypeBeanCreator()
+	public static ActivityPrototypeBeanCreator activityPrototypeBeanCreator()
 	{
 		return new ActivityPrototypeBeanCreator(TestActivitySelector.class, ProxyTest.class, ApiTest.class,
 				OrganizationProviderTest.class, EndpointProviderTest.class, FhirClientProviderTest.class,
@@ -35,5 +37,11 @@ public class Config
 				FieldInjectionTest.class, ErrorBoundaryEventTestThrow.class, ErrorBoundaryEventTestVerify.class,
 				ExceptionTest.class, ContinueSendTest.class, ContinueSendTestSend.class, ContinueSendTestEvaluate.class,
 				JsonVariableTestSet.class, JsonVariableTestGet.class);
+	}
+
+	@Bean
+	public FhirResourceModifier fhirResourceModifier()
+	{
+		return new FhirResourceModifierImpl();
 	}
 }

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/resources/fhir/ActivityDefinition/dsf-test.xml
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/resources/fhir/ActivityDefinition/dsf-test.xml
@@ -1,62 +1,43 @@
 <ActivityDefinition xmlns="http://hl7.org/fhir">
 	<meta>
 		<tag>
-			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
-			<code value="ALL" />
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag"/>
+			<code value="ALL"/>
 		</tag>
 	</meta>
 	<extension url="http://dsf.dev/fhir/StructureDefinition/extension-process-authorization">
 		<extension url="message-name">
-			<valueString value="start" />
+			<valueString value="start"/>
 		</extension>
 		<extension url="task-profile">
-			<valueCanonical value="http://dsf.dev/fhir/StructureDefinition/task-test|#{version}" />
+			<valueCanonical value="http://dsf.dev/fhir/StructureDefinition/task-test|#{version}"/>
 		</extension>
 		<extension url="requester">
 			<valueCoding>
-				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization" />
-				<code value="LOCAL_ALL" />
+				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization"/>
+				<code value="LOCAL_ALL"/>
 			</valueCoding>
 		</extension>
 		<extension url="recipient">
 			<valueCoding>
-				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization" />
-				<code value="LOCAL_ALL" />
+				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization"/>
+				<code value="LOCAL_ALL"/>
 			</valueCoding>
 		</extension>
 	</extension>
-	<extension url="http://dsf.dev/fhir/StructureDefinition/extension-process-authorization">
-		<extension url="message-name">
-			<valueString value="continue-send-test" />
-		</extension>
-		<extension url="task-profile">
-			<valueCanonical value="http://dsf.dev/fhir/StructureDefinition/task-continue-send-test|#{version}" />
-		</extension>
-		<extension url="requester">
-			<valueCoding>
-				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization" />
-				<code value="LOCAL_ALL" />
-			</valueCoding>
-		</extension>
-		<extension url="recipient">
-			<valueCoding>
-				<system value="http://dsf.dev/fhir/CodeSystem/process-authorization" />
-				<code value="LOCAL_ALL" />
-			</valueCoding>
-		</extension>
-	</extension>
-	<url value="http://dsf.dev/bpe/Process/test" />
+	<!-- Second process-authorization extension see dev.dsf.bpe.test.fhir.FhirResourceModifierImpl -->
+	<url value="http://dsf.dev/bpe/Process/test"/>
 	<!-- version managed by bpe -->
-	<version value="#{version}" />
-	<name value="Test" />
-	<title value="Test" />
-	<subtitle value="Test Process" />
+	<version value="#{version}"/>
+	<name value="Test"/>
+	<title value="Test"/>
+	<subtitle value="Test Process"/>
 	<!-- status managed by bpe -->
-	<status value="unknown" />
-	<experimental value="false" />
+	<status value="unknown"/>
+	<experimental value="false"/>
 	<!-- date managed by bpe -->
-	<date value="#{date}" />
-	<publisher value="DSF" />
-	<description value="Test process" />
-	<kind value="Task" />
+	<date value="#{date}"/>
+	<publisher value="DSF"/>
+	<description value="Test process"/>
+	<kind value="Task"/>
 </ActivityDefinition>


### PR DESCRIPTION
Mechanism to modify process plugin FHIR resources during plugin loading.

If process plugin FHIR resources should be modified during plugin loading, developers need to provide singleton beans implementing the new `dev.dsf.bpe.v2.fhir.FhirResourceModifier` interface. The abstract `dev.dsf.bpe.v2.fhir.AbstractFhirResourceModifier` class can be used as a base to only implement modifiers for a subset of FHIR resource types.

closes #292 

