### PR TITLE
Task Boolean Input Parameter

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/main/resources/static/form.js
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/static/form.js
@@ -177,7 +177,7 @@ function newTaskInputBoolean(type, id, checkedTrue, checkedFalse, optional) {
 		addError(errorListElement, "Input mandatory")
 	}
 
-	if (value) {
+	if (value !== null) {
 		return {
 			input: {
 				type: type,


### PR DESCRIPTION
adds missing not null check

fixes #323

should be ported to 2.0.0