### PR TITLE
Issue/307 target provider

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/ProcessPluginApiImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/ProcessPluginApiImpl.java
@@ -18,6 +18,7 @@ import dev.dsf.bpe.v2.service.OidcClientProvider;
 import dev.dsf.bpe.v2.service.OrganizationProvider;
 import dev.dsf.bpe.v2.service.QuestionnaireResponseHelper;
 import dev.dsf.bpe.v2.service.ReadAccessHelper;
+import dev.dsf.bpe.v2.service.TargetProvider;
 import dev.dsf.bpe.v2.service.TaskHelper;
 import dev.dsf.bpe.v2.service.process.ProcessAuthorizationHelper;
 
@@ -39,6 +40,7 @@ public class ProcessPluginApiImpl implements ProcessPluginApi, InitializingBean
 	private final ReadAccessHelper readAccessHelper;
 	private final TaskHelper taskHelper;
 	private final CryptoService cryptoService;
+	private final TargetProvider targetProvider;
 
 	public ProcessPluginApiImpl(ProxyConfig proxyConfig, EndpointProvider endpointProvider, FhirContext fhirContext,
 			DsfClientProvider dsfClientProvider, FhirClientProvider fhirClientProvider,
@@ -46,7 +48,7 @@ public class ProcessPluginApiImpl implements ProcessPluginApi, InitializingBean
 			ObjectMapper objectMapper, OrganizationProvider organizationProvider,
 			ProcessAuthorizationHelper processAuthorizationHelper,
 			QuestionnaireResponseHelper questionnaireResponseHelper, ReadAccessHelper readAccessHelper,
-			TaskHelper taskHelper, CryptoService cryptoService)
+			TaskHelper taskHelper, CryptoService cryptoService, TargetProvider targetProvider)
 	{
 		this.proxyConfig = proxyConfig;
 		this.endpointProvider = endpointProvider;
@@ -63,6 +65,7 @@ public class ProcessPluginApiImpl implements ProcessPluginApi, InitializingBean
 		this.readAccessHelper = readAccessHelper;
 		this.taskHelper = taskHelper;
 		this.cryptoService = cryptoService;
+		this.targetProvider = targetProvider;
 	}
 
 	@Override
@@ -82,6 +85,7 @@ public class ProcessPluginApiImpl implements ProcessPluginApi, InitializingBean
 		Objects.requireNonNull(readAccessHelper, "readAccessHelper");
 		Objects.requireNonNull(taskHelper, "taskHelper");
 		Objects.requireNonNull(cryptoService, "cryptoService");
+		Objects.requireNonNull(targetProvider, "targetProvider");
 	}
 
 	@Override
