### PR TITLE
Issue/202 java 25

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       if: ${{ matrix.language == 'java-kotlin' }}
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 21
+        java-version: 25
         cache: 'maven'
 
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,9 @@ jobs:
         languages: ${{ matrix.language }}
         queries: security-extended, security-and-quality
 
+    - name: Display Maven Version
+      run: mvn --version
+
     - name: Compile with Maven
       if: ${{ matrix.language == 'java-kotlin' }}
       run: mvn --batch-mode --fail-at-end --threads 1C -Dimpsort.skip=true -Dformatter.skip=true -Denforcer.skip -Dmaven.buildNumber.skip=true -Dexec.skip=true -DskipTests -DskipShadePlugin=true -P!generate-source-and-javadoc-jars clean package

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,15 +23,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up JDK 25
       if: ${{ matrix.language == 'java-kotlin' }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 25
         cache: 'maven'
+        check-latest: true
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 21
+        java-version: 25
         cache: 'maven'
     - name: Build with Maven
       run: mvn --batch-mode --fail-at-end -DforkCount=2 clean verify

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository 
+      uses: actions/checkout@v5
     - name: Set up JDK 25
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 25

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
           check-latest: true
       - name: Publish with Maven

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,9 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       - name: Set up JDK 25
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 25

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/service/OrganizationProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/service/OrganizationProviderImpl.java
@@ -141,6 +141,6 @@ public class OrganizationProviderImpl extends AbstractResourceProvider implement
 
 		Map<String, List<String>> searchParameters = Map.of("active", List.of("true"), "identifier:not",
 				List.of(toSearchParameter(localOrganizationIdentifier.get())));
-		return search(Organization.class, searchParameters, SearchEntryMode.MATCH, Organization.class, o -> true);
+		return search(Organization.class, searchParameters, SearchEntryMode.MATCH, Organization.class, _ -> true);
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
@@ -284,7 +284,7 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 	@Override
 	public boolean isValid(Resource resource)
 	{
-		return isValid(resource, organizationIdentifier -> true, role -> true);
+		return isValid(resource, _ -> true, _ -> true);
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
@@ -322,7 +322,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 							.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> requesterFrom(coding, c -> true, i -> true, c -> true).stream());
+					.flatMap(coding -> requesterFrom(coding, _ -> true, _ -> true, _ -> true).stream());
 	}
 
 	@Override
@@ -340,7 +340,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 							.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> recipientFrom(coding, i -> true, c -> true).stream());
+					.flatMap(coding -> recipientFrom(coding, _ -> true, _ -> true).stream());
 	}
 
 	private Optional<Extension> getAuthorizationExtension(ActivityDefinition activityDefinition, String processUrl,

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/OrganizationProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/OrganizationProviderImpl.java
@@ -142,7 +142,7 @@ public class OrganizationProviderImpl extends AbstractResourceProvider implement
 		Map<String, List<String>> searchParameters = Map.of("active", List.of("true"), "identifier:not",
 				List.of(toSearchParameter(localOrganizationIdentifier.get())), "_profile",
 				List.of("http://dsf.dev/fhir/StructureDefinition/organization"));
-		return search(Organization.class, searchParameters, SearchEntryMode.MATCH, Organization.class, o -> true);
+		return search(Organization.class, searchParameters, SearchEntryMode.MATCH, Organization.class, _ -> true);
 	}
 
 	@Override
