### PR TITLE
Issue/373 output parameters updates in progress tasks

### DIFF
--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/plugin/ProcessPluginImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/plugin/ProcessPluginImpl.java
@@ -112,7 +112,8 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<UserTaskListener> i
 
 		this.processPluginDefinition = processPluginDefinition;
 
-		variablesFactory = delegateExecution -> new VariablesImpl(delegateExecution, getObjectMapper());
+		variablesFactory = delegateExecution -> new VariablesImpl(delegateExecution, getObjectMapper(),
+				getProcessPluginApi().getDsfClientProvider().getLocalDsfClient());
 		pluginMdc = new PluginMdcImpl(processPluginApiVersion, processPluginDefinition.getName(),
 				processPluginDefinition.getVersion(), jarFile.toString(), serverBaseUrl, variablesFactory);
 	}

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/StartTaskUpdaterImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/StartTaskUpdaterImpl.java
@@ -1,0 +1,117 @@
+package dev.dsf.bpe.v2.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.Task.TaskOutputComponent;
+import org.hl7.fhir.r4.model.Type;
+
+import dev.dsf.bpe.v2.client.dsf.DsfClient;
+
+public class StartTaskUpdaterImpl implements StartTaskUpdater
+{
+	private final DsfClient client;
+
+	private final Supplier<Task> getStartTask;
+	private final Consumer<Task> updateTask;
+
+	public StartTaskUpdaterImpl(DsfClient client, Supplier<Task> getStartTask, Consumer<Task> updateTask)
+	{
+		this.client = Objects.requireNonNull(client, "client");
+
+		this.getStartTask = Objects.requireNonNull(getStartTask, "getStartTask");
+		this.updateTask = Objects.requireNonNull(updateTask, "updateTask");
+	}
+
+	@Override
+	public void addOutput(Coding outputType, Type outputValue)
+	{
+		Task task = getStartTask.get();
+		task.addOutput().setValue(outputValue).getType().addCoding(outputType);
+
+		Task updated = client.update(task);
+		updateTask.accept(updated);
+	}
+
+	@Override
+	public Optional<TaskOutputComponent> getOutput(Coding outputType)
+	{
+		checkOutputType(outputType);
+
+		Task task = getStartTask.get();
+		return doGetOutput(task, outputType);
+	}
+
+	private Optional<TaskOutputComponent> doGetOutput(Task task, Coding outputType)
+	{
+		return task.getOutput().stream().filter(matchesSystemAndCodeOptionallyVersion(outputType)).findFirst();
+	}
+
+	private Predicate<TaskOutputComponent> matchesSystemAndCodeOptionallyVersion(Coding outputType)
+	{
+		return o -> o.getType().getCoding().stream()
+				.anyMatch(c -> Objects.equals(c.getSystem(), outputType.getSystem())
+						&& Objects.equals(c.getCode(), outputType.getCode()) && outputType.hasVersion()
+								? Objects.equals(c.getVersion(), outputType.getVersion())
+								: true);
+	}
+
+	@Override
+	public void modifyOutput(Coding outputType, Type outputValue)
+	{
+		checkOutputType(outputType);
+
+		Task task = getStartTask.get();
+
+		doGetOutput(task, outputType)
+				.orElseThrow(() -> new IllegalArgumentException("Output for type " + outputType.getSystem() + "|"
+						+ outputType.getCode()
+						+ (outputType.hasVersion() ? " (version: " + outputType.getVersion() + ") not found" : "")))
+				.setValue(outputValue);
+
+		Task updated = client.update(task);
+		updateTask.accept(updated);
+	}
+
+	@Override
+	public void removeOutput(Coding outputType)
+	{
+		checkOutputType(outputType);
+
+		Task task = getStartTask.get();
+
+		List<TaskOutputComponent> filtered = task.getOutput().stream()
+				.filter(matchesSystemAndCodeOptionallyVersion(outputType).negate()).toList();
+
+		if (task.getOutput().size() == filtered.size())
+			throw new IllegalArgumentException("Output for type " + outputType.getSystem() + "|" + outputType.getCode()
+					+ (outputType.hasVersion() ? " (version: " + outputType.getVersion() + ") not found" : ""));
+
+		task.setOutput(filtered);
+
+		Task updated = client.update(task);
+		updateTask.accept(updated);
+	}
+
+	private void checkOutputType(Coding outputType)
+	{
+		Objects.requireNonNull(outputType, "outputType");
+
+		Objects.requireNonNull(outputType.getSystem(), "outputType.system");
+		Objects.requireNonNull(outputType.getCode(), "outputType.code");
+		Objects.requireNonNull(outputType.getVersion(), "outputType.version");
+
+		if (outputType.getSystem().isBlank())
+			throw new IllegalArgumentException("outputType.system is blank");
+		if (outputType.getCode().isBlank())
+			throw new IllegalArgumentException("outputType.code is blank");
+		if (outputType.getVersion().isBlank())
+			throw new IllegalArgumentException("outputType.version is blank");
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/TaskHelperImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/TaskHelperImpl.java
@@ -108,20 +108,8 @@ public class TaskHelperImpl implements TaskHelper
 	}
 
 	@Override
-	public ParameterComponent createInput(Type value, String system, String code)
-	{
-		return createInput(value, new Coding(system, code, null));
-	}
-
-	@Override
 	public TaskOutputComponent createOutput(Type value, Coding coding)
 	{
 		return new TaskOutputComponent(new CodeableConcept(coding), value);
-	}
-
-	@Override
-	public TaskOutputComponent createOutput(Type value, String system, String code)
-	{
-		return createOutput(value, new Coding(system, code, null));
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/spring/ApiServiceConfig.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/spring/ApiServiceConfig.java
@@ -254,7 +254,7 @@ public class ApiServiceConfig
 	@Bean
 	public Function<DelegateExecution, ListenerVariables> listenerVariablesFactory()
 	{
-		return execution -> new VariablesImpl(execution, objectMapper());
+		return execution -> new VariablesImpl(execution, objectMapper(), dsfClientProvider().getLocalDsfClient());
 	}
 
 	@Bean

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/VariablesImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/VariablesImpl.java
@@ -23,8 +23,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.dsf.bpe.api.Constants;
+import dev.dsf.bpe.v2.client.dsf.DsfClient;
 import dev.dsf.bpe.v2.constants.BpmnExecutionVariables;
 import dev.dsf.bpe.v2.listener.ListenerVariables;
+import dev.dsf.bpe.v2.service.StartTaskUpdater;
+import dev.dsf.bpe.v2.service.StartTaskUpdaterImpl;
 import dev.dsf.bpe.v2.variables.FhirResourceValues.FhirResourceValue;
 import dev.dsf.bpe.v2.variables.FhirResourcesListValues.FhirResourcesListValue;
 import dev.dsf.bpe.v2.variables.TargetValues.TargetValue;
@@ -69,16 +72,22 @@ public class VariablesImpl implements Variables, ListenerVariables
 	private final DelegateExecution execution;
 	private final ObjectMapper objectMapper;
 
+	private final StartTaskUpdater startTaskUpdater;
+
 	/**
 	 * @param execution
 	 *            not <code>null</code>
 	 * @param objectMapper
 	 *            not <code>null</code>
+	 * @param client
+	 *            not <code>null</code>
 	 */
-	public VariablesImpl(DelegateExecution execution, ObjectMapper objectMapper)
+	public VariablesImpl(DelegateExecution execution, ObjectMapper objectMapper, DsfClient client)
 	{
 		this.execution = Objects.requireNonNull(execution, "execution");
 		this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+
+		startTaskUpdater = new StartTaskUpdaterImpl(client, this::getStartTask, this::updateTask);
 	}
 
 	private JsonHolder toJsonHolder(Object json)
@@ -288,6 +297,12 @@ public class VariablesImpl implements Variables, ListenerVariables
 				execution.getParentActivityInstanceId(), execution.getParentId());
 
 		return getFhirResource(START_TASK);
+	}
+
+	@Override
+	public StartTaskUpdater getStartTaskUpdater()
+	{
+		return startTaskUpdater;
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/DefaultUserTaskListener.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/activity/DefaultUserTaskListener.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.Task;
 import org.hl7.fhir.r4.model.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,6 +89,10 @@ public class DefaultUserTaskListener implements UserTaskListener
 	private final Set<KeyAndValue> practitionerRoles = new HashSet<>();
 	private final Set<KeyAndValue> practitioners = new HashSet<>();
 
+	private String taskOutputSystem;
+	private String taskOutputCode;
+	private String taskOutputVersion;
+
 	/**
 	 * @param practitionerRole
 	 *            does nothing if <code>null</code> or blank
@@ -142,6 +147,48 @@ public class DefaultUserTaskListener implements UserTaskListener
 					.map(KeyAndValue.fromString(NamingSystems.PractitionerIdentifier.SID))
 					.forEach(this.practitioners::add);
 		}
+	}
+
+	/**
+	 * If {@link #taskOutputSystem}, {@link #taskOutputCode} and {@link #taskOutputVersion} are set with not blank
+	 * values, an output parameter is added to the start Task with a reference to the created
+	 * {@link QuestionnaireResponse} resource.
+	 *
+	 * @param taskOutputSystem
+	 * @deprecated only for field injection
+	 */
+	@Deprecated
+	public void setTaskOutputSystem(String taskOutputSystem)
+	{
+		this.taskOutputSystem = taskOutputSystem;
+	}
+
+	/**
+	 * If {@link #taskOutputSystem}, {@link #taskOutputCode} and {@link #taskOutputVersion} are set with not blank
+	 * values, an output parameter is added to the start Task with a reference to the created
+	 * {@link QuestionnaireResponse} resource.
+	 *
+	 * @param taskOutputCode
+	 * @deprecated only for field injection
+	 */
+	@Deprecated
+	public void setTaskOutputCode(String taskOutputCode)
+	{
+		this.taskOutputCode = taskOutputCode;
+	}
+
+	/**
+	 * If {@link #taskOutputSystem}, {@link #taskOutputCode} and {@link #taskOutputVersion} are set with not blank
+	 * values, an output parameter is added to the start Task with a reference to the created
+	 * {@link QuestionnaireResponse} resource.
+	 *
+	 * @param taskOutputVersion
+	 * @deprecated only for field injection
+	 */
+	@Deprecated
+	public void setTaskOutputVersion(String taskOutputVersion)
+	{
+		this.taskOutputVersion = taskOutputVersion;
 	}
 
 	@Override
@@ -286,7 +333,13 @@ public class DefaultUserTaskListener implements UserTaskListener
 
 	/**
 	 * <i>Override this method to execute code after the {@link QuestionnaireResponse} resource has been created on the
-	 * DSF FHIR server</i>
+	 * DSF FHIR server</i><br>
+	 * <br>
+	 * Default implementation will add an output parameter to the start {@link Task} with a reference to the created
+	 * {@link QuestionnaireResponse} resource if {@link #taskOutputSystem}, {@link #taskOutputCode} and
+	 * {@link #taskOutputVersion} are set with not blank values.<br>
+	 * <br>
+	 * Use field inject in BPMN to set value.
 	 *
 	 * @param api
 	 *            not <code>null</code>
@@ -301,7 +354,12 @@ public class DefaultUserTaskListener implements UserTaskListener
 	protected void afterQuestionnaireResponseCreate(ProcessPluginApi api, Variables variables,
 			CreateQuestionnaireResponseValues createQuestionnaireResponseValues, QuestionnaireResponse afterCreate)
 	{
-		// Nothing to do in default behavior
+		if (taskOutputSystem != null && !taskOutputSystem.isBlank() && taskOutputCode != null
+				&& !taskOutputCode.isBlank() && taskOutputVersion != null && !taskOutputVersion.isBlank())
+		{
+			variables.getStartTaskUpdater().addOutput(taskOutputSystem, taskOutputCode, taskOutputVersion,
+					new Reference(afterCreate.getIdElement().toUnqualifiedVersionless()));
+		}
 	}
 
 	/**

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/StartTaskUpdater.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/StartTaskUpdater.java
@@ -1,0 +1,206 @@
+package dev.dsf.bpe.v2.service;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.Task.TaskOutputComponent;
+import org.hl7.fhir.r4.model.Type;
+
+import jakarta.ws.rs.WebApplicationException;
+
+public interface StartTaskUpdater
+{
+	/**
+	 * Adds an output parameter to the start task, updates the {@link Task} on the DSF FHIR server and updates the
+	 * process variable.
+	 *
+	 * @param outputType
+	 *            not <code>null</code>, must have system, code and version
+	 * @param outputValue
+	 *            may be <code>null</code>
+	 * @throws WebApplicationException
+	 *             if start task can not be update at the DSF FHIR server
+	 * @throws IllegalArgumentException
+	 *             if system, code or version of the given <b>outputType</b> is blank
+	 */
+	void addOutput(Coding outputType, Type outputValue) throws WebApplicationException;
+
+	/**
+	 * Adds an output parameter to the start task, updates the {@link Task} on the DSF FHIR server and updates the
+	 * process variable.
+	 *
+	 * @param outputTypeSystem
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeCode
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeVersion
+	 *            not <code>null</code>, not blank
+	 * @param outputValue
+	 *            may be <code>null</code>
+	 * @throws WebApplicationException
+	 *             if start task can not be update at the DSF FHIR server
+	 * @throws IllegalArgumentException
+	 *             if <b>outputTypeSystem</b>, <b>outputTypeCode</b> or <b>outputTypeVersion</b> is blank
+	 */
+	default void addOutput(String outputTypeSystem, String outputTypeCode, String outputTypeVersion, Type outputValue)
+			throws WebApplicationException
+	{
+		Objects.requireNonNull(outputTypeSystem, "outputTypeSystem");
+		Objects.requireNonNull(outputTypeCode, "outputTypeCode");
+		Objects.requireNonNull(outputTypeVersion, "outputTypeVersion");
+
+		if (outputTypeSystem.isBlank())
+			throw new IllegalArgumentException("outputTypeSystem is blank");
+		if (outputTypeCode.isBlank())
+			throw new IllegalArgumentException("outputTypeCode is blank");
+		if (outputTypeVersion.isBlank())
+			throw new IllegalArgumentException("outputTypeVersion is blank");
+
+		addOutput(new Coding(outputTypeSystem, outputTypeCode, null).setVersion(outputTypeVersion), outputValue);
+	}
+
+	/**
+	 * @param outputType
+	 *            not <code>null</code>, must have system and code and version
+	 * @return Output with the given <b>outputType</b> from the start task if present
+	 */
+	Optional<TaskOutputComponent> getOutput(Coding outputType);
+
+	/**
+	 * @param outputTypeSystem
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeCode
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeVersion
+	 *            not <code>null</code>, not blank
+	 * @return Output with the given <b>outputType</b> from the start task if present
+	 * @throws IllegalArgumentException
+	 *             if <b>outputTypeSystem</b>, <b>outputTypeCode</b> or <b>outputTypeVersion</b> is blank
+	 */
+	default Optional<TaskOutputComponent> getOutput(String outputTypeSystem, String outputTypeCode,
+			String outputTypeVersion)
+	{
+		Objects.requireNonNull(outputTypeSystem, "outputTypeSystem");
+		Objects.requireNonNull(outputTypeCode, "outputTypeCode");
+		Objects.requireNonNull(outputTypeVersion, "outputTypeVersion");
+
+		if (outputTypeSystem.isBlank())
+			throw new IllegalArgumentException("outputTypeSystem is blank");
+		if (outputTypeCode.isBlank())
+			throw new IllegalArgumentException("outputTypeCode is blank");
+		if (outputTypeVersion.isBlank())
+			throw new IllegalArgumentException("outputTypeVersion is blank");
+
+		return getOutput(new Coding(outputTypeSystem, outputTypeCode, null).setVersion(outputTypeVersion));
+	}
+
+	/**
+	 * @param outputType
+	 *            not <code>null</code>, must have system and code and version
+	 * @return <code>true</code> if the start task has output parameter with the given <b>outputType</b>
+	 */
+	default boolean hasOuput(Coding outputType)
+	{
+		return getOutput(outputType).isPresent();
+	}
+
+	/**
+	 * Set the given <b>outputValue</b> for an output parameter of the start task with the given <b>outputType</b>,
+	 * updates the {@link Task} on the DSF FHIR server and updates the process variable.
+	 *
+	 * @param outputTypeSystem
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeCode
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeVersion
+	 *            not <code>null</code>, not blank
+	 * @param outputValue
+	 *            may be <code>null</code>
+	 * @throws WebApplicationException
+	 *             if start task can not be update at the DSF FHIR server
+	 * @throws IllegalArgumentException
+	 *             if the start task has no output parameter with the given outputType parameters or if
+	 *             <b>outputTypeSystem</b>, <b>outputTypeCode</b> or <b>outputTypeVersion</b> is blank
+	 */
+	default void modifyOutput(String outputTypeSystem, String outputTypeCode, String outputTypeVersion,
+			Type outputValue) throws WebApplicationException
+	{
+		Objects.requireNonNull(outputTypeSystem, "outputTypeSystem");
+		Objects.requireNonNull(outputTypeCode, "outputTypeCode");
+		Objects.requireNonNull(outputTypeVersion, "outputTypeVersion");
+
+		if (outputTypeSystem.isBlank())
+			throw new IllegalArgumentException("outputTypeSystem is blank");
+		if (outputTypeCode.isBlank())
+			throw new IllegalArgumentException("outputTypeCode is blank");
+		if (outputTypeVersion.isBlank())
+			throw new IllegalArgumentException("outputTypeVersion is blank");
+
+		modifyOutput(new Coding(outputTypeSystem, outputTypeCode, null).setVersion(outputTypeVersion), outputValue);
+	}
+
+	/**
+	 * Set the given <b>outputValue</b> for an output parameter of the start task with the given <b>outputType</b>,
+	 * updates the {@link Task} on the DSF FHIR server and updates the process variable.
+	 *
+	 * @param outputType
+	 *            not <code>null</code>, must have system, code and version
+	 * @param outputValue
+	 *            may be <code>null</code>
+	 * @throws WebApplicationException
+	 *             if start task can not be update at the DSF FHIR server
+	 * @throws IllegalArgumentException
+	 *             if the start task has no output parameter with the given <b>outputType</b> or if system, code or
+	 *             version of the given <b>outputType</b> is blank
+	 */
+	void modifyOutput(Coding outputType, Type outputValue) throws WebApplicationException;
+
+	/**
+	 * Removes an output parameter of the start task with the given <b>outputType</b>, updates the {@link Task} on the
+	 * DSF FHIR server and updates the process variable.
+	 *
+	 * @param outputType
+	 *            not <code>null</code>, must have system and code and version
+	 * @throws WebApplicationException
+	 *             if start task can not be update at the DSF FHIR server
+	 * @throws IllegalArgumentException
+	 *             if the start task has no output parameter with the given <b>outputType</b> or if system, code or
+	 *             version of the given <b>outputType</b> is blank
+	 */
+	void removeOutput(Coding outputType) throws WebApplicationException;
+
+	/**
+	 * Removes an output parameter of the start task with the given <b>outputType</b>, updates the {@link Task} on the
+	 * DSF FHIR server and updates the process variable.
+	 *
+	 * @param outputTypeSystem
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeCode
+	 *            not <code>null</code>, not blank
+	 * @param outputTypeVersion
+	 *            not <code>null</code>, not blank
+	 * @throws WebApplicationException
+	 *             if start task can not be update at the DSF FHIR server
+	 * @throws IllegalArgumentException
+	 *             if the start task has no output parameter with the given <b>outputType</b> or if system, code or
+	 *             version of the given <b>outputType</b> is blank
+	 */
+	default void removeOutput(String outputTypeSystem, String outputTypeCode, String outputTypeVersion)
+			throws WebApplicationException
+	{
+		Objects.requireNonNull(outputTypeSystem, "outputTypeSystem");
+		Objects.requireNonNull(outputTypeCode, "outputTypeCode");
+		Objects.requireNonNull(outputTypeVersion, "outputTypeVersion");
+
+		if (outputTypeSystem.isBlank())
+			throw new IllegalArgumentException("outputTypeSystem is blank");
+		if (outputTypeCode.isBlank())
+			throw new IllegalArgumentException("outputTypeCode is blank");
+		if (outputTypeVersion.isBlank())
+			throw new IllegalArgumentException("outputTypeVersion is blank");
+
+		removeOutput(new Coding(outputTypeSystem, outputTypeCode, null).setVersion(outputTypeVersion));
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/TaskHelper.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/service/TaskHelper.java
@@ -387,11 +387,16 @@ public interface TaskHelper
 	 *            may be <code>null</code>
 	 * @param code
 	 *            may be <code>null</code>
+	 * @param version
+	 *            may be <code>null</code>
 	 * @return not <code>null</code>
 	 * @see ParameterComponent#setType(org.hl7.fhir.r4.model.CodeableConcept)
 	 * @see ParameterComponent#setValue(Type)
 	 */
-	ParameterComponent createInput(Type value, String system, String code);
+	default ParameterComponent createInput(Type value, String system, String code, String version)
+	{
+		return createInput(value, new Coding(system, code, null).setVersion(version));
+	}
 
 
 	/**
@@ -416,9 +421,14 @@ public interface TaskHelper
 	 *            may be <code>null</code>
 	 * @param code
 	 *            may be <code>null</code>
+	 * @param version
+	 *            may be <code>null</code>
 	 * @return not <code>null</code>
 	 * @see TaskOutputComponent#setType(org.hl7.fhir.r4.model.CodeableConcept)
 	 * @see TaskOutputComponent#setValue(Type)
 	 */
-	TaskOutputComponent createOutput(Type value, String system, String code);
+	default TaskOutputComponent createOutput(Type value, String system, String code, String version)
+	{
+		return createOutput(value, new Coding(system, code, null).setVersion(version));
+	}
 }

--- a/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/variables/Variables.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2/src/main/java/dev/dsf/bpe/v2/variables/Variables.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.dsf.bpe.v2.activity.task.BusinessKeyStrategies;
 import dev.dsf.bpe.v2.constants.BpmnExecutionVariables;
+import dev.dsf.bpe.v2.service.StartTaskUpdater;
 
 /**
  * Gives access to process execution variables. Includes factory methods for {@link Target} and {@link Targets} values.
@@ -247,6 +248,14 @@ public interface Variables
 	 * @see #getTasks()
 	 */
 	Task getStartTask();
+
+	/**
+	 * Returns a {@link StartTaskUpdater} to modify the start task during process execution and propagate modified
+	 * output parameters to the local DSF FHIR server.
+	 *
+	 * @return service to update the start task
+	 */
+	StartTaskUpdater getStartTaskUpdater();
 
 	/**
 	 * Returns the latest {@link Task} received by this process or subprocess via a intermediate message catch event or

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/AbstractTest.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/AbstractTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractTest
 
 	private Consumer<String> output(ProcessPluginApi api, Variables variables, String code)
 	{
-		return t -> variables.getStartTask().addOutput(
-				api.getTaskHelper().createOutput(new StringType(t), "http://dsf.dev/fhir/CodeSystem/test", code));
+		return t -> variables.getStartTask().addOutput(api.getTaskHelper().createOutput(new StringType(t),
+				"http://dsf.dev/fhir/CodeSystem/test", code, api.getProcessPluginDefinition().getResourceVersion()));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/form.css
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/form.css
@@ -201,6 +201,15 @@ input[type=number] {
 	display: none;
 }
 
+.open {
+	align-self: center;
+	margin-left: 0.5em;
+}
+
+.open svg {
+	margin-top: 0.2em;
+}
+
 .copy {
 	align-self: center;
 	margin-left: 0.5em;
@@ -217,14 +226,6 @@ input[type=number] {
 input.identifier-coding-code {
 	margin-top: 6px;
 }
-
-/* .input-output-header {
-	font-family: monospace;
-	font-size: 1.75em;
-	color: #326F95;
-	padding-left: 5px;
-	margin-bottom: 12px;
-} */
 
 .invisible {
 	display: none;

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/resourceTask.html
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/resourceTask.html
@@ -30,6 +30,9 @@
 							<div class="input-group">
 								<input th:type="${i.type}" placeholder="string" th:id="${i.id}" th:attr="${resource.status == 'draft' ? 'placeholder' : 'value'} = ${i.stringValue} ?: ${i.type}, fhir-type = ${i.fhirType}">
 								<svg class="insert" height="22" width="22" viewBox="0 -960 960 960" th:disabled="${i.stringValue} == null" th:if="${resource.status == 'draft'}"><title>Insert Placeholder Value</title><path d="M140-160q-24 0-42-18t-18-42v-169h60v169h680v-520H140v171H80v-171q0-24 18-42t42-18h680q24 0 42 18t18 42v520q0 24-18 42t-42 18H140Zm319-143-43-43 103-103H80v-60h439L416-612l43-43 176 176-176 176Z"></path></svg>
+								<a class="open" th:href="${i.stringValue}" th:if="${resource.status != 'draft' and i.type == 'url'}">
+									<svg height="22" width="22" viewBox="0 -960 960 960"><title>Open Resource</title><path d="M180-120q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h600q24 0 42 18t18 42v600q0 24-18 42t-42 18H570v-60h210v-540H180v540h210v60H180Zm270 0v-284l-83 83-43-43 156-156 156 156-43 43-83-83v284h-60Z"/></svg>
+								</a>
 								<svg class="copy" height="22" width="22" viewBox="0 -960 960 960" th:if="${resource.status != 'draft'}"><title>Copy to Clipboard</title><path d="M362.308-260.001q-30.308 0-51.307-21-21-21-21-51.308v-455.382q0-30.308 21-51.308 20.999-21 51.307-21h335.383q30.307 0 51.307 21 21 21 21 51.308v455.382q0 30.308-21 51.308t-51.307 21H362.308Zm0-59.999h335.383q4.615 0 8.462-3.846 3.846-3.847 3.846-8.463v-455.382q0-4.616-3.846-8.463-3.847-3.846-8.462-3.846H362.308q-4.616 0-8.462 3.846-3.847 3.847-3.847 8.463v455.382q0 4.616 3.847 8.463 3.846 3.846 8.462 3.846ZM222.309-120.003q-30.307 0-51.307-21-21-21-21-51.307v-515.381h59.999v515.381q0 4.616 3.846 8.462 3.847 3.847 8.462 3.847h395.382v59.998H222.309ZM349.999-320V-800-320Z"/></svg>
 							</div>								
 						</th:block>
@@ -79,7 +82,7 @@
 				</fieldset>
 			</form>
 			<h3 th:if="${not #lists.isEmpty(task.output)}">Output</h3>
-			<form th:if="${(resource.status == 'failed' or resource.status == 'completed') and not #lists.isEmpty(task.output)}">
+			<form th:if="${(resource.status == 'in-progress' or resource.status == 'failed' or resource.status == 'completed') and not #lists.isEmpty(task.output)}">
 				<fieldset id="form-fieldset" disabled>
 					<div class="row" th:each="o : ${task.output}" th:if="${task.output}" th:classappend="${o.type == null ? 'row-display' : ''}" th:attr="for = ${o.id}">
 						<th:block th:if="${o.type == null}">
@@ -89,6 +92,9 @@
 							<label class="row-label" th:if="${o.label}" th:for="${o.id}" th:title="${o.labelTitle}" th:text="${o.label}">label</label>
 							<div class="input-group">
 								<input th:type="${o.type}" th:id="${o.id}" th:value="${o.stringValue}">
+								<a class="open" th:href="${o.stringValue}" th:if="${resource.status != 'draft' and o.type == 'url'}">
+									<svg height="22" width="22" viewBox="0 -960 960 960"><title>Open Resource</title><path d="M180-120q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h600q24 0 42 18t18 42v600q0 24-18 42t-42 18H570v-60h210v-540H180v540h210v60H180Zm270 0v-284l-83 83-43-43 156-156 156 156-43 43-83-83v284h-60Z"/></svg>
+								</a>
 								<svg class="copy" height="22" width="22" viewBox="0 -960 960 960" th:if="${resource.status != 'draft'}"><title>Copy to Clipboard</title><path d="M362.308-260.001q-30.308 0-51.307-21-21-21-21-51.308v-455.382q0-30.308 21-51.308 20.999-21 51.307-21h335.383q30.307 0 51.307 21 21 21 21 51.308v455.382q0 30.308-21 51.308t-51.307 21H362.308Zm0-59.999h335.383q4.615 0 8.462-3.846 3.846-3.847 3.846-8.463v-455.382q0-4.616-3.846-8.463-3.847-3.846-8.462-3.846H362.308q-4.616 0-8.462 3.846-3.847 3.847-3.847 8.463v455.382q0 4.616 3.847 8.463 3.846 3.846 8.462 3.846ZM222.309-120.003q-30.307 0-51.307-21-21-21-21-51.307v-515.381h59.999v515.381q0 4.616 3.846 8.462 3.847 3.847 8.462 3.847h395.382v59.998H222.309ZM349.999-320V-800-320Z"/></svg>
 							</div>								
 						</th:block>
@@ -131,6 +137,9 @@
 									<label class="extension-label" th:if="${e.url}" th:for="${e.id}" th:title="${e.url}" th:text="${e.url}">url</label>
 									<div class="input-group">
 										<input th:type="${e.type}" th:id="${e.id}" th:value="${e.stringValue}">
+										<a class="open" th:href="${e.stringValue}" th:if="${resource.status != 'draft' and e.type == 'url'}">
+											<svg height="22" width="22" viewBox="0 -960 960 960"><title>Open Resource</title><path d="M180-120q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h600q24 0 42 18t18 42v600q0 24-18 42t-42 18H570v-60h210v-540H180v540h210v60H180Zm270 0v-284l-83 83-43-43 156-156 156 156-43 43-83-83v284h-60Z"/></svg>
+										</a>
 										<svg class="copy" height="22" width="22" viewBox="0 -960 960 960" th:if="${resource.status != 'draft'}"><title>Copy to Clipboard</title><path d="M362.308-260.001q-30.308 0-51.307-21-21-21-21-51.308v-455.382q0-30.308 21-51.308 20.999-21 51.307-21h335.383q30.307 0 51.307 21 21 21 21 51.308v455.382q0 30.308-21 51.308t-51.307 21H362.308Zm0-59.999h335.383q4.615 0 8.462-3.846 3.846-3.847 3.846-8.463v-455.382q0-4.616-3.846-8.463-3.847-3.846-8.462-3.846H362.308q-4.616 0-8.462 3.846-3.847 3.847-3.847 8.463v455.382q0 4.616 3.847 8.463 3.846 3.846 8.462 3.846ZM222.309-120.003q-30.307 0-51.307-21-21-21-21-51.307v-515.381h59.999v515.381q0 4.616 3.846 8.462 3.847 3.847 8.462 3.847h395.382v59.998H222.309ZM349.999-320V-800-320Z"/></svg>
 									</div>								
 								</th:block>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-task-profile-1.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/dsf-test-task-profile-1.0.xml
@@ -1,36 +1,82 @@
-<StructureDefinition xmlns="http://hl7.org/fhir"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<StructureDefinition xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/R4/fhir-single.xsd">
-  <meta>
-    <tag>
-      <system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
-      <code value="ALL" />
-    </tag>
-  </meta>
-  <url value="http://dsf.dev/fhir/StructureDefinition/test-task" />
-  <version value="1.0" />
-  <name value="TestTask" />
-  <status value="active" />
-  <experimental value="false" />
-  <date value="2021-05-17" />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Task" />
-  <baseDefinition value="http://dsf.dev/fhir/StructureDefinition/task-base" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Task.instantiatesCanonical">
-      <path value="Task.instantiatesCanonical" />
-      <fixedCanonical value="http://dsf.dev/bpe/Process/test|1.0" />
-    </element>
-    <element id="Task.input:message-name">
-      <path value="Task.input" />
-      <sliceName value="message-name" />
-    </element>
-    <element id="Task.input:message-name.value[x]">
-      <path value="Task.input.value[x]" />
-      <fixedString value="test-message" />
-    </element>
-  </differential>
+	<meta>
+		<tag>
+			<system value="http://dsf.dev/fhir/CodeSystem/read-access-tag" />
+			<code value="ALL" />
+		</tag>
+	</meta>
+	<url value="http://dsf.dev/fhir/StructureDefinition/test-task" />
+	<version value="1.0" />
+	<name value="TestTask" />
+	<status value="active" />
+	<experimental value="false" />
+	<date value="2021-05-17" />
+	<fhirVersion value="4.0.1" />
+	<kind value="resource" />
+	<abstract value="false" />
+	<type value="Task" />
+	<baseDefinition value="http://dsf.dev/fhir/StructureDefinition/task-base" />
+	<derivation value="constraint" />
+	<differential>
+		<element id="Task.instantiatesCanonical">
+			<path value="Task.instantiatesCanonical" />
+			<fixedCanonical value="http://dsf.dev/bpe/Process/test|1.0" />
+		</element>
+		<element id="Task.input:message-name">
+			<path value="Task.input" />
+			<sliceName value="message-name" />
+		</element>
+		<element id="Task.input:message-name.value[x]">
+			<path value="Task.input.value[x]" />
+			<fixedString value="test-message" />
+		</element>
+		<element id="Task.output:binary-ref">
+			<path value="Task.output" />
+			<sliceName value="binary-ref" />
+			<min value="0" />
+			<max value="1" />
+		</element>
+		<element id="Task.output:binary-ref.type">
+			<path value="Task.output.type" />
+			<binding>
+				<strength value="required" />
+				<valueSet value="http://dsf.dev/fhir/ValueSet/test|1.7" />
+			</binding>
+		</element>
+		<element id="Task.output:binary-ref.type.coding">
+			<path value="Task.output.type.coding" />
+			<min value="1" />
+			<max value="1" />
+		</element>
+		<element id="Task.output:binary-ref.type.coding.system">
+			<path value="Task.output.type.coding.system" />
+			<min value="1" />
+			<fixedUri value="http://dsf.dev/fhir/CodeSystem/test" />
+		</element>
+		<element id="Task.output:binary-ref.type.coding.version">
+			<path value="Task.output.type.coding.version" />
+			<min value="1" />
+			<fixedString value="1.7" />
+		</element>
+		<element id="Task.output:binary-ref.type.coding.code">
+			<path value="Task.output.type.coding.code" />
+			<min value="1" />
+			<fixedCode value="binary-ref" />
+		</element>
+		<element id="Task.output:binary-ref.value[x]">
+			<path value="Task.output.value[x]" />
+			<type>
+				<code value="Reference" />
+			</type>
+		</element>
+		<element id="Task.output:binary-ref.value[x].reference">
+			<path value="Task.output.value[x].reference" />
+			<min value="1" />
+		</element>
+		<element id="Task.output:binary-ref.value[x].identifier">
+			<path value="Task.output.value[x].identifier" />
+			<max value="0" />
+		</element>
+	</differential>
 </StructureDefinition>


### PR DESCRIPTION
- Modifies the TaskAuthorizationRule to allow `in-progress` to `in-progress` Task updates.
- Adds service to the Variables interface to help in adding output parameters to the start-task during process execution.
- Some UI mods to display output parameters for Task resource with status `in-progress`.

closes #373 