@@ -172,5 +176,11 @@ public class ProcessPluginApiImpl implements ProcessPluginApi, InitializingBean
 	public CryptoService getCryptoService()
 	{
 		return cryptoService;
+	}
+
+	@Override
+	public TargetProvider getTargetProvider()
+	{
+		return targetProvider;
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/TargetProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/TargetProviderImpl.java
@@ -1,0 +1,199 @@
+package dev.dsf.bpe.v2.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Bundle.SearchEntryMode;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.OrganizationAffiliation;
+
+import dev.dsf.bpe.v2.constants.NamingSystems.EndpointIdentifier;
+import dev.dsf.bpe.v2.constants.NamingSystems.OrganizationIdentifier;
+import dev.dsf.bpe.v2.variables.Target;
+import dev.dsf.bpe.v2.variables.TargetImpl;
+import dev.dsf.bpe.v2.variables.Targets;
+import dev.dsf.bpe.v2.variables.TargetsImpl;
+
+public class TargetProviderImpl extends AbstractResourceProvider implements TargetProvider
+{
+	public static class BuilderImpl implements Builder
+	{
+		private static final record OrganizationAffiliationAndOrganizationAndEndpoint(
+				OrganizationAffiliation affiliation, Organization member, Endpoint endpoint)
+		{
+		}
+
+		private final List<OrganizationAffiliation> affiliations = new ArrayList<>();
+		private final Map<String, Organization> organizationsById = new HashMap<>();
+		private final Map<String, Endpoint> endpointsById = new HashMap<>();
+
+		private final Set<String> memberOrganizationIdentifiers = new HashSet<>();
+
+		public BuilderImpl(Identifier[] memberOrganizationIdentifiers)
+		{
+			if (memberOrganizationIdentifiers != null)
+				this.memberOrganizationIdentifiers.addAll(Arrays.stream(memberOrganizationIdentifiers)
+						.filter(Objects::nonNull).map(this::identifierToString).toList());
+		}
+
+		private String identifierToString(Identifier i)
+		{
+			return i.getSystem() + "|" + i.getValue();
+		}
+
+		private Predicate filter;
+
+		protected Target createTarget(String organizationIdentifierValue, String endpointIdentifierValue,
+				String endpointAddress, String correlationKey)
+		{
+			Objects.requireNonNull(organizationIdentifierValue, "organizationIdentifierValue");
+			Objects.requireNonNull(endpointIdentifierValue, "endpointIdentifierValue");
+			Objects.requireNonNull(endpointAddress, "endpointAddress");
+
+			return new TargetImpl(organizationIdentifierValue, endpointIdentifierValue, endpointAddress,
+					correlationKey);
+		}
+
+		@Override
+		public Targets withCorrelationKey()
+		{
+			return toTargets(true);
+		}
+
+		@Override
+		public Targets withoutCorrelationKey()
+		{
+			return toTargets(false);
+		}
+
+		private Targets toTargets(boolean withCorrelationKey)
+		{
+			List<TargetImpl> targets = affiliations.stream()
+					.filter(a -> organizationsById
+							.containsKey(a.getParticipatingOrganization().getReferenceElement().getIdPart())
+							&& endpointsById.containsKey(a.getEndpointFirstRep().getReferenceElement().getIdPart()))
+					.map(a -> new OrganizationAffiliationAndOrganizationAndEndpoint(a,
+							organizationsById.get(a.getParticipatingOrganization().getReferenceElement().getIdPart()),
+							endpointsById.get(a.getEndpointFirstRep().getReferenceElement().getIdPart())))
+					.filter(a -> OrganizationIdentifier.hasIdentifier(a.member)
+							&& EndpointIdentifier.hasIdentifier(a.endpoint) && a.endpoint.hasAddressElement()
+							&& a.endpoint.getAddressElement().hasValue())
+					.filter(a -> memberOrganizationIdentifiers.isEmpty() ? true
+							: memberOrganizationIdentifiers.contains(
+									OrganizationIdentifier.findFirst(a.member).map(this::identifierToString).get()))
+					.filter(a -> filter == null ? true : filter.test(a.affiliation, a.member, a.endpoint)).map(a ->
+					{
+						String organizationIdentifierValue = OrganizationIdentifier.findFirst(a.member)
+								.map(Identifier::getValue).get();
+						String endpointIdentifierValue = EndpointIdentifier.findFirst(a.endpoint)
+								.map(Identifier::getValue).get();
+
+						return new TargetImpl(organizationIdentifierValue, endpointIdentifierValue,
+								a.endpoint.getAddress(), withCorrelationKey ? UUID.randomUUID().toString() : null);
+					}).toList();
+
+			return new TargetsImpl(targets);
+		}
+
+		@Override
+		public Builder filter(Predicate filter)
+		{
+			this.filter = filter;
+
+			return this;
+		}
+	}
+
+	public TargetProviderImpl(DsfClientProvider clientProvider, String localEndpointAddress)
+	{
+		super(clientProvider, localEndpointAddress);
+	}
+
+	protected BuilderImpl createBuilder(Identifier... memberOrganizationIdentifier)
+	{
+		return new BuilderImpl(memberOrganizationIdentifier);
+	}
+
+	private Builder toBuilder(Stream<BundleEntryComponent> entries, Identifier... memberOrganizationIdentifier)
+	{
+		BuilderImpl builder = createBuilder(memberOrganizationIdentifier);
+
+		entries.forEach(c ->
+		{
+			SearchEntryMode mode = c.getSearch().getMode();
+
+			if (SearchEntryMode.MATCH.equals(mode) && c.getResource() instanceof OrganizationAffiliation a)
+				builder.affiliations.add(a);
+
+			else if (SearchEntryMode.INCLUDE.equals(mode))
+			{
+				if (c.getResource() instanceof Organization o)
+					builder.organizationsById.put(o.getIdElement().getIdPart(), o);
+				else if (c.getResource() instanceof Endpoint e)
+					builder.endpointsById.put(e.getIdElement().getIdPart(), e);
+			}
+		});
+
+		return builder;
+	}
+
+	@Override
+	public Builder create(Identifier parentOrganizationIdentifier)
+	{
+		Objects.requireNonNull(parentOrganizationIdentifier, "parentOrganizationIdentifier");
+
+		Stream<BundleEntryComponent> entries = search(OrganizationAffiliation.class,
+				Map.of("active", List.of("true"), "primary-organization:identifier",
+						List.of(toSearchParameter(parentOrganizationIdentifier)), "_include",
+						List.of("OrganizationAffiliation:endpoint:Endpoint",
+								"OrganizationAffiliation:participating-organization:Organization")));
+
+		return toBuilder(entries);
+	}
+
+	@Override
+	public Builder create(Identifier parentOrganizationIdentifier, Coding memberOrganizationRole)
+	{
+		Objects.requireNonNull(parentOrganizationIdentifier, "parentOrganizationIdentifier");
+		Objects.requireNonNull(memberOrganizationRole, "memberOrganizationRole");
+
+		Stream<BundleEntryComponent> entries = search(OrganizationAffiliation.class,
+				Map.of("active", List.of("true"), "primary-organization:identifier",
+						List.of(toSearchParameter(parentOrganizationIdentifier)), "_include",
+						List.of("OrganizationAffiliation:endpoint:Endpoint",
+								"OrganizationAffiliation:participating-organization:Organization"),
+						"role", List.of(toSearchParameter(memberOrganizationRole))));
+
+		return toBuilder(entries);
+	}
+
+	@Override
+	public Builder create(Identifier parentOrganizationIdentifier, Coding memberOrganizationRole,
+			Identifier... memberOrganizationIdentifier)
+	{
+		Objects.requireNonNull(parentOrganizationIdentifier, "parentOrganizationIdentifier");
+		Objects.requireNonNull(memberOrganizationRole, "memberOrganizationRole");
+		Objects.requireNonNull(memberOrganizationIdentifier, "memberOrganizationIdentifier");
+
+		Stream<BundleEntryComponent> entries = search(OrganizationAffiliation.class,
+				Map.of("active", List.of("true"), "primary-organization:identifier",
+						List.of(toSearchParameter(parentOrganizationIdentifier)), "_include",
+						List.of("OrganizationAffiliation:endpoint:Endpoint",
+								"OrganizationAffiliation:participating-organization:Organization"),
+						"role", List.of(toSearchParameter(memberOrganizationRole))));
+
+		return toBuilder(entries, memberOrganizationIdentifier);
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/spring/ApiServiceConfig.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/spring/ApiServiceConfig.java
@@ -58,6 +58,8 @@ import dev.dsf.bpe.v2.service.QuestionnaireResponseHelper;
 import dev.dsf.bpe.v2.service.QuestionnaireResponseHelperImpl;
 import dev.dsf.bpe.v2.service.ReadAccessHelper;
 import dev.dsf.bpe.v2.service.ReadAccessHelperImpl;
+import dev.dsf.bpe.v2.service.TargetProvider;
+import dev.dsf.bpe.v2.service.TargetProviderImpl;
 import dev.dsf.bpe.v2.service.TaskHelper;
 import dev.dsf.bpe.v2.service.TaskHelperImpl;
 import dev.dsf.bpe.v2.service.detector.CombinedDetectors;
@@ -99,7 +101,7 @@ public class ApiServiceConfig
 		return new ProcessPluginApiImpl(proxyConfigDelegate(), endpointProvider(), fhirContext(), dsfClientProvider(),
 				fhirClientProvider(), oidcClientProvider(), mailService(), mimetypeService(), objectMapper(),
 				organizationProvider(), processAuthorizationHelper(), questionnaireResponseHelper(), readAccessHelper(),
-				taskHelper(), cryptoService());
+				taskHelper(), cryptoService(), targetProvider());
 	}
 
 	@Bean
@@ -284,5 +286,11 @@ public class ApiServiceConfig
 	public CryptoService cryptoService()
 	{
 		return new CryptoServiceImpl();
+	}
+
+	@Bean
+	public TargetProvider targetProvider()
+	{
+		return new TargetProviderImpl(dsfClientProvider(), dsfClientConfig.getLocalConfig().getBaseUrl());
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/TargetsImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/TargetsImpl.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -70,6 +71,12 @@ public class TargetsImpl implements Targets
 	public int size()
 	{
 		return entries.size();
+	}
+
+	@Override
+	public Optional<Target> getFirst()
+	{
+		return entries.isEmpty() ? Optional.empty() : Optional.of(entries.get(0));
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/TargetsImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/TargetsImpl.java
@@ -67,6 +67,12 @@ public class TargetsImpl implements Targets
 	}
 
 	@Override
+	public int size()
+	{
+		return entries.size();
+	}
+
+	@Override
 	public String toString()
 	{
 		return "TargetsImpl [entries=" + entries + "]";

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/ProcessPluginApi.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/ProcessPluginApi.java
@@ -17,6 +17,7 @@ import dev.dsf.bpe.v2.service.OidcClientProvider;
 import dev.dsf.bpe.v2.service.OrganizationProvider;
 import dev.dsf.bpe.v2.service.QuestionnaireResponseHelper;
 import dev.dsf.bpe.v2.service.ReadAccessHelper;
+import dev.dsf.bpe.v2.service.TargetProvider;
 import dev.dsf.bpe.v2.service.TaskHelper;
 import dev.dsf.bpe.v2.service.process.ProcessAuthorizationHelper;
 import dev.dsf.bpe.v2.variables.Variables;
@@ -58,4 +59,6 @@ public interface ProcessPluginApi
 	TaskHelper getTaskHelper();
 
 	CryptoService getCryptoService();
+
+	TargetProvider getTargetProvider();
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/MessageSendTask.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/MessageSendTask.java
@@ -1,10 +1,43 @@
 package dev.dsf.bpe.v2.activity;
 
+import org.hl7.fhir.r4.model.Task;
+
+import dev.dsf.bpe.v2.ProcessPluginApi;
+import dev.dsf.bpe.v2.activity.task.BusinessKeyStrategy;
+import dev.dsf.bpe.v2.activity.task.TaskSender;
+import dev.dsf.bpe.v2.activity.values.SendTaskValues;
+import dev.dsf.bpe.v2.error.ErrorBoundaryEvent;
 import dev.dsf.bpe.v2.error.MessageSendTaskErrorHandler;
 import dev.dsf.bpe.v2.error.impl.DefaultMessageSendTaskErrorHandler;
+import dev.dsf.bpe.v2.variables.Variables;
 
 public interface MessageSendTask extends MessageActivity
 {
+	/**
+	 * Default implementation uses a {@link TaskSender} from
+	 * {@link #getTaskSender(ProcessPluginApi, Variables, SendTaskValues)} to send {@link Task} resources with the
+	 * {@link BusinessKeyStrategy} from {@link #getBusinessKeyStrategy()}. No {@link ErrorBoundaryEvent} are thrown by
+	 * the default implementation.
+	 *
+	 * @param api
+	 *            not <code>null</code>
+	 * @param variables
+	 *            not <code>null</code>
+	 * @param sendTaskValues
+	 *            not <code>null</code>
+	 * @throws ErrorBoundaryEvent
+	 *             to trigger custom error handling flow in BPMN, when using {@link DefaultMessageSendTaskErrorHandler}
+	 * @throws Exception
+	 *             to fail the FHIR {@link Task} and stop the process instance, when using
+	 *             {@link DefaultMessageSendTaskErrorHandler}
+	 */
+	@Override
+	default void execute(ProcessPluginApi api, Variables variables, SendTaskValues sendTaskValues)
+			throws ErrorBoundaryEvent, Exception
+	{
+		getTaskSender(api, variables, sendTaskValues).send();
+	}
+
 	@Override
 	default MessageSendTaskErrorHandler getErrorHandler()
 	{

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/ServiceTask.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/ServiceTask.java
@@ -1,5 +1,7 @@
 package dev.dsf.bpe.v2.activity;
 
+import org.hl7.fhir.r4.model.Task;
+
 import dev.dsf.bpe.v2.ProcessPluginApi;
 import dev.dsf.bpe.v2.error.ErrorBoundaryEvent;
 import dev.dsf.bpe.v2.error.ServiceTaskErrorHandler;
@@ -8,6 +10,17 @@ import dev.dsf.bpe.v2.variables.Variables;
 
 public interface ServiceTask extends Activity
 {
+	/**
+	 * @param api
+	 *            not <code>null</code>
+	 * @param variables
+	 *            not <code>null</code>
+	 * @throws ErrorBoundaryEvent
+	 *             to trigger custom error handling flow in BPMN, when using {@link DefaultServiceTaskErrorHandler}
+	 * @throws Exception
+	 *             to fail the FHIR {@link Task} and stop the process instance, when using
+	 *             {@link DefaultServiceTaskErrorHandler}
+	 */
 	void execute(ProcessPluginApi api, Variables variables) throws ErrorBoundaryEvent, Exception;
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/constants/NamingSystems.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/constants/NamingSystems.java
@@ -13,8 +13,6 @@ import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Task;
 
-import dev.dsf.bpe.v2.constants.NamingSystems;
-
 /**
  * Constants defining standard DSF NamingSystems
  */
@@ -32,7 +30,24 @@ public final class NamingSystems
 
 		List<Identifier> identifiers = identifierSupplier.get();
 		return identifiers == null ? Optional.empty()
-				: identifiers.stream().filter(i -> identifierSystem.equals(i.getSystem())).findFirst();
+				: identifiers.stream()
+						.filter(i -> i.hasSystemElement() && i.getSystemElement().hasValue() && i.hasValueElement()
+								&& i.getValueElement().hasValue()
+								&& identifierSystem.equals(i.getSystemElement().getValue()))
+						.findFirst();
+	}
+
+	private static boolean hasIdentifier(Supplier<List<Identifier>> identifierSupplier, String identifierSystem)
+	{
+		Objects.requireNonNull(identifierSupplier, "identifierSupplier");
+		Objects.requireNonNull(identifierSystem, "identifierSystem");
+
+		List<Identifier> identifiers = identifierSupplier.get();
+		return identifiers == null ? false
+				: identifiers.stream()
+						.anyMatch(i -> i.hasSystemElement() && i.getSystemElement().hasValue() && i.hasValueElement()
+								&& i.getValueElement().hasValue()
+								&& identifierSystem.equals(i.getSystemElement().getValue()));
 	}
 
 	private static <R extends Resource> Optional<Identifier> findFirst(Optional<R> resource,
@@ -75,6 +90,11 @@ public final class NamingSystems
 			Objects.requireNonNull(organization, "organization");
 			return NamingSystems.findFirst(organization, Organization::getIdentifier, SID);
 		}
+
+		public static boolean hasIdentifier(Organization organization)
+		{
+			return organization == null ? false : NamingSystems.hasIdentifier(organization::getIdentifier, SID);
+		}
 	}
 
 	public static final class EndpointIdentifier
@@ -99,6 +119,11 @@ public final class NamingSystems
 		{
 			Objects.requireNonNull(endpoint, "endpoint");
 			return NamingSystems.findFirst(endpoint, Endpoint::getIdentifier, SID);
+		}
+
+		public static boolean hasIdentifier(Endpoint endpoint)
+		{
+			return endpoint == null ? false : NamingSystems.hasIdentifier(endpoint::getIdentifier, SID);
 		}
 	}
 
@@ -125,6 +150,11 @@ public final class NamingSystems
 			Objects.requireNonNull(practitioner, "practitioner");
 			return NamingSystems.findFirst(practitioner, Practitioner::getIdentifier, SID);
 		}
+
+		public static boolean hasIdentifier(Practitioner practitioner)
+		{
+			return practitioner == null ? false : NamingSystems.hasIdentifier(practitioner::getIdentifier, SID);
+		}
 	}
 
 	public static final class TaskIdentifier
@@ -149,6 +179,11 @@ public final class NamingSystems
 		{
 			Objects.requireNonNull(task, "task");
 			return NamingSystems.findFirst(task, Task::getIdentifier, SID);
+		}
+
+		public static boolean hasIdentifier(Task task)
+		{
+			return task == null ? false : NamingSystems.hasIdentifier(task::getIdentifier, SID);
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/TargetProvider.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/TargetProvider.java
@@ -8,8 +8,10 @@ import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.OrganizationAffiliation;
 
+import dev.dsf.bpe.v2.constants.BpmnExecutionVariables;
 import dev.dsf.bpe.v2.constants.CodeSystems.OrganizationRole;
 import dev.dsf.bpe.v2.constants.NamingSystems.OrganizationIdentifier;
+import dev.dsf.bpe.v2.variables.Target;
 import dev.dsf.bpe.v2.variables.Targets;
 
 public interface TargetProvider
@@ -31,8 +33,31 @@ public interface TargetProvider
 			boolean test(OrganizationAffiliation affiliation, Organization member, Endpoint endpoint);
 		}
 
+		/**
+		 * <i>A <b>correlationKey</b> should be used if return messages i.e. Task resources from multiple organizations
+		 * with the same message-name are expected in a following multi instance message receive task or intermediate
+		 * message catch event in a multi instance subprocess.<br>
+		 * Note: The correlationKey needs to be set as a {@link BpmnExecutionVariables#CORRELATION_KEY} variable in the
+		 * message receive task or intermediate message catch event of a subprocess before incoming messages i.e. Task
+		 * resources can be correlated. Within a BPMN file this can be accomplished by setting an input variable with
+		 * name: {@link BpmnExecutionVariables#CORRELATION_KEY}, type:</i> <code>string or expression</code><i>, and
+		 * value: </i><code>${target.correlationKey}</code>.
+		 * <p>
+		 * <i>A <b>correlationKey</b> should also be used when sending a message i.e. Task resource back to an
+		 * organization waiting for multiple returns.</i>
+		 *
+		 * @return {@link Targets} including correlation keys
+		 * @see Target#getCorrelationKey()
+		 */
 		Targets withCorrelationKey();
 
+		/**
+		 * <i>{@link Targets} without correlation key can be used when sending out multiple messages without expecting
+		 * replies.</i>
+		 *
+		 * @return {@link Targets} without correlation keys
+		 * @see Target#getCorrelationKey()
+		 */
 		Targets withoutCorrelationKey();
 
 		/**
@@ -46,16 +71,40 @@ public interface TargetProvider
 		Builder filter(Predicate predicate);
 	}
 
+	/**
+	 * @param parentOrganizationIdentifier
+	 *            not <code>null</code>
+	 * @return {@link Targets} builder for all active members of the given parent organization
+	 */
 	Builder create(Identifier parentOrganizationIdentifier);
 
+	/**
+	 * @param parentOrganizationIdentifierValue
+	 *            not <code>null</code>
+	 * @return {@link Targets} builder for all active members of the given parent organization
+	 */
 	default Builder create(String parentOrganizationIdentifierValue)
 	{
 		return create(parentOrganizationIdentifierValue == null ? null
 				: OrganizationIdentifier.withValue(parentOrganizationIdentifierValue));
 	}
 
+	/**
+	 * @param parentOrganizationIdentifier
+	 *            not <code>null</code>
+	 * @param memberOrganizationRole
+	 *            not <code>null</code>
+	 * @return {@link Targets} builder for all active members of the given parent organization with the given role
+	 */
 	Builder create(Identifier parentOrganizationIdentifier, Coding memberOrganizationRole);
 
+	/**
+	 * @param parentOrganizationIdentifierValue
+	 *            not <code>null</code>
+	 * @param memberOrganizationRoleCode
+	 *            not <code>null</code>
+	 * @return {@link Targets} builder for all active members of the given parent organization with the given role
+	 */
 	default Builder create(String parentOrganizationIdentifierValue, String memberOrganizationRoleCode)
 	{
 		return create(
@@ -64,9 +113,29 @@ public interface TargetProvider
 				memberOrganizationRoleCode == null ? null : OrganizationRole.withCode(memberOrganizationRoleCode));
 	}
 
+	/**
+	 * @param parentOrganizationIdentifier
+	 *            not <code>null</code>
+	 * @param memberOrganizationRole
+	 *            not <code>null</code>
+	 * @param memberOrganizationIdentifier
+	 *            not <code>null</code>, array <code>null</code> values will be ignored
+	 * @return {@link Targets} builder for all active members of the given parent organization with the given role,
+	 *         filtered by the given member organization
+	 */
 	Builder create(Identifier parentOrganizationIdentifier, Coding memberOrganizationRole,
 			Identifier... memberOrganizationIdentifier);
 
+	/**
+	 * @param parentOrganizationIdentifierValue
+	 *            not <code>null</code>
+	 * @param memberOrganizationRoleCode
+	 *            not <code>null</code>
+	 * @param memberOrganizationIdentifierValue
+	 *            not <code>null</code>, array <code>null</code> values will be ignored
+	 * @return {@link Targets} builder for all active members of the given parent organization with the given role,
+	 *         filtered by the given member organization
+	 */
 	default Builder create(String parentOrganizationIdentifierValue, String memberOrganizationRoleCode,
 			String... memberOrganizationIdentifierValue)
 	{

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/TargetProvider.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/TargetProvider.java
@@ -1,0 +1,81 @@
+package dev.dsf.bpe.v2.service;
+
+import java.util.Arrays;
+
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.OrganizationAffiliation;
+
+import dev.dsf.bpe.v2.constants.CodeSystems.OrganizationRole;
+import dev.dsf.bpe.v2.constants.NamingSystems.OrganizationIdentifier;
+import dev.dsf.bpe.v2.variables.Targets;
+
+public interface TargetProvider
+{
+	interface Builder
+	{
+		@FunctionalInterface
+		interface Predicate
+		{
+			/**
+			 * @param affiliation
+			 *            not <code>null</code>
+			 * @param member
+			 *            not <code>null</code>
+			 * @param endpoint
+			 *            not <code>null</code>
+			 * @return <code>true</code> if the entry should part of the resulting {@link Targets}
+			 */
+			boolean test(OrganizationAffiliation affiliation, Organization member, Endpoint endpoint);
+		}
+
+		Targets withCorrelationKey();
+
+		Targets withoutCorrelationKey();
+
+		/**
+		 * Returns a builder consisting of the elements that match the given predicate. A <code>null</code>
+		 * <b>predicate</b> will be ignored.
+		 *
+		 * @param predicate
+		 *            may be <code>null</code>
+		 * @return filtered builder
+		 */
+		Builder filter(Predicate predicate);
+	}
+
+	Builder create(Identifier parentOrganizationIdentifier);
+
+	default Builder create(String parentOrganizationIdentifierValue)
+	{
+		return create(parentOrganizationIdentifierValue == null ? null
+				: OrganizationIdentifier.withValue(parentOrganizationIdentifierValue));
+	}
+
+	Builder create(Identifier parentOrganizationIdentifier, Coding memberOrganizationRole);
+
+	default Builder create(String parentOrganizationIdentifierValue, String memberOrganizationRoleCode)
+	{
+		return create(
+				parentOrganizationIdentifierValue == null ? null
+						: OrganizationIdentifier.withValue(parentOrganizationIdentifierValue),
+				memberOrganizationRoleCode == null ? null : OrganizationRole.withCode(memberOrganizationRoleCode));
+	}
+
+	Builder create(Identifier parentOrganizationIdentifier, Coding memberOrganizationRole,
+			Identifier... memberOrganizationIdentifier);
+
+	default Builder create(String parentOrganizationIdentifierValue, String memberOrganizationRoleCode,
+			String... memberOrganizationIdentifierValue)
+	{
+		return create(
+				parentOrganizationIdentifierValue == null ? null
+						: OrganizationIdentifier.withValue(parentOrganizationIdentifierValue),
+				memberOrganizationRoleCode == null ? null : OrganizationRole.withCode(memberOrganizationRoleCode),
+				memberOrganizationIdentifierValue == null ? null
+						: Arrays.stream(memberOrganizationIdentifierValue).map(OrganizationIdentifier::withValue)
+								.toArray(Identifier[]::new));
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/variables/Targets.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/variables/Targets.java
@@ -49,4 +49,9 @@ public interface Targets
 	 * @return <code>true</code> if the entries list is empty
 	 */
 	boolean isEmpty();
+
+	/**
+	 * @return number of target entries
+	 */
+	int size();
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/variables/Targets.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/variables/Targets.java
@@ -2,6 +2,7 @@ package dev.dsf.bpe.v2.variables;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import dev.dsf.bpe.v2.constants.BpmnExecutionVariables;
 
@@ -54,4 +55,10 @@ public interface Targets
 	 * @return number of target entries
 	 */
 	int size();
+
+	/**
+	 * @return {@link Optional} with the first element of the target entries, or {@link Optional#empty()} if
+	 *         {@link Targets#isEmpty()}
+	 */
+	Optional<Target> getFirst();
 }

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/integration/PluginV2IntegrationTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/integration/PluginV2IntegrationTest.java
@@ -222,4 +222,10 @@ public class PluginV2IntegrationTest extends AbstractPluginIntegrationTest
 
 		executePluginTest(createTestTask("DsfClientTest"));
 	}
+
+	@Test
+	public void startTargetProviderTest() throws Exception
+	{
+		executePluginTest(createTestTask("TargetProviderTest"));
+	}
 }

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/service/TargetProviderTest.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/service/TargetProviderTest.java
@@ -1,0 +1,300 @@
+package dev.dsf.bpe.test.service;
+
+import static dev.dsf.bpe.test.PluginTestExecutor.expectException;
+import static dev.dsf.bpe.test.PluginTestExecutor.expectNotNull;
+import static dev.dsf.bpe.test.PluginTestExecutor.expectNull;
+import static dev.dsf.bpe.test.PluginTestExecutor.expectSame;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Identifier;
+
+import dev.dsf.bpe.test.AbstractTest;
+import dev.dsf.bpe.test.PluginTest;
+import dev.dsf.bpe.v2.ProcessPluginApi;
+import dev.dsf.bpe.v2.activity.ServiceTask;
+import dev.dsf.bpe.v2.constants.CodeSystems.OrganizationRole;
+import dev.dsf.bpe.v2.constants.NamingSystems.OrganizationIdentifier;
+import dev.dsf.bpe.v2.error.ErrorBoundaryEvent;
+import dev.dsf.bpe.v2.service.TargetProvider;
+import dev.dsf.bpe.v2.variables.Target;
+import dev.dsf.bpe.v2.variables.Targets;
+import dev.dsf.bpe.v2.variables.Variables;
+
+public class TargetProviderTest extends AbstractTest implements ServiceTask
+{
+	private static final String ORGANIZATION_IDENTIFIER_PARENT_VALUE = "Parent_Organization";
+	private static final Identifier ORGANIZATION_IDENTIFIER_PARENT = OrganizationIdentifier
+			.withValue(ORGANIZATION_IDENTIFIER_PARENT_VALUE);
+
+	private static final String ORGANIZATION_IDENTIFIER_LOCAL_VALUE = "Test_Organization";
+	private static final Identifier ORGANIZATION_IDENTIFIER_LOCAL = OrganizationIdentifier
+			.withValue(ORGANIZATION_IDENTIFIER_LOCAL_VALUE);
+	private static final String ORGANIZATION_IDENTIFIER_EXTERNAL_VALUE = "External_Test_Organization";
+	private static final Identifier ORGANIZATION_IDENTIFIER_EXTERNAL = OrganizationIdentifier
+			.withValue(ORGANIZATION_IDENTIFIER_EXTERNAL_VALUE);
+
+	private static final String ENDPOINT_IDENTIFIER_LOCAL_VALUE = "Test_Endpoint";
+	private static final String ENDPOINT_IDENTIFIER_EXTERNAL_VALUE = "External_Test_Endpoint";
+
+	private static final String ORGANIZATION_IDENTIFIER_NOT_EXISTING_VALUE = "not-existing-identifier-value";
+	private static final Identifier ORGANIZATION_IDENTIFIER_NOT_EXISTING = OrganizationIdentifier
+			.withValue(ORGANIZATION_IDENTIFIER_NOT_EXISTING_VALUE);
+	private static final String MEMBER_ROLE_NOT_EXISTING_CODE = "not-existing-role";
+	private static final Coding MEMBER_ROLE_NOT_EXISTING = OrganizationRole.withCode(MEMBER_ROLE_NOT_EXISTING_CODE);
+
+	@Override
+	public void execute(ProcessPluginApi api, Variables variables) throws ErrorBoundaryEvent, Exception
+	{
+		executeTests(api, variables, api.getTargetProvider());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithCorrelationKey(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT_VALUE).withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(2, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(2, entries.size());
+
+		Target target0 = entries.get(0);
+		expectNotNull(target0);
+		expectSame(ORGANIZATION_IDENTIFIER_LOCAL_VALUE, target0.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_LOCAL_VALUE, target0.getEndpointIdentifierValue());
+		expectNotNull(target0.getEndpointUrl());
+		expectNotNull(target0.getCorrelationKey());
+
+		Target target1 = entries.get(1);
+		expectNotNull(target1);
+		expectSame(ORGANIZATION_IDENTIFIER_EXTERNAL_VALUE, target1.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_EXTERNAL_VALUE, target1.getEndpointIdentifierValue());
+		expectNotNull(target1.getEndpointUrl());
+		expectNotNull(target1.getCorrelationKey());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithoutCorrelationKey(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT_VALUE).withoutCorrelationKey();
+		expectNotNull(targets);
+		expectSame(2, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(2, entries.size());
+
+		Target target0 = entries.get(0);
+		expectNotNull(target0);
+		expectSame(ORGANIZATION_IDENTIFIER_LOCAL_VALUE, target0.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_LOCAL_VALUE, target0.getEndpointIdentifierValue());
+		expectNotNull(target0.getEndpointUrl());
+		expectNull(target0.getCorrelationKey());
+
+		Target target1 = entries.get(1);
+		expectNotNull(target1);
+		expectSame(ORGANIZATION_IDENTIFIER_EXTERNAL_VALUE, target1.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_EXTERNAL_VALUE, target1.getEndpointIdentifierValue());
+		expectNotNull(target1.getEndpointUrl());
+		expectNull(target1.getCorrelationKey());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithFilter(TargetProvider targetProvider) throws Exception
+	{
+		AtomicInteger counter = new AtomicInteger(0);
+
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT_VALUE).filter((a, o, e) ->
+		{
+			expectNotNull(a);
+			expectNotNull(o);
+			expectNotNull(e);
+
+			counter.incrementAndGet();
+
+			return false;
+
+		}).withCorrelationKey();
+
+		expectNotNull(targets);
+		expectSame(0, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(0, entries.size());
+
+		expectSame(2, counter.get());
+	}
+
+	@PluginTest
+	public void createForNotExistingParentIdentifierValue(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_NOT_EXISTING_VALUE).withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(0, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(0, entries.size());
+	}
+
+	@PluginTest
+	public void createForNotExistingParentIdentifier(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_NOT_EXISTING).withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(0, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(0, entries.size());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithCorrelationKeyDic(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT, OrganizationRole.dic())
+				.withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(1, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(1, entries.size());
+
+		Target target0 = entries.get(0);
+		expectNotNull(target0);
+		expectSame(ORGANIZATION_IDENTIFIER_LOCAL_VALUE, target0.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_LOCAL_VALUE, target0.getEndpointIdentifierValue());
+		expectNotNull(target0.getEndpointUrl());
+		expectNotNull(target0.getCorrelationKey());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithCorrelationKeyDts(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT, OrganizationRole.dts())
+				.withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(1, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(1, entries.size());
+
+		Target target0 = entries.get(0);
+		expectNotNull(target0);
+		expectSame(ORGANIZATION_IDENTIFIER_EXTERNAL_VALUE, target0.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_EXTERNAL_VALUE, target0.getEndpointIdentifierValue());
+		expectNotNull(target0.getEndpointUrl());
+		expectNotNull(target0.getCorrelationKey());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithCorrelationKeyDicMemberIdentifier(TargetProvider targetProvider)
+			throws Exception
+	{
+		Targets targets = targetProvider
+				.create(ORGANIZATION_IDENTIFIER_PARENT, OrganizationRole.dic(), ORGANIZATION_IDENTIFIER_LOCAL)
+				.withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(1, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(1, entries.size());
+
+		Target target0 = entries.get(0);
+		expectNotNull(target0);
+		expectSame(ORGANIZATION_IDENTIFIER_LOCAL_VALUE, target0.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_LOCAL_VALUE, target0.getEndpointIdentifierValue());
+		expectNotNull(target0.getEndpointUrl());
+		expectNotNull(target0.getCorrelationKey());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithCorrelationKeyDicMemberIdentifierWithoutDicRole(
+			TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider
+				.create(ORGANIZATION_IDENTIFIER_PARENT, OrganizationRole.dic(), ORGANIZATION_IDENTIFIER_EXTERNAL)
+				.withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(0, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(0, entries.size());
+	}
+
+	@PluginTest
+	public void createNull(TargetProvider targetProvider) throws Exception
+	{
+		expectException(NullPointerException.class, () -> targetProvider.create((String) null).withoutCorrelationKey());
+		expectException(NullPointerException.class,
+				() -> targetProvider.create((Identifier) null).withoutCorrelationKey());
+	}
+
+	@PluginTest
+	public void createNotNullNull(TargetProvider targetProvider) throws Exception
+	{
+		expectException(NullPointerException.class, () -> targetProvider
+				.create(ORGANIZATION_IDENTIFIER_PARENT_VALUE, (String) null).withoutCorrelationKey());
+		expectException(NullPointerException.class,
+				() -> targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT, (Coding) null).withoutCorrelationKey());
+	}
+
+	@PluginTest
+	public void createNotNullNotNullNull(TargetProvider targetProvider) throws Exception
+	{
+		expectException(NullPointerException.class,
+				() -> targetProvider
+						.create(ORGANIZATION_IDENTIFIER_PARENT_VALUE, MEMBER_ROLE_NOT_EXISTING_CODE, (String[]) null)
+						.withoutCorrelationKey());
+		expectException(NullPointerException.class,
+				() -> targetProvider
+						.create(ORGANIZATION_IDENTIFIER_PARENT, MEMBER_ROLE_NOT_EXISTING, (Identifier[]) null)
+						.withoutCorrelationKey());
+	}
+
+	@PluginTest
+	public void createForExistingParentWithCorrelationKeyNullFilter(TargetProvider targetProvider) throws Exception
+	{
+		Targets targets = targetProvider.create(ORGANIZATION_IDENTIFIER_PARENT_VALUE).filter(null).withCorrelationKey();
+		expectNotNull(targets);
+		expectSame(2, targets.size());
+
+		List<Target> entries = targets.getEntries().stream()
+				.sorted(Comparator.comparing(Target::getOrganizationIdentifierValue).reversed()).toList();
+		expectNotNull(entries);
+		expectSame(2, entries.size());
+
+		Target target0 = entries.get(0);
+		expectNotNull(target0);
+		expectSame(ORGANIZATION_IDENTIFIER_LOCAL_VALUE, target0.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_LOCAL_VALUE, target0.getEndpointIdentifierValue());
+		expectNotNull(target0.getEndpointUrl());
+		expectNotNull(target0.getCorrelationKey());
+
+		Target target1 = entries.get(1);
+		expectNotNull(target1);
+		expectSame(ORGANIZATION_IDENTIFIER_EXTERNAL_VALUE, target1.getOrganizationIdentifierValue());
+		expectSame(ENDPOINT_IDENTIFIER_EXTERNAL_VALUE, target1.getEndpointIdentifierValue());
+		expectNotNull(target1.getEndpointUrl());
+		expectNotNull(target1.getCorrelationKey());
+	}
+}

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/spring/config/Config.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/spring/config/Config.java
@@ -33,6 +33,7 @@ import dev.dsf.bpe.test.service.JsonVariableTestSet;
 import dev.dsf.bpe.test.service.MimetypeServiceTest;
 import dev.dsf.bpe.test.service.OrganizationProviderTest;
 import dev.dsf.bpe.test.service.ProxyTest;
+import dev.dsf.bpe.test.service.TargetProviderTest;
 import dev.dsf.bpe.test.service.TestActivitySelector;
 import dev.dsf.bpe.v2.documentation.ProcessDocumentation;
 import dev.dsf.bpe.v2.fhir.FhirResourceModifier;
@@ -68,7 +69,7 @@ public class Config implements InitializingBean
 				ExceptionTest.class, ContinueSendTest.class, ContinueSendTestSend.class, ContinueSendTestEvaluate.class,
 				JsonVariableTestSet.class, JsonVariableTestGet.class, CryptoServiceTest.class,
 				MimetypeServiceTest.class, FhirBinaryVariableTestSet.class, FhirBinaryVariableTestGet.class,
-				DsfClientTest.class);
+				DsfClientTest.class, TargetProviderTest.class);
 	}
 
 	@Bean

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/resources/bpe/test.bpmn
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/resources/bpe/test.bpmn
@@ -38,6 +38,7 @@
       <bpmn:outgoing>Flow_151zxir</bpmn:outgoing>
       <bpmn:outgoing>Flow_1bo772x</bpmn:outgoing>
       <bpmn:outgoing>Flow_1gipugc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1wjdaz2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1bqddk1" sourceRef="TestActivitySelector" targetRef="Gateway_0eszi2t" />
     <bpmn:sequenceFlow id="Flow_14rzc0j" sourceRef="Gateway_0eszi2t" targetRef="ProxyTest">
@@ -64,6 +65,7 @@
       <bpmn:incoming>Flow_1ic3b4h</bpmn:incoming>
       <bpmn:incoming>Flow_01nnroq</bpmn:incoming>
       <bpmn:incoming>Flow_04z1f6i</bpmn:incoming>
+      <bpmn:incoming>Flow_0w963xd</bpmn:incoming>
       <bpmn:outgoing>Flow_0a1kwg9</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_08zzudo" sourceRef="ProxyTest" targetRef="Gateway_056f6tw" />
@@ -290,6 +292,14 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${testActivity == 'DsfClientTest'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_04z1f6i" sourceRef="DsfClientTest" targetRef="Gateway_056f6tw" />
+    <bpmn:serviceTask id="TargetProviderTest" name="TargetProviderTest" camunda:class="dev.dsf.bpe.test.service.TargetProviderTest">
+      <bpmn:incoming>Flow_1wjdaz2</bpmn:incoming>
+      <bpmn:outgoing>Flow_0w963xd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0w963xd" sourceRef="TargetProviderTest" targetRef="Gateway_056f6tw" />
+    <bpmn:sequenceFlow id="Flow_1wjdaz2" sourceRef="Gateway_0eszi2t" targetRef="TargetProviderTest">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${testActivity == 'TargetProviderTest'}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmn:message id="Message_1nn2wdw" name="start" />
   <bpmn:message id="Message_2iq6v5e" name="proxyTest" />
@@ -411,6 +421,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0og1ky5" bpmnElement="DsfClientTest">
         <dc:Bounds x="480" y="1830" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1jxi9cb" bpmnElement="TargetProviderTest">
+        <dc:Bounds x="480" y="1940" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1w9i7ga_di" bpmnElement="Event_1dnlmzp">
@@ -633,6 +647,16 @@
         <di:waypoint x="580" y="1870" />
         <di:waypoint x="1180" y="1870" />
         <di:waypoint x="1180" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w963xd_di" bpmnElement="Flow_0w963xd">
+        <di:waypoint x="580" y="1980" />
+        <di:waypoint x="1180" y="1980" />
+        <di:waypoint x="1180" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wjdaz2_di" bpmnElement="Flow_1wjdaz2">
+        <di:waypoint x="410" y="145" />
+        <di:waypoint x="410" y="1980" />
+        <di:waypoint x="480" y="1980" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
* API v2 target provider impl and integration tests.
* Added throws ErrorBoundaryEvent to default execute method of MessageSendTask to document that custom error handling flows can be implemented in BPMN by throwing ErrorBoundaryEvent.

closes #307