### PR TITLE
Issue/352 non root proxy containers

### DIFF
--- a/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
@@ -1,11 +1,10 @@
-FROM debian:buster-slim AS builder
-RUN adduser --system --no-create-home --group --uid 2202 java
+FROM debian:trixie-slim AS builder
 WORKDIR /opt/bpe
-COPY --chown=root:java ./ ./
-RUN chown root:java ./ && \
+COPY --chown=root:2202 ./ ./
+RUN chown root:2202 ./ && \
     chmod 750 ./ ./ca ./conf ./lib ./lib_external ./process ./ui ./dsf_bpe_start.sh ./healthcheck.sh && \
-	chmod 440 ./ca/client_cert_ca_chains.pem ./ca/server_cert_root_cas.pem ./conf/log4j2.xml ./dsf_bpe.jar ./lib/*.jar && \
-	chmod 1775 ./log
+    chmod 440 ./ca/client_cert_ca_chains.pem ./ca/server_cert_root_cas.pem ./conf/log4j2.xml ./dsf_bpe.jar ./lib/*.jar && \
+    chmod 1775 ./log
 
 
 FROM azul/zulu-openjdk:17-jre-headless
@@ -15,8 +14,10 @@ LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 
 EXPOSE 8080
 
-RUN adduser --system --no-create-home --group --uid 2202 java && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt update && apt dist-upgrade -y && apt install curl -y
+RUN adduser --system --no-create-home --group --uid 2202 java
 
 WORKDIR /opt/bpe
 COPY --from=builder /opt/bpe ./

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/dsf_bpe_start.sh
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/dsf_bpe_start.sh
@@ -3,11 +3,11 @@
 echo "Executing DSF BPE with"
 java --version
 
-trap 'kill -TERM $PID' TERM INT
-java $EXTRA_JVM_ARGS -Djdk.tls.acknowledgeCloseNotify=true -cp lib/*:lib_external/*:dsf_bpe.jar dev.dsf.bpe.BpeJettyServer &
+trap 'kill -TERM $PID' TERM
+java $EXTRA_JVM_ARGS -Djdk.tls.acknowledgeCloseNotify=true -cp lib/*:lib_external/*:dsf_bpe.jar dev.dsf.bpe.BpeJettyServer
 PID=$!
 wait $PID
-trap - TERM INT
+trap - TERM
 wait $PID
 
 JAVA_EXIT=$?

--- a/dsf-docker/bpe_proxy/.dockerignore
+++ b/dsf-docker/bpe_proxy/.dockerignore
@@ -1,3 +1,4 @@
 ca/README.md
 .dockerignore
 Dockerfile
+README.md

--- a/dsf-docker/bpe_proxy/Dockerfile
+++ b/dsf-docker/bpe_proxy/Dockerfile
@@ -3,13 +3,18 @@ LABEL org.opencontainers.image.source=https://github.com/datasharingframework/ds
 LABEL org.opencontainers.image.description="DSF BPE Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 
+RUN --mount=type=cache,target=/etc/apk/cache \
+    apk update && apk upgrade && apk -q add libcap && \
+    setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd && \
+    addgroup -g 4202 apache && adduser -S -H -u 4202 -G apache apache
+
 WORKDIR /usr/local/apache2
 COPY ./ ./
-RUN chown daemon:daemon ./ca/ && \
-	chmod 750 ./ca/ ./start.sh && \
-	chmod 440 ./ca/client_cert_ca_chains.pem ./ca/client_cert_issuing_cas.pem && \
-    chmod 644 ./conf/httpd.conf ./conf/extra/host.conf ./conf/extra/host-ssl.conf ./conf/extra/httpd-ssl.conf && \
-    apk update && apk upgrade && rm -vrf /var/cache/apk/*
+
+RUN chmod 750 ./ca/ ./start.sh && \
+    chmod 440 ./ca/client_cert_ca_chains.pem ./ca/client_cert_issuing_cas.pem && \
+    chmod 640 ./conf/httpd.conf ./conf/extra/host.conf ./conf/extra/host-ssl.conf ./conf/extra/httpd-ssl.conf && \
+    chown -hR apache:apache /usr/local/apache2/
 
 # setting non existing default values, see host-ssl.conf IfFile tests
 ENV SSL_CERTIFICATE_CHAIN_FILE="/does/not/exist"
@@ -44,4 +49,6 @@ ENV PROXY_PASS_CONNECTION_TIMEOUT_WS=30
 # server context path: / character at start, no / character at end
 ENV SERVER_CONTEXT_PATH="/bpe"
 
+USER apache
 ENTRYPOINT [ "sh", "./start.sh" ]
+HEALTHCHECK --interval=10s --timeout=15s --start-period=10s --retries=5 CMD nc -zv localhost 80 && nc -zv localhost 443 || exit 1

--- a/dsf-docker/bpe_proxy/start.sh
+++ b/dsf-docker/bpe_proxy/start.sh
@@ -1,39 +1,39 @@
 #!/bin/sh
 
 is_comma_separated_list() {
-  echo "$1" | grep -qE "^(\'[^\']+\')(,\s*\'[^\']+\')*$"
+	echo "$1" | grep -qE "^(\'[^\']+\')(,\s*\'[^\']+\')*$"
 }
 
 if [ -z "$SSL_EXPECTED_CLIENT_S_DN_C_VALUES" ]; then
-  echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES environment variable not set"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES environment variable not set"
+	exit 1
 fi
 if ! is_comma_separated_list "$SSL_EXPECTED_CLIENT_S_DN_C_VALUES"; then
-  echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES must be a comma-separated list of strings in single quotation marks"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES must be a comma-separated list of strings in single quotation marks"
+	exit 1
 fi
 if [ -z "$SSL_EXPECTED_CLIENT_I_DN_CN_VALUES" ]; then
-  echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES environment variable not set"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES environment variable not set"
+	exit 1
 fi
 if ! is_comma_separated_list "$SSL_EXPECTED_CLIENT_I_DN_CN_VALUES"; then
-  echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES must be a comma-separated list of strings in single quotation marks"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES must be a comma-separated list of strings in single quotation marks"
+	exit 1
 fi
 
 if [ "$SSL_VERIFY_CLIENT" != "optional" ] && [ "$SSL_VERIFY_CLIENT" != "require" ]; then
-    echo "Error: SSL_VERIFY_CLIENT must be set to either 'optional' or 'require'"
-    exit 1
+	echo "Error: SSL_VERIFY_CLIENT must be set to either 'optional' or 'require'"
+	exit 1
 fi
 
 out="./conf/extra/certificate_require_expr.conf"
 
-if [ -e "$out" ]; then
-  echo "Info: Not creating $out, file exists"
-elif [ "$SSL_VERIFY_CLIENT" == "optional" ]; then
-  echo "Require expr \"%{SSL_CLIENT_VERIFY} == 'NONE' || %{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
-elif [ "$SSL_VERIFY_CLIENT" == "require" ]; then
-  echo "Require expr \"%{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
+if [ ! -f "$out" ]; then
+	if [ "$SSL_VERIFY_CLIENT" == "optional" ]; then
+		echo "Require expr \"%{SSL_CLIENT_VERIFY} == 'NONE' || %{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
+	elif [ "$SSL_VERIFY_CLIENT" == "require" ]; then
+		echo "Require expr \"%{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
+	fi
 fi
 
-httpd-foreground
+exec httpd-foreground

--- a/dsf-docker/fhir_proxy/.dockerignore
+++ b/dsf-docker/fhir_proxy/.dockerignore
@@ -1,3 +1,4 @@
 ca/README.md
 .dockerignore
 Dockerfile
+README.md

--- a/dsf-docker/fhir_proxy/Dockerfile
+++ b/dsf-docker/fhir_proxy/Dockerfile
@@ -3,13 +3,18 @@ LABEL org.opencontainers.image.source=https://github.com/datasharingframework/ds
 LABEL org.opencontainers.image.description="DSF FHIR Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 
+RUN --mount=type=cache,target=/etc/apk/cache \
+    apk update && apk upgrade && apk -q add libcap && \
+    setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd && \
+    addgroup -g 4101 apache && adduser -S -H -u 4101 -G apache apache
+
 WORKDIR /usr/local/apache2
 COPY ./ ./
-RUN chown daemon:daemon ./ca/ && \
-	chmod 750 ./ca/ ./start.sh && \
-	chmod 440 ./ca/client_cert_ca_chains.pem ./ca/client_cert_issuing_cas.pem && \
-    chmod 644 ./conf/httpd.conf ./conf/extra/host.conf ./conf/extra/host-ssl.conf ./conf/extra/httpd-ssl.conf && \
-    apk update && apk upgrade && rm -vrf /var/cache/apk/*
+
+RUN chmod 750 ./ca/ ./start.sh && \
+    chmod 440 ./ca/client_cert_ca_chains.pem ./ca/client_cert_issuing_cas.pem && \
+    chmod 640 ./conf/httpd.conf ./conf/extra/host.conf ./conf/extra/host-ssl.conf ./conf/extra/httpd-ssl.conf && \
+    chown -hR apache:apache /usr/local/apache2/
 
 # setting non existing default values, see host-ssl.conf IfFile tests
 ENV SSL_CERTIFICATE_CHAIN_FILE="/does/not/exist"
@@ -44,4 +49,6 @@ ENV PROXY_PASS_CONNECTION_TIMEOUT_WS=30
 # server context path: / character at start, no / character at end
 ENV SERVER_CONTEXT_PATH="/fhir"
 
+USER apache
 ENTRYPOINT [ "sh", "./start.sh" ]
+HEALTHCHECK --interval=10s --timeout=15s --start-period=10s --retries=5 CMD nc -zv localhost 80 && nc -zv localhost 443 || exit 1

--- a/dsf-docker/fhir_proxy/start.sh
+++ b/dsf-docker/fhir_proxy/start.sh
@@ -1,39 +1,39 @@
 #!/bin/sh
 
 is_comma_separated_list() {
-  echo "$1" | grep -qE "^(\'[^\']+\')(,\s*\'[^\']+\')*$"
+	echo "$1" | grep -qE "^(\'[^\']+\')(,\s*\'[^\']+\')*$"
 }
 
 if [ -z "$SSL_EXPECTED_CLIENT_S_DN_C_VALUES" ]; then
-  echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES environment variable not set"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES environment variable not set"
+	exit 1
 fi
 if ! is_comma_separated_list "$SSL_EXPECTED_CLIENT_S_DN_C_VALUES"; then
-  echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES must be a comma-separated list of strings in single quotation marks"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_S_DN_C_VALUES must be a comma-separated list of strings in single quotation marks"
+	exit 1
 fi
 if [ -z "$SSL_EXPECTED_CLIENT_I_DN_CN_VALUES" ]; then
-  echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES environment variable not set"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES environment variable not set"
+	exit 1
 fi
 if ! is_comma_separated_list "$SSL_EXPECTED_CLIENT_I_DN_CN_VALUES"; then
-  echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES must be a comma-separated list of strings in single quotation marks"
-  exit 1
+	echo "Error: SSL_EXPECTED_CLIENT_I_DN_CN_VALUES must be a comma-separated list of strings in single quotation marks"
+	exit 1
 fi
 
 if [ "$SSL_VERIFY_CLIENT" != "optional" ] && [ "$SSL_VERIFY_CLIENT" != "require" ]; then
-    echo "Error: SSL_VERIFY_CLIENT must be set to either 'optional' or 'require'"
-    exit 1
+	echo "Error: SSL_VERIFY_CLIENT must be set to either 'optional' or 'require'"
+	exit 1
 fi
 
 out="./conf/extra/certificate_require_expr.conf"
 
-if [ -e "$out" ]; then
-  echo "Info: Not creating $out, file exists"
-elif [ "$SSL_VERIFY_CLIENT" == "optional" ]; then
-  echo "Require expr \"%{SSL_CLIENT_VERIFY} == 'NONE' || %{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
-elif [ "$SSL_VERIFY_CLIENT" == "require" ]; then
-  echo "Require expr \"%{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
+if [ ! -f "$out" ]; then
+	if [ "$SSL_VERIFY_CLIENT" == "optional" ]; then
+		echo "Require expr \"%{SSL_CLIENT_VERIFY} == 'NONE' || %{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
+	elif [ "$SSL_VERIFY_CLIENT" == "require" ]; then
+		echo "Require expr \"%{SSL_CLIENT_S_DN_C} in { $SSL_EXPECTED_CLIENT_S_DN_C_VALUES } && %{SSL_CLIENT_I_DN_CN} in { $SSL_EXPECTED_CLIENT_I_DN_CN_VALUES }\"" > "$out"
+	fi
 fi
 
-httpd-foreground
+exec httpd-foreground

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -1,11 +1,10 @@
-FROM debian:buster-slim AS builder
-RUN adduser --system --no-create-home --group --uid 2101 java
+FROM debian:trixie-slim AS builder
 WORKDIR /opt/fhir
-COPY --chown=root:java ./ ./
-RUN chown root:java ./ && \
+COPY --chown=root:2101 ./ ./
+RUN chown root:2101 ./ && \
     chmod 750 ./ ./ca ./conf ./lib ./ui ./dsf_fhir_start.sh ./healthcheck.sh && \
-	chmod 440 ./ca/client_cert_ca_chains.pem ./ca/server_cert_root_cas.pem ./conf/log4j2.xml ./conf/bundle.xml ./dsf_fhir.jar ./lib/*.jar && \
-	chmod 1775 ./log
+    chmod 440 ./ca/client_cert_ca_chains.pem ./ca/server_cert_root_cas.pem ./conf/log4j2.xml ./conf/bundle.xml ./dsf_fhir.jar ./lib/*.jar && \
+    chmod 1775 ./log
 
 
 FROM azul/zulu-openjdk:17-jre-headless
@@ -15,8 +14,10 @@ LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 
 EXPOSE 8080
 
-RUN adduser --system --no-create-home --group --uid 2101 java && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt update && apt dist-upgrade -y && apt install curl -y
+RUN adduser --system --no-create-home --group --uid 2101 java
 
 WORKDIR /opt/fhir
 COPY --from=builder /opt/fhir ./

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/dsf_fhir_start.sh
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/dsf_fhir_start.sh
@@ -3,11 +3,11 @@
 echo "Executing DSF FHIR with"
 java --version
 
-trap 'kill -TERM $PID' TERM INT
+trap 'kill -TERM $PID' TERM
 java $EXTRA_JVM_ARGS -Djdk.tls.acknowledgeCloseNotify=true -cp lib/*:dsf_fhir.jar dev.dsf.fhir.FhirJettyServer &
 PID=$!
 wait $PID
-trap - TERM INT
+trap - TERM
 wait $PID
 
 JAVA_EXIT=$?

--- a/dsf-tools/dsf-tools-db-migration/src/main/java/dev/dsf/tools/db/DbMigrator.java
+++ b/dsf-tools/dsf-tools-db-migration/src/main/java/dev/dsf/tools/db/DbMigrator.java
@@ -220,7 +220,7 @@ public final class DbMigrator
 				logger.warn("PSQLException ({}): trying again in 5s", p.getServerErrorMessage().getMessage());
 				try
 				{
-					Thread.sleep(10_000);
+					Thread.sleep(5_000);
 				}
 				catch (InterruptedException e1)
 				{


### PR DESCRIPTION
* fhir/bpe build image upgrade, apt cache mount, removed not needed SIGINT signal trap
* fhir_proxy/bpe_proxy images: apache httpd no runs a non-root user
* fhir_proxy image uid/gid 4101
* bpe_proxy image uid/gid 4202
* httpd now runs as PID 1 (exec httpd-foreground)
* Improved DbMigrator error handling, added retries for postgresql startup errors: `the database system is starting up` and			`the database system is not yet accepting connections`

closes #352

Changes should be ported to DSF 2.