### PR TITLE
Issue/241 process plugin api class loader allow list

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v1/allowed-bpe-classes.list
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v1/allowed-bpe-classes.list
@@ -1,12 +1,14 @@
 com.fasterxml.jackson.annotation
 com.fasterxml.jackson.core
 com.fasterxml.jackson.databind
+com.google.common
 dev.dsf.bpe.api
 jakarta.ws.rs
 org.apache.commons.codec
 org.apache.commons.io
 org.apache.commons.lang3
 org.apache.commons.text
+org.apache.http
 org.bouncycastle
 org.camunda.bpm.engine.delegate
 org.camunda.bpm.engine.impl.el.FixedValue
@@ -22,5 +24,7 @@ org.slf4j.LoggerFactory
 org.springframework.beans
 org.springframework.cglib
 org.springframework.context
+org.springframework.lang
+org.springframework.util
 org.springframework.web.util.UriComponents
 org.springframework.web.util.UriComponentsBuilder

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v2/allowed-bpe-classes.list
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v2/allowed-bpe-classes.list
@@ -28,5 +28,7 @@ org.slf4j.LoggerFactory
 org.springframework.beans
 org.springframework.cglib
 org.springframework.context
+org.springframework.lang
+org.springframework.util
 org.w3c.dom
 org.xml.sax


### PR DESCRIPTION
* additional v1 and v2 entries based on Testing with v1 plugins [mii-process-report](https://github.com/medizininformatik-initiative/mii-process-report) and [mii-process-feasibility](https://github.com/medizininformatik-initiative/mii-process-feasibility)

We may need to revisit #241 after testing with other existing v1 plugins.

closes #241 