@@ -150,6 +150,6 @@ public class OrganizationProviderImpl extends AbstractResourceProvider implement
 	{
 		Map<String, List<String>> searchParameters = Map.of("active", List.of("true"), "_profile",
 				List.of("http://dsf.dev/fhir/StructureDefinition/organization-parent"));
-		return search(Organization.class, searchParameters, SearchEntryMode.MATCH, Organization.class, o -> true);
+		return search(Organization.class, searchParameters, SearchEntryMode.MATCH, Organization.class, _ -> true);
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/ReadAccessHelperImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/ReadAccessHelperImpl.java
@@ -298,7 +298,7 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 	@Override
 	public boolean isValid(Resource resource)
 	{
-		return isValid(resource, organizationIdentifier -> true, role -> true);
+		return isValid(resource, _ -> true, _ -> true);
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/process/ProcessAuthorizationHelperImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/process/ProcessAuthorizationHelperImpl.java
@@ -437,7 +437,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 					.filter(e -> EXTENSION_PROCESS_AUTHORIZATION_REQUESTER.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> requesterFrom(coding, c -> true, i -> true, c -> true).stream());
+					.flatMap(coding -> requesterFrom(coding, _ -> true, _ -> true, _ -> true).stream());
 	}
 
 	@Override
@@ -454,7 +454,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 					.filter(e -> EXTENSION_PROCESS_AUTHORIZATION_RECIPIENT.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> recipientFrom(coding, i -> true, c -> true).stream());
+					.flatMap(coding -> recipientFrom(coding, _ -> true, _ -> true).stream());
 	}
 
 	private Optional<Extension> getAuthorizationExtension(ActivityDefinition activityDefinition, String processUrl,

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/task/DefaultTaskSender.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/task/DefaultTaskSender.java
@@ -44,7 +44,7 @@ public class DefaultTaskSender implements TaskSender
 	public DefaultTaskSender(ProcessPluginApi api, Variables variables, SendTaskValues sendTaskValues,
 			BusinessKeyStrategy businessKeyStrategy)
 	{
-		this(api, variables, sendTaskValues, businessKeyStrategy, t -> List.of());
+		this(api, variables, sendTaskValues, businessKeyStrategy, _ -> List.of());
 	}
 
 	public DefaultTaskSender(ProcessPluginApi api, Variables variables, SendTaskValues sendTaskValues,

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/AbstractProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/AbstractProcessPlugin.java
@@ -247,7 +247,7 @@ public abstract class AbstractProcessPlugin<UTL> implements ProcessPlugin
 		}
 
 		Map<String, Integer> processCounts = models.stream()
-				.collect(Collectors.toMap(m -> m.toProcessIdAndVersion().getId(), m -> 1, (c1, c2) -> c1 + c2));
+				.collect(Collectors.toMap(m -> m.toProcessIdAndVersion().getId(), _ -> 1, (c1, c2) -> c1 + c2));
 		if (processCounts.values().stream().anyMatch(c -> c > 1))
 		{
 			logger.warn("Ignoring process plugin {}-{} from {}: Processes with duplicate IDs found {}",
@@ -1164,7 +1164,7 @@ public abstract class AbstractProcessPlugin<UTL> implements ProcessPlugin
 	private Object modifyBaseDefinitionIfTaskProfile(Object resource, String file)
 	{
 		Optional<String> baseDefinition = fhirConfig.getStructureDefinitionBaseDefinition(resource);
-		baseDefinition.filter(d -> STRUCTURE_DEFINITION_BASE_TASK_URL_V1.equals(d)).ifPresent(d ->
+		baseDefinition.filter(d -> STRUCTURE_DEFINITION_BASE_TASK_URL_V1.equals(d)).ifPresent(_ ->
 		{
 			logger.info(
 					"Setting StructureDefinition.baseDefinition to {} for FHIR resource {} from process plugin {}-{}",

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN chown root:java ./ && \
 	chmod 1775 ./log
 
 
-FROM azul/zulu-openjdk:21-jre-headless
+FROM azul/zulu-openjdk:25-jre-headless
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -211,12 +211,6 @@
 			<artifactId>log4j-slf4j2-impl</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- For async logging with log4j2 -->
-		<dependency>
-			<groupId>com.lmax</groupId>
-			<artifactId>disruptor</artifactId>
-			<scope>test</scope>
-		</dependency>
 		
 		<dependency>
 			<groupId>dev.dsf</groupId>

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateActivityBehavior.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/camunda/MultiVersionClassDelegateActivityBehavior.java
@@ -40,14 +40,14 @@ public class MultiVersionClassDelegateActivityBehavior extends ClassDelegateActi
 
 			JavaDelegate delegate = switch (e.getBpmnModelElementInstance())
 			{
-				case SendTask st ->
+				case SendTask _ ->
 					delegateProvider.getMessageSendTask(processKeyAndVersion, className, fieldDeclarations, execution);
-				case ServiceTask st ->
+				case ServiceTask _ ->
 					delegateProvider.getServiceTask(processKeyAndVersion, className, fieldDeclarations, execution);
-				case EndEvent ee ->
+				case EndEvent _ ->
 					delegateProvider.getMessageEndEvent(processKeyAndVersion, className, fieldDeclarations, execution);
-				case IntermediateThrowEvent ite -> delegateProvider.getMessageIntermediateThrowEvent(
-						processKeyAndVersion, className, fieldDeclarations, execution);
+				case IntermediateThrowEvent _ -> delegateProvider.getMessageIntermediateThrowEvent(processKeyAndVersion,
+						className, fieldDeclarations, execution);
 
 				default -> throw new IllegalArgumentException("Unexpected value: " + e.getBpmnModelElementInstance());
 			};

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/mail/SmtpMailService.java
@@ -156,8 +156,8 @@ public class SmtpMailService implements BpeMailService, InitializingBean
 			MailManagerFactory factory = (name, data) -> new SmtpManager(name, session, message, data)
 			{
 			};
-			FactoryData data = new FactoryData(null, null, null, null, null, null, event -> subject, null, null, 0,
-					null, null, false, messageBufferSize, null, null);
+			FactoryData data = new FactoryData(null, null, null, null, null, null, _ -> subject, null, null, 0, null,
+					null, false, messageBufferSize, null, null);
 			manager = AbstractManager.getManager("SmtpMailService.Log4jAppender.Manager", factory, data);
 		}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/FhirResourceHandlerImpl.java
@@ -96,7 +96,7 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 
 			currentOrOldProcessResources.forEach(res ->
 			{
-				resources.computeIfPresent(res.getResourceInfo(), (processInfo, processResource) ->
+				resources.computeIfPresent(res.getResourceInfo(), (_, processResource) ->
 				{
 					processResource.addAll(res.getProcesses());
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/AuthenticationConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/spring/config/AuthenticationConfig.java
@@ -44,7 +44,7 @@ public class AuthenticationConfig
 	public RoleConfig roleConfig()
 	{
 		RoleConfig config = new RoleConfigReader().read(propertiesConfig.getRoleConfig(),
-				role -> BpeServerRole.isValid(role) ? BpeServerRole.valueOf(role) : null, s -> null);
+				role -> BpeServerRole.isValid(role) ? BpeServerRole.valueOf(role) : null, _ -> null);
 
 		logger.info("Role config: {}", config.toString());
 		return config;

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/ConcurrentSubscriptionHandlerFactory.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/subscription/ConcurrentSubscriptionHandlerFactory.java
@@ -35,7 +35,7 @@ public class ConcurrentSubscriptionHandlerFactory<R extends Resource>
 			throw new IllegalArgumentException("corePoolSize <= 0");
 
 		executor = new ThreadPoolExecutor(corePoolSize, corePoolSize, 30, TimeUnit.MINUTES, queue,
-				(r, executor) -> logger.error("Unable to handle Task - execution rejected"));
+				(_, _) -> logger.error("Unable to handle Task - execution rejected"));
 		executor.allowCoreThreadTimeOut(true);
 
 		this.delegate = delegate;

--- a/dsf-bpe/dsf-bpe-server/src/test/resources/log4j2-maven-surefire-config.xml
+++ b/dsf-bpe/dsf-bpe-server/src/test/resources/log4j2-maven-surefire-config.xml
@@ -14,12 +14,12 @@
 			<AppenderRef ref="DATA"/>
 		</Logger>
 
-		<AsyncLogger name="dev.dsf" level="INFO"/>
-		<AsyncLogger name="org.eclipse.jetty" level="INFO"/>
+		<Logger name="dev.dsf" level="INFO"/>
+		<Logger name="org.eclipse.jetty" level="INFO"/>
 		<Logger name="ca.uhn.fhir.parser.LenientErrorHandler" level="ERROR"/>
 
-		<AsyncRoot level="WARN">
+		<Root level="WARN">
 			<AppenderRef ref="CONSOLE"/>
-		</AsyncRoot>
+		</Root>
 	</Loggers>
 </Configuration>

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/service/ErrorBoundaryEventTestThrow.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/service/ErrorBoundaryEventTestThrow.java
@@ -21,6 +21,6 @@ public class ErrorBoundaryEventTestThrow implements ServiceTask
 	@Override
 	public ServiceTaskErrorHandler getErrorHandler()
 	{
-		return new ExceptionToErrorBoundaryEventTranslationErrorHandler(e -> TEST_ERROR_CODE);
+		return new ExceptionToErrorBoundaryEventTranslationErrorHandler(_ -> TEST_ERROR_CODE);
 	}
 }

--- a/dsf-common/dsf-common-auth/src/test/java/dev/dsf/common/auth/RoleConfigReaderTest.java
+++ b/dsf-common/dsf-common-auth/src/test/java/dev/dsf/common/auth/RoleConfigReaderTest.java
@@ -12,24 +12,24 @@ public class RoleConfigReaderTest
 	@Test(expected = NullPointerException.class)
 	public void testReadNullString() throws Exception
 	{
-		new RoleConfigReader().read((String) null, s -> null, s -> null);
+		new RoleConfigReader().read((String) null, _ -> null, _ -> null);
 	}
 
 	@Test
 	public void testReadEmptyString() throws Exception
 	{
-		new RoleConfigReader().read("", s -> null, s -> null);
+		new RoleConfigReader().read("", _ -> null, _ -> null);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testReadNullInputStream() throws Exception
 	{
-		new RoleConfigReader().read((InputStream) null, s -> null, s -> null);
+		new RoleConfigReader().read((InputStream) null, _ -> null, _ -> null);
 	}
 
 	@Test
 	public void testReadEmptyInputStream() throws Exception
 	{
-		new RoleConfigReader().read(new ByteArrayInputStream(new byte[0]), s -> null, s -> null);
+		new RoleConfigReader().read(new ByteArrayInputStream(new byte[0]), _ -> null, _ -> null);
 	}
 }

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/logging/Log4jInitializer.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/logging/Log4jInitializer.java
@@ -180,11 +180,11 @@ public abstract class Log4jInitializer
 			return configuration -> JsonTemplateLayout.newBuilder().setConfiguration(configuration)
 					.setEventTemplateUri(TemplateUri.LOGSTASH.getUri()).build();
 		else if (SPECIAL_TEXT.equalsIgnoreCase(value))
-			return configuration -> PatternLayout.newBuilder().withPattern("%d %m%n").build();
+			return _ -> PatternLayout.newBuilder().withPattern("%d %m%n").build();
 		else if (SPECIAL_TEXT_MDC.equalsIgnoreCase(value))
-			return configuration -> PatternLayout.newBuilder().withPattern("%d%notEmpty{ %X} %m%n").build();
+			return _ -> PatternLayout.newBuilder().withPattern("%d%notEmpty{ %X} %m%n").build();
 		else if (SPECIAL_OFF.equalsIgnoreCase(value))
-			return configuration -> null;
+			return _ -> null;
 		else
 			throw new IllegalArgumentException("Value '" + value + "' for " + parameter + " not supported");
 	}

--- a/dsf-common/dsf-common-oidc/src/main/java/dev/dsf/common/oidc/Jwks.java
+++ b/dsf-common/dsf-common-oidc/src/main/java/dev/dsf/common/oidc/Jwks.java
@@ -66,39 +66,42 @@ public class Jwks
 		{
 			return switch (kty)
 			{
-				case "RSA" -> {
-
-					RSAPublicKey key = toRsaPublicKey(n, e);
-					RSAKeyProvider keyProvider = toRsaKeyProvider(key, kid);
-
-					yield switch (alg)
-					{
-						case "RS256" -> Algorithm.RSA256(keyProvider);
-						case "RS384" -> Algorithm.RSA384(keyProvider);
-						case "RS512" -> Algorithm.RSA512(keyProvider);
-
-						default -> throw new JwksException(
-								"JWKS alg property value '" + alg + "' not one of 'RSA256', 'RSA384' or 'RSA512'");
-					};
-				}
-
-				case "EC" -> {
-
-					ECPublicKey key = toEcPublicKey(x, y, crv);
-					ECDSAKeyProvider keyProvider = toEcKeyProvider(key, kid);
-
-					yield switch (alg)
-					{
-						case "ES256" -> Algorithm.ECDSA256(keyProvider);
-						case "ES384" -> Algorithm.ECDSA384(keyProvider);
-						case "ES512" -> Algorithm.ECDSA512(keyProvider);
-
-						default -> throw new JwksException(
-								"JWKS crv property value '" + alg + "' not one of 'ES256', 'ES384' or 'ES512'");
-					};
-				}
+				case "RSA" -> toRsaAlgorithm();
+				case "EC" -> toEcdsaAlgorithm();
 
 				default -> throw new JwksException("JWKS kty property value '" + kty + "' not one of 'RSA' or 'EC'");
+			};
+		}
+
+		private Algorithm toRsaAlgorithm()
+		{
+			RSAPublicKey key = toRsaPublicKey(n, e);
+			RSAKeyProvider keyProvider = toRsaKeyProvider(key, kid);
+
+			return switch (alg)
+			{
+				case "RS256" -> Algorithm.RSA256(keyProvider);
+				case "RS384" -> Algorithm.RSA384(keyProvider);
+				case "RS512" -> Algorithm.RSA512(keyProvider);
+
+				default -> throw new JwksException(
+						"JWKS alg property value '" + alg + "' not one of 'RSA256', 'RSA384' or 'RSA512'");
+			};
+		}
+
+		private Algorithm toEcdsaAlgorithm()
+		{
+			ECPublicKey key = toEcPublicKey(x, y, crv);
+			ECDSAKeyProvider keyProvider = toEcKeyProvider(key, kid);
+
+			return switch (alg)
+			{
+				case "ES256" -> Algorithm.ECDSA256(keyProvider);
+				case "ES384" -> Algorithm.ECDSA384(keyProvider);
+				case "ES512" -> Algorithm.ECDSA512(keyProvider);
+
+				default -> throw new JwksException(
+						"JWKS crv property value '" + alg + "' not one of 'ES256', 'ES384' or 'ES512'");
 			};
 		}
 

--- a/dsf-common/dsf-common-oidc/src/main/java/dev/dsf/common/oidc/JwtVerifierImpl.java
+++ b/dsf-common/dsf-common-oidc/src/main/java/dev/dsf/common/oidc/JwtVerifierImpl.java
@@ -45,7 +45,7 @@ public class JwtVerifierImpl implements JwtVerifier
 		JWTVerifier verifier = oidcClient.getJwks().getKey(keyId).map(JwksKey::toAlgorithm).map(algorithm ->
 		{
 			return createVerification(algorithm).withAudience(clientId).withClaim("events",
-					(claim, jwt) -> claim.asMap().containsKey("http://schemas.openid.net/event/backchannel-logout"))
+					(claim, _) -> claim.asMap().containsKey("http://schemas.openid.net/event/backchannel-logout"))
 					.build();
 
 		}).orElseThrow(() -> new OidcClientException(

--- a/dsf-common/dsf-common-status/src/main/java/dev/dsf/common/status/webservice/StatusService.java
+++ b/dsf-common/dsf-common-status/src/main/java/dev/dsf/common/status/webservice/StatusService.java
@@ -55,7 +55,7 @@ public class StatusService implements InitializingBean
 			return Response.status(Status.UNAUTHORIZED).build();
 		}
 
-		try (Connection connection = dataSource.getConnection())
+		try (Connection _ = dataSource.getConnection())
 		{
 			return Response.ok().build();
 		}

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperImpl.java
@@ -322,7 +322,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 							.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> requesterFrom(coding, c -> true, i -> true, c -> true).stream());
+					.flatMap(coding -> requesterFrom(coding, _ -> true, _ -> true, _ -> true).stream());
 	}
 
 	@Override
@@ -340,7 +340,7 @@ public class ProcessAuthorizationHelperImpl implements ProcessAuthorizationHelpe
 							.equals(e.getUrl()))
 					.filter(Extension::hasValue).filter(e -> e.getValue() instanceof Coding)
 					.map(e -> (Coding) e.getValue())
-					.flatMap(coding -> recipientFrom(coding, i -> true, c -> true).stream());
+					.flatMap(coding -> recipientFrom(coding, _ -> true, _ -> true).stream());
 	}
 
 	private Optional<Extension> getAuthorizationExtension(ActivityDefinition activityDefinition, String processUrl,

--- a/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-auth/src/main/java/dev/dsf/fhir/authorization/read/ReadAccessHelperImpl.java
@@ -284,7 +284,7 @@ public class ReadAccessHelperImpl implements ReadAccessHelper
 	@Override
 	public boolean isValid(Resource resource)
 	{
-		return isValid(resource, organizationIdentifier -> true, role -> true);
+		return isValid(resource, _ -> true, _ -> true);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-auth/src/test/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperTest.java
+++ b/dsf-fhir/dsf-fhir-auth/src/test/java/dev/dsf/fhir/authorization/process/ProcessAuthorizationHelperTest.java
@@ -69,7 +69,7 @@ public class ProcessAuthorizationHelperTest
 		pa2.addExtension("recipient",
 				new Coding("http://dsf.dev/fhir/CodeSystem/process-authorization", "LOCAL_ALL", null));
 
-		assertFalse(helper.isValid(ad, p -> true, c -> true, o -> true, c -> true));
+		assertFalse(helper.isValid(ad, _ -> true, _ -> true, _ -> true, _ -> true));
 	}
 
 	@Test
@@ -80,7 +80,7 @@ public class ProcessAuthorizationHelperTest
 		{
 			var ad = FhirContext.forR4().newXmlParser().parseResource(ActivityDefinition.class, in);
 
-			assertTrue(helper.isValid(ad, p -> true, c -> true, o -> true, c -> true));
+			assertTrue(helper.isValid(ad, _ -> true, _ -> true, _ -> true, _ -> true));
 		}
 	}
 
@@ -93,7 +93,7 @@ public class ProcessAuthorizationHelperTest
 		{
 			var ad = FhirContext.forR4().newXmlParser().parseResource(ActivityDefinition.class, in);
 
-			assertTrue(helper.isValid(ad, p -> true, c -> true, o -> true, c -> true));
+			assertTrue(helper.isValid(ad, _ -> true, _ -> true, _ -> true, _ -> true));
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-auth/src/test/java/dev/dsf/fhir/authorization/read/ReadAccessHelperTest.java
+++ b/dsf-fhir/dsf-fhir-auth/src/test/java/dev/dsf/fhir/authorization/read/ReadAccessHelperTest.java
@@ -52,7 +52,7 @@ public class ReadAccessHelperTest
 			var r = FhirContext.forR4().newXmlParser().parseResource(CodeSystem.class, in);
 
 			assertTrue(helper.isValid(r));
-			assertTrue(helper.isValid(r, org -> false, role -> false));
+			assertTrue(helper.isValid(r, _ -> false, _ -> false));
 
 			assertTrue(helper.hasLocal(r));
 			assertFalse(helper.hasAll(r));
@@ -102,7 +102,7 @@ public class ReadAccessHelperTest
 			var r = FhirContext.forR4().newXmlParser().parseResource(CodeSystem.class, in);
 
 			assertTrue(helper.isValid(r));
-			assertTrue(helper.isValid(r, org -> organizationIdentifier.equals(org.getValue()), role -> false));
+			assertTrue(helper.isValid(r, org -> organizationIdentifier.equals(org.getValue()), _ -> false));
 
 			assertTrue(helper.hasLocal(r));
 			assertTrue(helper.hasOrganization(r, organizationIdentifier));
@@ -202,7 +202,7 @@ public class ReadAccessHelperTest
 			var r = FhirContext.forR4().newXmlParser().parseResource(CodeSystem.class, in);
 
 			assertTrue(helper.isValid(r));
-			assertTrue(helper.isValid(r, org -> false, role -> false));
+			assertTrue(helper.isValid(r, _ -> false, _ -> false));
 			assertTrue(helper.hasAll(r));
 		}
 	}
@@ -235,7 +235,7 @@ public class ReadAccessHelperTest
 		helper.addLocal(r);
 		helper.addOrganization(r, organizationIdentifier);
 
-		assertTrue(helper.isValid(r, org -> organizationIdentifier.equals(org.getValue()), role -> true));
+		assertTrue(helper.isValid(r, org -> organizationIdentifier.equals(org.getValue()), _ -> true));
 	}
 
 	@Test

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/adapter/FhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/dev/dsf/fhir/adapter/FhirAdapter.java
@@ -158,7 +158,7 @@ public class FhirAdapter implements MessageBodyReader<BaseResource>, MessageBody
 	{
 		Map<String, DeferredBase64BinaryType> dataByPlaceholder = getDeferredBase64BinaryTypes(bundle)
 				.collect(Collectors.toMap(DeferredBase64BinaryType::createPlaceHolderAndSetAsUserData,
-						Function.identity(), (a, b) -> a, LinkedHashMap::new));
+						Function.identity(), (a, _) -> a, LinkedHashMap::new));
 
 		String s = getParser(mediaType).encodeResourceToString(bundle);
 

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN chown root:java ./ && \
 	chmod 1775 ./log
 
 
-FROM azul/zulu-openjdk:21-jre-headless
+FROM azul/zulu-openjdk:25-jre-headless
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -219,12 +219,6 @@
 			<artifactId>log4j-slf4j2-impl</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- For async logging with log4j2 -->
-		<dependency>
-			<groupId>com.lmax</groupId>
-			<artifactId>disruptor</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceTask.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceTask.java
@@ -221,17 +221,17 @@ public class ResourceTask extends AbstractResource<Task>
 	{
 		return switch (typedValue)
 		{
-			case BooleanType b -> "boolean";
-			case DecimalType d -> "number";
-			case IntegerType i -> "number";
-			case DateType d -> "date";
-			case DateTimeType dt -> "datetime-local";
-			case TimeType t -> "time";
-			case InstantType i -> "datetime-local";
-			case StringType s -> "text";
-			case UriType u -> "url";
-			case Coding c -> "coding";
-			case Identifier i -> "identifier";
+			case BooleanType _ -> "boolean";
+			case DecimalType _ -> "number";
+			case IntegerType _ -> "number";
+			case DateType _ -> "date";
+			case DateTimeType _ -> "datetime-local";
+			case TimeType _ -> "time";
+			case InstantType _ -> "datetime-local";
+			case StringType _ -> "text";
+			case UriType _ -> "url";
+			case Coding _ -> "coding";
+			case Identifier _ -> "identifier";
 			case Reference r when r.hasReferenceElement() -> "url";
 			case Reference r when r.hasIdentifier() -> "identifier";
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafTemplateServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafTemplateServiceImpl.java
@@ -163,7 +163,7 @@ public class ThymeleafTemplateServiceImpl implements ThymeleafTemplateService, I
 		{
 			Optional<String> lastSegment = uriInfo.getPathSegments().stream().filter(Objects::nonNull)
 					.map(PathSegment::getPath).filter(Objects::nonNull).filter(s -> !s.isBlank())
-					.reduce((first, second) -> second);
+					.reduce((_, second) -> second);
 
 			return lastSegment.map(g::isResourceSupported).orElse(false);
 		}).findFirst();

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/ActivityDefinitionAuthorizationRule.java
@@ -68,8 +68,7 @@ public class ActivityDefinitionAuthorizationRule
 		List<String> errors = new ArrayList<>();
 
 		// TODO check existence of profiles, codes and identifier against DB
-		if (!processAuthorizationHelper.isValid(newResource, taskProfile -> true, practitionerRole -> true,
-				organizationIdentifier -> true, organizationRole -> true))
+		if (!processAuthorizationHelper.isValid(newResource, _ -> true, _ -> true, _ -> true, _ -> true))
 		{
 			errors.add("ActivityDefinition.extension with url "
 					+ ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/authorization/StructureDefinitionAuthorizationRule.java
@@ -96,7 +96,7 @@ public class StructureDefinitionAuthorizationRule
 		{
 			return getDao()
 					.readByUrlAndVersionWithTransaction(connection, newResource.getUrl(), newResource.getVersion())
-					.map(s -> true).orElse(false);
+					.isPresent();
 		}
 		catch (SQLException e)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CommandFactoryImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/command/CommandFactoryImpl.java
@@ -279,7 +279,7 @@ public class CommandFactoryImpl implements InitializingBean, CommandFactory
 		Optional<? extends ResourceDao<R>> dao = (Optional<? extends ResourceDao<R>>) daoProvider
 				.getDao(resource.getClass());
 
-		if (referenceExtractor.getReferences(resource).anyMatch(r -> true)) // at least one entry
+		if (referenceExtractor.getReferences(resource).anyMatch(_ -> true)) // at least one entry
 		{
 			return dao.map(d -> Stream.of(cmd,
 					new CheckReferencesCommand<R, ResourceDao<R>>(index, identity, returnType, bundle, entry,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -260,10 +260,10 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 						return read;
 				}, status -> audit.info("Read of {}/{}/_history/{} for identity '{}' successful, status: {} {}",
 						resourceTypeName, entityId, entityVersion, getCurrentIdentity().getName(),
-						read.getStatusInfo().getStatusCode(), read.getStatusInfo().getReasonPhrase()),
+						status.getStatusCode(), status.getReasonPhrase()),
 						status -> audit.info("Read of {}/{}/_history/{} for identity '{}' failed, status: {} {}",
 								resourceTypeName, entityId, entityVersion, getCurrentIdentity().getName(),
-								read.getStatusInfo().getStatusCode(), read.getStatusInfo().getReasonPhrase()));
+								status.getStatusCode(), status.getReasonPhrase()));
 			}
 		}
 		else if (read.hasEntity() && read.getEntity() instanceof OperationOutcome)

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -213,7 +213,7 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 
 		expectNotAcceptable(() ->
 		{
-			try (InputStream in = getWebserviceClient().readBinary(created.getIdElement().getIdPart(),
+			try (InputStream _ = getWebserviceClient().readBinary(created.getIdElement().getIdPart(),
 					MediaType.APPLICATION_XML_TYPE))
 			{
 			}

--- a/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/ParallelCreateIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/dev/dsf/fhir/integration/ParallelCreateIntegrationTest.java
@@ -516,7 +516,7 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 				List.of("COS"));
 
 		return createBundle(bundleType, a1, a2,
-				(a, r) -> r.setIfNoneExist("primary-organization:identifier=http://dsf.dev/sid/organization-identifier|"
+				(_, r) -> r.setIfNoneExist("primary-organization:identifier=http://dsf.dev/sid/organization-identifier|"
 						+ ORGANIZATION_IDENTIFIER_VALUE_PARENT
 						+ "&participating-organization:identifier=http://dsf.dev/sid/organization-identifier|"
 						+ ORGANIZATION_IDENTIFIER_VALUE_MEMBER));
@@ -558,7 +558,7 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 				List.of("DIC", "COS"));
 
 		return createBundle(bundleType, oA1, oA2,
-				(a, r) -> r.setIfNoneExist("primary-organization:identifier=http://dsf.dev/sid/organization-identifier|"
+				(_, r) -> r.setIfNoneExist("primary-organization:identifier=http://dsf.dev/sid/organization-identifier|"
 						+ ORGANIZATION_IDENTIFIER_VALUE_PARENT
 						+ "&participating-organization:identifier=http://dsf.dev/sid/organization-identifier|"
 						+ ORGANIZATION_IDENTIFIER_VALUE_MEMBER));
@@ -652,7 +652,7 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 		activityDefinitionDao.create(createActivityDefinition());
 
 		Bundle bundle = createBundle(BundleType.TRANSACTION, createTask(),
-				(t, r) -> r.setIfNoneExist("identifier=" + NAMING_SYSTEM_TASK_IDENTIFIER + "|" + TASK_IDENTIFIER_VALUE),
+				(_, r) -> r.setIfNoneExist("identifier=" + NAMING_SYSTEM_TASK_IDENTIFIER + "|" + TASK_IDENTIFIER_VALUE),
 				2);
 
 		testCreateDuplicatesViaBundleWithIfNoneExists(bundle, BundleType.TRANSACTIONRESPONSE);
@@ -666,7 +666,7 @@ public class ParallelCreateIntegrationTest extends AbstractIntegrationTest
 		activityDefinitionDao.create(createActivityDefinition());
 
 		Bundle bundle = createBundle(BundleType.BATCH, createTask(),
-				(t, r) -> r.setIfNoneExist("identifier=" + NAMING_SYSTEM_TASK_IDENTIFIER + "|" + TASK_IDENTIFIER_VALUE),
+				(_, r) -> r.setIfNoneExist("identifier=" + NAMING_SYSTEM_TASK_IDENTIFIER + "|" + TASK_IDENTIFIER_VALUE),
 				2);
 
 		testCreateDuplicatesViaBundleWithIfNoneExists(bundle, BundleType.BATCHRESPONSE);

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/log4j2-maven-surefire-config.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/log4j2-maven-surefire-config.xml
@@ -7,12 +7,12 @@
 	</Appenders>
 
 	<Loggers>
-		<AsyncLogger name="dev.dsf" level="INFO"/>
-		<AsyncLogger name="org.eclipse.jetty" level="INFO"/>
+		<Logger name="dev.dsf" level="INFO"/>
+		<Logger name="org.eclipse.jetty" level="INFO"/>
 		<Logger name="ca.uhn.fhir.parser.LenientErrorHandler" level="ERROR"/>
 
-		<AsyncRoot level="WARN">
+		<Root level="WARN">
 			<AppenderRef ref="CONSOLE"/>
-		</AsyncRoot>
+		</Root>
 	</Loggers>
 </Configuration>

--- a/dsf-maven/dsf-maven-plugin/pom.xml
+++ b/dsf-maven/dsf-maven-plugin/pom.xml
@@ -121,6 +121,14 @@
 						</goals>
 					</execution>
 				</executions>
+				<!-- TODO remove ASM dependency version override when maven-plugin-plugin supports Java 25 -->
+				<dependencies>
+					<dependency>
+						<groupId>org.ow2.asm</groupId>
+						<artifactId>asm</artifactId>
+						<version>9.8</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
-		<maven.compiler.release>21</maven.compiler.release>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
+		<maven.compiler.release>25</maven.compiler.release>
 
 		<main.basedir>${project.basedir}</main.basedir>
 
@@ -118,12 +118,6 @@
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-layout-template-json</artifactId>
 				<version>${log4j.version}</version>
-			</dependency>
-			<!-- async logging -->
-			<dependency>
-				<groupId>com.lmax</groupId>
-				<artifactId>disruptor</artifactId>
-				<version>3.4.4</version>
 			</dependency>
 
 			<dependency>
@@ -590,6 +584,7 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>3.15.1</version>
+					<!-- TODO remove ASM dependency version override in dsf-maven-plugin when maven-plugin-plugin supports Java 25 -->
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -981,6 +976,8 @@
 				<configuration>
 					<groups>java.,javax.,org.,com.</groups>
 					<staticGroups>java,*</staticGroups>
+					<!-- TODO remove config option when impsort-maven-plugin support Java 25 -->
+					<ignoreParseErrorsBelowImports>true</ignoreParseErrorsBelowImports>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Upgrade Java 21 to Java 25

* maven-plugin-plugin workaround, included ASM dependency does not support Java 25, manually configured dependency to use ASM version 9.8
* impsort-maven-plugin workaround, included com.github.javaparser:javaparser-core dependency does not support Java
25, set ignoreParseErrorsBelowImports option to true
* removed async logging during test execution, no performance advantage and removes deprecated use of sun.misc.Unsafe warning during build
* Upgrade from azul/zulu-openjdk:21-jre-headless to azul/zulu-openjdk:25-jre-headless
* Hats off to the Azul team for making Java 25 docker images available just 24 hours after the official release of Java 25
* Changed unused variables to unnamed variables (underscore)
* Some code cleanup
* Refactored code to make it past impsort-maven-plugin build error
* Java 25 upgrade in GitHub actions

closes #202