### PR TITLE
Issue/388 fhir server UI improvements

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/static/dsf.css
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/static/dsf.css
@@ -37,49 +37,70 @@ body {
 	background-color: var(--color-background);
 }
 
-table#header {
-	margin-bottom: 0.4em;
+#header {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto auto;
+	margin-bottom: 1em;
 }
 
-table#header img {
-	height: 7em;
-	padding-bottom: 0.38em;
-	display: block;
+#logo {
+	grid-row: 1 / span 2;
+	margin-bottom: 0.41em;
 }
 
-td#heading {
-	vertical-align: bottom;
+#icons {
+	grid-column: 2;
+  	grid-row: 1;
+	display: flex;
+	column-gap: 0.25em;
+	justify-self: right;
 }
 
-td#heading h1 {
+#heading {
+	grid-column: 2;
+	grid-row: 2;
 	font-size: 2em;
 	font-family: monospace;
 	color: var(--color-prime);
+	align-self: end;
 	margin: 0 0 0 1em;
 	word-break: break-word;
 }
 
-td#heading h1 a {
-	white-space: nowrap;
+@media ( max-width: 64rem) {
+	#header {
+		grid-template-columns: 1fr;
+		grid-template-rows: auto auto auto;
+		height: auto;
+	}
+	#icons {
+		grid-column: 1;
+		grid-row: 1;
+		margin: 0 0 1em 0;
+	}
+	#logo {
+		grid-column: 1;
+		grid-row: 2;
+		margin: 0;
+		height: 14vw;
+	}
+	#heading {
+		grid-column: 1;
+		grid-row: 3;
+		margin: 1em 0 0 0;
+	}
 }
 
-td#heading h1 a:link,
-td#heading h1 a:visited,
-td#heading h1 a:active {
+#heading a:link,
+#heading a:visited,
+#heading a:active {
 	color: var(--color-prime);
 	text-decoration: none;
 }
 
-td#heading h1 a:hover {
+#heading a:hover {
 	text-decoration: underline;
-}
-
-#icons {
-	position: absolute;
-	top: 2em;
-	right: 2em;
-	display: flex;
-	column-gap: 0.25em;
 }
 
 #hello-user {

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/template/main.html
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/template/main.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:attr="theme=${theme}">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="theme=${theme}" lang="en">
 <head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#326F95">
 <base th:href="(${basePath} + '/')" href="/">
 <link rel="icon" type="image/svg+xml" href="static/favicon.svg">
 <link rel="icon" type="image/png" href="static/favicon_32x32.png" sizes="32x32">
 <link rel="icon" type="image/png" href="static/favicon_96x96.png" sizes="96x96">
-<meta name="theme-color" content="#326F95">
 <script src="static/main.js"></script>
 <script src="static/bpmn-viewer-prod.js" th:if="${bpmnViewer}" th:src="${bpmnProd ? 'static/bpmn-viewer-prod.js' : 'static/bpmn-viewer-dev.js'}"></script>
 <script src="static/bpmn.js" th:if="${bpmnViewer}"></script>
@@ -15,20 +17,16 @@
 <title th:text="${title}">DSF</title>
 </head>
 <body>
-	<div id="icons">
-		<span id="hello-user" th:if="${username}">Hello, [[${username}]]</span><a href="logout" th:if="${openid}"><svg class="icon" id="logout-icon" viewBox="0 0 24 24"><title>Logout</title><path d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h7v2Zm11-4-1.375-1.45 2.55-2.55H9v-2h8.175l-2.55-2.55L16 7l5 5Z" /></svg></a>
-		<svg class="icon" id="light-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Light Mode</title><path d="M479.765-340Q538-340 579-380.765q41-40.764 41-99Q620-538 579.235-579q-40.764-41-99-41Q422-620 381-579.235q-41 40.764-41 99Q340-422 380.765-381q40.764 41 99 41Zm.235 60q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM70-450q-12.75 0-21.375-8.675Q40-467.351 40-480.175 40-493 48.625-501.5T70-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T170-450H70Zm720 0q-12.75 0-21.375-8.675-8.625-8.676-8.625-21.5 0-12.825 8.625-21.325T790-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T890-450H790ZM479.825-760Q467-760 458.5-768.625T450-790v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-890v100q0 12.75-8.675 21.375-8.676 8.625-21.5 8.625Zm0 720Q467-40 458.5-48.625T450-70v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-170v100q0 12.75-8.675 21.375Q492.649-40 479.825-40ZM240-678l-57-56q-9-9-8.629-21.603.37-12.604 8.526-21.5 8.896-8.897 21.5-8.897Q217-786 226-777l56 57q8 9 8 21t-8 20.5q-8 8.5-20.5 8.5t-21.5-8Zm494 495-56-57q-8-9-8-21.375T678.5-282q8.5-9 20.5-9t21 9l57 56q9 9 8.629 21.603-.37 12.604-8.526 21.5-8.896 8.897-21.5 8.897Q743-174 734-183Zm-56-495q-9-9-9-21t9-21l56-57q9-9 21.603-8.629 12.604.37 21.5 8.526 8.897 8.896 8.897 21.5Q786-743 777-734l-57 56q-8 8-20.364 8-12.363 0-21.636-8ZM182.897-182.897q-8.897-8.896-8.897-21.5Q174-217 183-226l57-56q8.8-9 20.9-9 12.1 0 20.709 9Q291-273 291-261t-9 21l-56 57q-9 9-21.603 8.629-12.604-.37-21.5-8.526ZM480-480Z" /></svg>
-		<svg class="icon" id="dark-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Dark Mode</title><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q8 0 17 .5t23 1.5q-36 32-56 79t-20 99q0 90 63 153t153 63q52 0 99-18.5t79-51.5q1 12 1.5 19.5t.5 14.5q0 150-105 255T480-120Zm0-60q109 0 190-67.5T771-406q-25 11-53.667 16.5Q688.667-384 660-384q-114.689 0-195.345-80.655Q384-545.311 384-660q0-24 5-51.5t18-62.5q-98 27-162.5 109.5T180-480q0 125 87.5 212.5T480-180Zm-4-297Z" /></svg>
-		<a href="" download="" id="download-link" title="" th:if="${download}" th:href="${download.href}" th:title="${download.title}" th:attr="download = ${download.filename}"><svg class="icon" id="download" viewBox="0 0 24 24"><path d="M18,15v3H6v-3H4v3c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2v-3H18z M17,11l-1.41-1.41L13,12.17V4h-2v8.17L8.41,9.59L7,11l5,5 L17,11z" /></svg></a>
+	<div id="header">
+		<div id="icons">
+			<span id="hello-user" th:if="${username}">Hello, [[${username}]]</span><a href="logout" th:if="${openid}"><svg class="icon" id="logout-icon" viewBox="0 0 24 24"><title>Logout</title><path d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h7v2Zm11-4-1.375-1.45 2.55-2.55H9v-2h8.175l-2.55-2.55L16 7l5 5Z" /></svg></a>
+			<svg class="icon" id="light-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Light Mode</title><path d="M479.765-340Q538-340 579-380.765q41-40.764 41-99Q620-538 579.235-579q-40.764-41-99-41Q422-620 381-579.235q-41 40.764-41 99Q340-422 380.765-381q40.764 41 99 41Zm.235 60q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM70-450q-12.75 0-21.375-8.675Q40-467.351 40-480.175 40-493 48.625-501.5T70-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T170-450H70Zm720 0q-12.75 0-21.375-8.675-8.625-8.676-8.625-21.5 0-12.825 8.625-21.325T790-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T890-450H790ZM479.825-760Q467-760 458.5-768.625T450-790v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-890v100q0 12.75-8.675 21.375-8.676 8.625-21.5 8.625Zm0 720Q467-40 458.5-48.625T450-70v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-170v100q0 12.75-8.675 21.375Q492.649-40 479.825-40ZM240-678l-57-56q-9-9-8.629-21.603.37-12.604 8.526-21.5 8.896-8.897 21.5-8.897Q217-786 226-777l56 57q8 9 8 21t-8 20.5q-8 8.5-20.5 8.5t-21.5-8Zm494 495-56-57q-8-9-8-21.375T678.5-282q8.5-9 20.5-9t21 9l57 56q9 9 8.629 21.603-.37 12.604-8.526 21.5-8.896 8.897-21.5 8.897Q743-174 734-183Zm-56-495q-9-9-9-21t9-21l56-57q9-9 21.603-8.629 12.604.37 21.5 8.526 8.897 8.896 8.897 21.5Q786-743 777-734l-57 56q-8 8-20.364 8-12.363 0-21.636-8ZM182.897-182.897q-8.897-8.896-8.897-21.5Q174-217 183-226l57-56q8.8-9 20.9-9 12.1 0 20.709 9Q291-273 291-261t-9 21l-56 57q-9 9-21.603 8.629-12.604-.37-21.5-8.526ZM480-480Z" /></svg>
+			<svg class="icon" id="dark-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Dark Mode</title><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q8 0 17 .5t23 1.5q-36 32-56 79t-20 99q0 90 63 153t153 63q52 0 99-18.5t79-51.5q1 12 1.5 19.5t.5 14.5q0 150-105 255T480-120Zm0-60q109 0 190-67.5T771-406q-25 11-53.667 16.5Q688.667-384 660-384q-114.689 0-195.345-80.655Q384-545.311 384-660q0-24 5-51.5t18-62.5q-98 27-162.5 109.5T180-480q0 125 87.5 212.5T480-180Zm-4-297Z" /></svg>
+			<a href="" download="" id="download-link" title="" th:if="${download}" th:href="${download.href}" th:title="${download.title}" th:attr="download = ${download.filename}"><svg class="icon" id="download" viewBox="0 0 24 24"><path d="M18,15v3H6v-3H4v3c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2v-3H18z M17,11l-1.41-1.41L13,12.17V4h-2v8.17L8.41,9.59L7,11l5,5 L17,11z" /></svg></a>
+		</div>
+		<img id="logo" src="static/logo.svg" title="Logo">
+		<h1 id="heading" th:utext="${heading}"></h1>
 	</div>
-	<table id="header">
-		<tr>
-			<td><image src="static/logo.svg"></td>
-			<td id="heading">
-				<h1 th:utext="${heading}"></h1>
-			</td>
-		</tr>
-	</table>
 	<div id="html" th:insert="${htmlFragment} ? ~{(${htmlFragment})::content} : _" th:if="${htmlFragment}"></div>
 </body>
 </html>

--- a/dsf-common/dsf-common-ui/src/main/java/dev/dsf/common/ui/webservice/StaticResourcesService.java
+++ b/dsf-common/dsf-common-ui/src/main/java/dev/dsf/common/ui/webservice/StaticResourcesService.java
@@ -168,9 +168,9 @@ public class StaticResourcesService
 	private static final String FILENAME_PATTERN_STRING = "^[0-9a-zA-Z_-]+\\.[0-9a-zA-Z]+$";
 	private static final Pattern FILENAME_PATTERN = Pattern.compile(FILENAME_PATTERN_STRING);
 
-	private static final Map<String, String> MIME_TYPE_BY_SUFFIX = Map.of("css", "text/css", "js", "text/javascript",
-			"html", "text/html", "pdf", "application/pdf", "png", "image/png", "svg", "image/svg+xml", "jpg",
-			"image/jpeg");
+	private static final Map<String, String> MIME_TYPE_BY_SUFFIX = Map.of("css", "text/css; charset=utf-8", "js",
+			"text/javascript; charset=utf-8", "html", "text/html; charset=utf-8", "pdf", "application/pdf", "png",
+			"image/png", "svg", "image/svg+xml; charset=utf-8", "jpg", "image/jpeg");
 
 	private final AbstractCache cache;
 	private final CacheControl cacheControl;

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractResource.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractResource.java
@@ -13,7 +13,7 @@ import org.hl7.fhir.r4.model.Resource;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 
-abstract class AbstractResource<R extends Resource> extends AbstractThymeleafContext<R>
+abstract class AbstractResource<R extends Resource> extends AbstractResourceThymeleafContext<R>
 {
 	private record ResourceData(String type, String id, String version, String lastUpdated, String profiles,
 			Boolean active, String status)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractResourceThymeleafContext.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractResourceThymeleafContext.java
@@ -5,8 +5,6 @@ import java.util.function.BiConsumer;
 
 import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.common.auth.conf.Identity;
-
 abstract class AbstractResourceThymeleafContext<R extends Resource> extends AbstractThymeleafContext
 {
 	private final Class<R> resourceType;
@@ -31,7 +29,7 @@ abstract class AbstractResourceThymeleafContext<R extends Resource> extends Abst
 	}
 
 	@Override
-	public final void setVariables(BiConsumer<String, Object> variables, Resource resource, Identity identity)
+	public final void setVariables(BiConsumer<String, Object> variables, Resource resource)
 	{
 		if (resourceType.isInstance(resource))
 			doSetVariables(variables, resourceType.cast(resource));

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractResourceThymeleafContext.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractResourceThymeleafContext.java
@@ -1,0 +1,44 @@
+package dev.dsf.fhir.adapter;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.hl7.fhir.r4.model.Resource;
+
+import dev.dsf.common.auth.conf.Identity;
+
+abstract class AbstractResourceThymeleafContext<R extends Resource> extends AbstractThymeleafContext
+{
+	private final Class<R> resourceType;
+	private final String htmlFragment;
+
+	protected AbstractResourceThymeleafContext(Class<R> resourceType, String htmlFragment)
+	{
+		this.resourceType = Objects.requireNonNull(resourceType, "resourceType");
+		this.htmlFragment = Objects.requireNonNull(htmlFragment, "htmlFragment");
+	}
+
+	@Override
+	public Class<R> getResourceType()
+	{
+		return resourceType;
+	}
+
+	@Override
+	public String getHtmlFragment()
+	{
+		return htmlFragment;
+	}
+
+	@Override
+	public final void setVariables(BiConsumer<String, Object> variables, Resource resource, Identity identity)
+	{
+		if (resourceType.isInstance(resource))
+			doSetVariables(variables, resourceType.cast(resource));
+		else
+			throw new IllegalStateException("Unsupported resource of type " + resource.getClass().getName()
+					+ ", expected " + resourceType.getName());
+	}
+
+	protected abstract void doSetVariables(BiConsumer<String, Object> variables, R resource);
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractSearchSet.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractSearchSet.java
@@ -27,7 +27,7 @@ import org.hl7.fhir.r4.model.Task.ParameterComponent;
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import jakarta.ws.rs.core.MultivaluedMap;
 
-abstract class AbstractSearchSet<MR extends Resource> extends AbstractThymeleafContext<Bundle>
+abstract class AbstractSearchSet<MR extends Resource> extends AbstractResourceThymeleafContext<Bundle>
 {
 	protected static final String INSTANTIATES_CANONICAL_PATTERN_STRING = "(?<processUrl>http[s]{0,1}://(?<domain>(?:(?:[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])\\.)+(?:[a-zA-Z0-9]{1,63}))"
 			+ "/bpe/Process/(?<processName>[a-zA-Z0-9-]+))\\|(?<processVersion>\\d+\\.\\d+)$";

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractThymeleafContext.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/AbstractThymeleafContext.java
@@ -7,7 +7,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -27,54 +26,11 @@ import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.UrlType;
 
-abstract class AbstractThymeleafContext<R extends Resource> implements ThymeleafContext
+public abstract class AbstractThymeleafContext implements ThymeleafContext
 {
 	private static final DateTimeFormatter DATE_DISPLAY_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 	private static final DateTimeFormatter DATE_TIME_DISPLAY_FORMAT = DateTimeFormatter
 			.ofPattern("dd.MM.yyyy HH:mm:ss");
-
-	private final Class<R> resourceType;
-	private final String htmlFragment;
-
-	protected AbstractThymeleafContext(Class<R> resourceType, String htmlFragment)
-	{
-		this.resourceType = Objects.requireNonNull(resourceType, "resourceType");
-		this.htmlFragment = Objects.requireNonNull(htmlFragment, "htmlFragment");
-	}
-
-	@Override
-	public Class<R> getResourceType()
-	{
-		return resourceType;
-	}
-
-	@Override
-	public String getHtmlFragment()
-	{
-		return htmlFragment;
-	}
-
-	@Override
-	public final void setVariables(BiConsumer<String, Object> variables, Resource resource)
-	{
-		if (resourceType.isInstance(resource))
-			doSetVariables(variables, resourceType.cast(resource));
-		else
-			throw new IllegalStateException("Unsupported resource of type " + resource.getClass().getName()
-					+ ", expected " + resourceType.getName());
-	}
-
-	protected abstract void doSetVariables(BiConsumer<String, Object> variables, R resource);
-
-	protected final String formatDate(Date date)
-	{
-		return format(date, DATE_DISPLAY_FORMAT);
-	}
-
-	protected final String formatDateTime(Date date)
-	{
-		return format(date, DATE_TIME_DISPLAY_FORMAT);
-	}
 
 	protected final String format(Date date, DateTimeFormatter formatter)
 	{
@@ -84,6 +40,17 @@ abstract class AbstractThymeleafContext<R extends Resource> implements Thymeleaf
 			return null;
 		else
 			return formatter.format(LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()));
+	}
+
+
+	protected final String formatDate(Date date)
+	{
+		return format(date, DATE_DISPLAY_FORMAT);
+	}
+
+	protected final String formatDateTime(Date date)
+	{
+		return format(date, DATE_TIME_DISPLAY_FORMAT);
 	}
 
 	protected final String formatLastUpdated(Resource resource)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceOperationOutcome.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceOperationOutcome.java
@@ -1,0 +1,216 @@
+package dev.dsf.fhir.adapter;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.springframework.beans.factory.InitializingBean;
+
+import dev.dsf.common.auth.conf.Identity;
+import dev.dsf.common.build.BuildInfoReader;
+import dev.dsf.fhir.dao.StatisticsDao;
+import dev.dsf.fhir.dao.StatisticsDao.Statistics;
+import dev.dsf.fhir.help.ExceptionHandler;
+import dev.dsf.fhir.webservice.impl.RootServiceImpl;
+
+public class ResourceOperationOutcome extends AbstractThymeleafContext implements ThymeleafContext, InitializingBean
+{
+	private record Element(String status, Boolean active, String type, String title, String subtitle, String unit,
+			String value, String link)
+	{
+	}
+
+	private record ByteSize(double value, String unit)
+	{
+	}
+
+	private static final String[] BYTE_UNITS = { "B", "KiB", "MiB", "GiB", "TiB" };
+
+	private final BuildInfoReader buildInfoReader;
+	private final StatisticsDao statisticsDao;
+	private final ExceptionHandler exceptionHandler;
+
+	public ResourceOperationOutcome(BuildInfoReader buildInfoReader, StatisticsDao statisticsDao,
+			ExceptionHandler exceptionHandler)
+	{
+		this.buildInfoReader = buildInfoReader;
+		this.statisticsDao = statisticsDao;
+		this.exceptionHandler = exceptionHandler;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception
+	{
+		Objects.requireNonNull(buildInfoReader, "buildInfoReader");
+		Objects.requireNonNull(statisticsDao, "statisticsDao");
+		Objects.requireNonNull(exceptionHandler, "exceptionHandler");
+	}
+
+	@Override
+	public Class<? extends Resource> getResourceType()
+	{
+		return OperationOutcome.class;
+	}
+
+	@Override
+	public boolean isResourceSupported(String requestPathLastElement)
+	{
+		return false;
+	}
+
+	@Override
+	public boolean isRootSupported(Resource resource)
+	{
+		return resource instanceof OperationOutcome o && (boolean) o.getUserData(RootServiceImpl.ROOT_GET);
+	}
+
+	@Override
+	public String getHtmlFragment()
+	{
+		return "root";
+	}
+
+	@Override
+	public void setVariables(BiConsumer<String, Object> variables, Resource resource, Identity identity)
+	{
+		variables.accept("elements", Stream.concat(buildInfoElements(), statisticsElements()).toList());
+	}
+
+	private Stream<Element> buildInfoElements()
+	{
+		return Stream.of(
+				new Element(null, null, null, "DSF", "Version", null, buildInfoReader.getProjectVersion(), null),
+				new Element(null, null, null, "DSF", "Release Date", null,
+						formatDate(buildInfoReader.getBuildDateAsDate()), null));
+	}
+
+	private Stream<Element> statisticsElements()
+	{
+		Statistics statistics = exceptionHandler.catchAndLogSqlExceptionAndIfReturn(() -> statisticsDao.getStatistics(),
+				() -> null);
+
+		if (statistics == null)
+			return Stream.of();
+
+		ByteSize databaseSize = formatBytes(statistics.databaseSize());
+		ByteSize binariesSize = formatBytes(statistics.binariesSize());
+
+		String minusOneDay = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+				.format(OffsetDateTime.now().minusDays(1).withNano(0));
+		String minusThirtyDays = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+				.format(OffsetDateTime.now().minusDays(30).withNano(0));
+
+		return Stream.of(
+				new Element(null, null, null, "DSF", "Database Size", databaseSize.unit(),
+						String.format("%.2f", databaseSize.value()), null),
+				new Element(null, null, null, "DSF", "Binaries Size", binariesSize.unit(),
+						String.format("%.2f", binariesSize.value()), null),
+				new Element("active", null, ResourceType.ActivityDefinition.name(),
+						ResourceType.ActivityDefinition.name(), null, null,
+						String.valueOf(statistics.activitDefinitions()),
+						ResourceType.ActivityDefinition.name() + "?_sort=status,url,version"),
+				new Element(null, null, ResourceType.Binary.name(), ResourceType.Binary.name(), null, null,
+						String.valueOf(statistics.binaries()), ResourceType.Binary.name()),
+				new Element(null, null, ResourceType.DocumentReference.name(), ResourceType.DocumentReference.name(),
+						null, null, String.valueOf(statistics.documentReferences()),
+						ResourceType.DocumentReference.name()),
+				new Element("active", null, ResourceType.Endpoint.name(), ResourceType.Endpoint.name(), "active", null,
+						String.valueOf(statistics.endpoints()), ResourceType.Endpoint.name() + "?status=active"),
+				new Element(null, null, ResourceType.Library.name(), ResourceType.Library.name(), null, null,
+						String.valueOf(statistics.libraries()), ResourceType.Library.name()),
+				new Element(null, null, ResourceType.Measure.name(), ResourceType.Measure.name(), null, null,
+						String.valueOf(statistics.measures()), ResourceType.Measure.name()),
+				new Element(null, null, ResourceType.MeasureReport.name(), ResourceType.MeasureReport.name(), null,
+						null, String.valueOf(statistics.measureReports()), ResourceType.MeasureReport.name()),
+				new Element(null, true, ResourceType.Organization.name(), ResourceType.Organization.name(),
+						"member, active", null, String.valueOf(statistics.organizationsMember()),
+						ResourceType.Organization.name()
+								+ "?_profile=http://dsf.dev/fhir/StructureDefinition/organization"),
+				new Element(null, true, ResourceType.Organization.name(), ResourceType.Organization.name(),
+						"parent, active", null, String.valueOf(statistics.organizationsParent()),
+						ResourceType.Organization.name()
+								+ "?_profile=http://dsf.dev/fhir/StructureDefinition/organization-parent"),
+				new Element(null, true, ResourceType.OrganizationAffiliation.name(),
+						ResourceType.OrganizationAffiliation.name(), "active", null,
+						String.valueOf(statistics.organizationAffiliations()),
+						ResourceType.OrganizationAffiliation + "?active=true"),
+				new Element("in-progress", null, ResourceType.QuestionnaireResponse.name(),
+						ResourceType.QuestionnaireResponse.name(), "in-progress", "24h",
+						String.valueOf(statistics.questionnaireResponsesInProgress24h()),
+						ResourceType.QuestionnaireResponse.name() + "?status=in-progress&_lastUpdated=ge"
+								+ minusOneDay),
+				new Element("amended", null, ResourceType.QuestionnaireResponse.name(),
+						ResourceType.QuestionnaireResponse.name(), "amended", "24h",
+						String.valueOf(statistics.questionnaireResponsesAmended24h()),
+						ResourceType.QuestionnaireResponse.name() + "?status=amended&_lastUpdated=ge" + minusOneDay),
+				new Element("in-progress", null, ResourceType.QuestionnaireResponse.name(),
+						ResourceType.QuestionnaireResponse.name(), "in-progress", "30d",
+						String.valueOf(statistics.questionnaireResponsesInProgress30d()),
+						ResourceType.QuestionnaireResponse.name() + "?status=in-progress&_lastUpdated=ge"
+								+ minusThirtyDays),
+				new Element("amended", null, ResourceType.QuestionnaireResponse.name(),
+						ResourceType.QuestionnaireResponse.name(), "amended", "30d",
+						String.valueOf(statistics.questionnaireResponsesAmended30d()),
+						ResourceType.QuestionnaireResponse.name() + "?status=amended&_lastUpdated=ge"
+								+ minusThirtyDays),
+				new Element("in-progress", null, ResourceType.QuestionnaireResponse.name(),
+						ResourceType.QuestionnaireResponse.name(), "in-progress", null,
+						String.valueOf(statistics.questionnaireResponsesInProgress()),
+						ResourceType.QuestionnaireResponse.name() + "?status=in-progress"),
+				new Element("amended", null, ResourceType.QuestionnaireResponse.name(),
+						ResourceType.QuestionnaireResponse.name(), "amended", null,
+						String.valueOf(statistics.questionnaireResponsesAmended()),
+						ResourceType.QuestionnaireResponse.name() + "?status=amended"),
+				new Element("draft", null, ResourceType.Task.name(), ResourceType.Task.name(), "draft", null,
+						String.valueOf(statistics.tasksDraft()),
+						ResourceType.Task.name() + "?status=draft&_sort=_profile,identifier"),
+				new Element("in-progress", null, ResourceType.Task.name(), ResourceType.Task.name(), "in-progress",
+						"24h", String.valueOf(statistics.tasksInProgress24h()),
+						ResourceType.Task.name() + "?status=in-progress&_lastUpdated=ge" + minusOneDay),
+				new Element("completed", null, ResourceType.Task.name(), ResourceType.Task.name(), "completed", "24h",
+						String.valueOf(statistics.tasksCompleted24h()),
+						ResourceType.Task.name() + "?status=completed&_lastUpdated=ge" + minusOneDay),
+				new Element("failed", null, ResourceType.Task.name(), ResourceType.Task.name(), "failed", "24h",
+						String.valueOf(statistics.tasksFailed24h()),
+						ResourceType.Task.name() + "?status=failed&_lastUpdated=ge" + minusOneDay),
+				new Element("in-progress", null, ResourceType.Task.name(), ResourceType.Task.name(), "in-progress",
+						"30d", String.valueOf(statistics.tasksInProgress30d()),
+						ResourceType.Task.name() + "?status=in-progress&_lastUpdated=ge" + minusThirtyDays),
+				new Element("completed", null, ResourceType.Task.name(), ResourceType.Task.name(), "completed", "30d",
+						String.valueOf(statistics.tasksCompleted30d()),
+						ResourceType.Task.name() + "?status=completed&_lastUpdated=ge" + minusThirtyDays),
+				new Element("failed", null, ResourceType.Task.name(), ResourceType.Task.name(), "failed", "30d",
+						String.valueOf(statistics.tasksFailed30d()),
+						ResourceType.Task.name() + "?status=failed&_lastUpdated=ge" + minusThirtyDays),
+				new Element("in-progress", null, ResourceType.Task.name(), ResourceType.Task.name(), "in-progress",
+						null, String.valueOf(statistics.tasksInProgress()),
+						ResourceType.Task.name() + "?status=in-progress"),
+				new Element("completed", null, ResourceType.Task.name(), ResourceType.Task.name(), "completed", null,
+						String.valueOf(statistics.tasksCompleted()), ResourceType.Task.name() + "?status=completed"),
+				new Element("failed", null, ResourceType.Task.name(), ResourceType.Task.name(), "failed", null,
+						String.valueOf(statistics.tasksFailed()), ResourceType.Task.name() + "?status=failed"));
+	}
+
+	private ByteSize formatBytes(long bytes)
+	{
+		if (bytes < 0)
+			return new ByteSize(0, "B");
+
+		double value = bytes;
+		int unitIndex = 0;
+
+		while (value >= 1024 && unitIndex < BYTE_UNITS.length - 1)
+		{
+			value /= 1024;
+			unitIndex++;
+		}
+
+		return new ByteSize(value, BYTE_UNITS[unitIndex]);
+	}
+
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceOperationOutcome.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ResourceOperationOutcome.java
@@ -11,7 +11,6 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.springframework.beans.factory.InitializingBean;
 
-import dev.dsf.common.auth.conf.Identity;
 import dev.dsf.common.build.BuildInfoReader;
 import dev.dsf.fhir.dao.StatisticsDao;
 import dev.dsf.fhir.dao.StatisticsDao.Statistics;
@@ -76,7 +75,7 @@ public class ResourceOperationOutcome extends AbstractThymeleafContext implement
 	}
 
 	@Override
-	public void setVariables(BiConsumer<String, Object> variables, Resource resource, Identity identity)
+	public void setVariables(BiConsumer<String, Object> variables, Resource resource)
 	{
 		variables.accept("elements", Stream.concat(buildInfoElements(), statisticsElements()).toList());
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafContext.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafContext.java
@@ -4,13 +4,20 @@ import java.util.function.BiConsumer;
 
 import org.hl7.fhir.r4.model.Resource;
 
+import dev.dsf.common.auth.conf.Identity;
+
 public interface ThymeleafContext
 {
 	Class<? extends Resource> getResourceType();
 
 	boolean isResourceSupported(String requestPathLastElement);
 
+	default boolean isRootSupported(Resource resource)
+	{
+		return false;
+	}
+
 	String getHtmlFragment();
 
-	void setVariables(BiConsumer<String, Object> variables, Resource resource);
+	void setVariables(BiConsumer<String, Object> variables, Resource resource, Identity identity);
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafContext.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafContext.java
@@ -4,8 +4,6 @@ import java.util.function.BiConsumer;
 
 import org.hl7.fhir.r4.model.Resource;
 
-import dev.dsf.common.auth.conf.Identity;
-
 public interface ThymeleafContext
 {
 	Class<? extends Resource> getResourceType();
@@ -19,5 +17,5 @@ public interface ThymeleafContext
 
 	String getHtmlFragment();
 
-	void setVariables(BiConsumer<String, Object> variables, Resource resource, Identity identity);
+	void setVariables(BiConsumer<String, Object> variables, Resource resource);
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafContext.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafContext.java
@@ -1,5 +1,6 @@
 package dev.dsf.fhir.adapter;
 
+import java.security.Principal;
 import java.util.function.BiConsumer;
 
 import org.hl7.fhir.r4.model.Resource;
@@ -10,7 +11,7 @@ public interface ThymeleafContext
 
 	boolean isResourceSupported(String requestPathLastElement);
 
-	default boolean isRootSupported(Resource resource)
+	default boolean isRootSupported(Resource resource, Principal principal)
 	{
 		return false;
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafTemplateServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafTemplateServiceImpl.java
@@ -174,8 +174,7 @@ public class ThymeleafTemplateServiceImpl implements ThymeleafTemplateService, I
 		getContext(type, uriInfo, resource).ifPresent(tContext ->
 		{
 			context.setVariable("htmlFragment", tContext.getHtmlFragment());
-			tContext.setVariables(context::setVariable, resource,
-					securityContext.getUserPrincipal() instanceof Identity i ? i : null);
+			tContext.setVariables(context::setVariable, resource);
 		});
 
 		OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/StatisticsDao.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/StatisticsDao.java
@@ -5,7 +5,7 @@ import java.sql.SQLException;
 public interface StatisticsDao
 {
 	record Statistics(long organizationsMember, long organizationsParent, long endpoints, long organizationAffiliations,
-			long activitDefinitions, long tasksDraft, long tasksInProgress24h, long tasksInProgress30d,
+			long activityDefinitions, long tasksDraft, long tasksInProgress24h, long tasksInProgress30d,
 			long tasksInProgress, long tasksCompleted24h, long tasksCompleted30d, long tasksCompleted,
 			long tasksFailed24h, long tasksFailed30d, long tasksFailed, long questionnaireResponsesInProgress24h,
 			long questionnaireResponsesInProgress30d, long questionnaireResponsesInProgress,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/StatisticsDao.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/StatisticsDao.java
@@ -1,0 +1,19 @@
+package dev.dsf.fhir.dao;
+
+import java.sql.SQLException;
+
+public interface StatisticsDao
+{
+	record Statistics(long organizationsMember, long organizationsParent, long endpoints, long organizationAffiliations,
+			long activitDefinitions, long tasksDraft, long tasksInProgress24h, long tasksInProgress30d,
+			long tasksInProgress, long tasksCompleted24h, long tasksCompleted30d, long tasksCompleted,
+			long tasksFailed24h, long tasksFailed30d, long tasksFailed, long questionnaireResponsesInProgress24h,
+			long questionnaireResponsesInProgress30d, long questionnaireResponsesInProgress,
+			long questionnaireResponsesAmended24h, long questionnaireResponsesAmended30d,
+			long questionnaireResponsesAmended, long binaries, long documentReferences, long measureReports,
+			long measures, long libraries, long databaseSize, long binariesSize)
+	{
+	}
+
+	Statistics getStatistics() throws SQLException;
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/StatisticsDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/StatisticsDaoJdbc.java
@@ -72,7 +72,7 @@ public class StatisticsDaoJdbc implements StatisticsDao, InitializingBean
 			long organizationsParent = result.getLong(2);
 			long endpoints = result.getLong(3);
 			long organizationAffiliations = result.getLong(4);
-			long activitDefinitions = result.getLong(5);
+			long activityDefinitions = result.getLong(5);
 			long tasksDraft = result.getLong(6);
 			long tasksInProgress24h = result.getLong(7);
 			long tasksInProgress30d = result.getLong(8);
@@ -98,7 +98,7 @@ public class StatisticsDaoJdbc implements StatisticsDao, InitializingBean
 			long binariesSize = result.getLong(28);
 
 			return new Statistics(organizationsMember, organizationsParent, endpoints, organizationAffiliations,
-					activitDefinitions, tasksDraft, tasksInProgress24h, tasksInProgress30d, tasksInProgress,
+					activityDefinitions, tasksDraft, tasksInProgress24h, tasksInProgress30d, tasksInProgress,
 					tasksCompleted24h, tasksCompleted30d, tasksCompleted, tasksFailed24h, tasksFailed30d, tasksFailed,
 					questionnaireResponsesInProgress24h, questionnaireResponsesInProgress30d,
 					questionnaireResponsesInProgress, questionnaireResponsesAmended24h,

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/StatisticsDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/StatisticsDaoJdbc.java
@@ -1,0 +1,109 @@
+package dev.dsf.fhir.dao.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.InitializingBean;
+
+import dev.dsf.fhir.dao.StatisticsDao;
+
+public class StatisticsDaoJdbc implements StatisticsDao, InitializingBean
+{
+	private static final String QUERY = """
+			SELECT
+			  (SELECT count(*) FROM current_organizations WHERE (organization->>'active')::boolean AND organization->'meta'->'profile' ?? 'http://dsf.dev/fhir/StructureDefinition/organization') AS organizations_member
+			, (SELECT count(*) FROM current_organizations WHERE (organization->>'active')::boolean AND organization->'meta'->'profile' ?? 'http://dsf.dev/fhir/StructureDefinition/organization-parent') AS organizations_parent
+			, (SELECT count(*) FROM current_endpoints WHERE endpoint->>'status' = 'active') AS endpoints
+			, (SELECT count(*) FROM current_organization_affiliations WHERE (organization_affiliation->>'active')::boolean) AS organization_affiliations
+			, (SELECT count(*) FROM current_activity_definitions) AS activity_definitions
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'draft') AS tasks_draft
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'in-progress' AND (task->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '1 day' AND NOW()) AS tasks_in_progress_24h
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'in-progress' AND (task->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '30 day' AND NOW()) AS tasks_in_progress_30d
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'in-progress') AS tasks_in_progress
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'completed' AND (task->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '1 day' AND NOW()) AS tasks_completed_24h
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'completed' AND (task->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '30 day' AND NOW()) AS tasks_completed_30d
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'completed') AS tasks_completed
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'failed' AND (task->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '1 day' AND NOW()) AS tasks_failed_24h
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'failed' AND (task->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '30 day' AND NOW()) AS tasks_failed_30d
+			, (SELECT count(*) FROM current_tasks WHERE task->>'status' = 'failed') AS tasks_failed
+			, (SELECT count(*) FROM current_questionnaire_responses WHERE questionnaire_response->>'status' = 'in-progress' AND (questionnaire_response->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '1 day' AND NOW()) AS questionnaire_responses_in_progress_24h
+			, (SELECT count(*) FROM current_questionnaire_responses WHERE questionnaire_response->>'status' = 'in-progress' AND (questionnaire_response->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '30 day' AND NOW()) AS questionnaire_responses_in_progress_30d
+			, (SELECT count(*) FROM current_questionnaire_responses WHERE questionnaire_response->>'status' = 'in-progress') AS questionnaire_responses_in_progress
+			, (SELECT count(*) FROM current_questionnaire_responses WHERE questionnaire_response->>'status' = 'amended' AND (questionnaire_response->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '1 day' AND NOW()) AS questionnaire_responses_amended_24h
+			, (SELECT count(*) FROM current_questionnaire_responses WHERE questionnaire_response->>'status' = 'amended' AND (questionnaire_response->'meta'->>'lastUpdated')::timestamptz BETWEEN NOW() - INTERVAL '30 day' AND NOW()) AS questionnaire_responses_amended_30d
+			, (SELECT count(*) FROM current_questionnaire_responses WHERE questionnaire_response->>'status' = 'amended') AS questionnaire_responses_amended
+			, (SELECT count(*) FROM current_binaries) AS binaries
+			, (SELECT count(*) FROM current_document_references) AS document_references
+			, (SELECT count(*) FROM current_measure_reports WHERE measure_report->>'status' = 'complete') AS measure_reports
+			, (SELECT count(*) FROM current_measures WHERE measure->>'status' = 'active') AS measures
+			, (SELECT count(*) FROM current_libraries WHERE library->>'status' = 'active') AS libraries
+			, (SELECT pg_database_size(current_database())) AS database_size
+			, (SELECT SUM(binary_size) FROM binaries) AS binaries_size
+			""";
+
+	private final DataSource dataSource;
+
+	public StatisticsDaoJdbc(DataSource dataSource)
+	{
+		this.dataSource = dataSource;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception
+	{
+		Objects.requireNonNull(dataSource, "dataSource");
+	}
+
+	@Override
+	public Statistics getStatistics() throws SQLException
+	{
+		try (Connection connection = dataSource.getConnection();
+				PreparedStatement statement = connection.prepareStatement(QUERY);
+				ResultSet result = statement.executeQuery())
+		{
+			result.next();
+
+			long organizationsMember = result.getLong(1);
+			long organizationsParent = result.getLong(2);
+			long endpoints = result.getLong(3);
+			long organizationAffiliations = result.getLong(4);
+			long activitDefinitions = result.getLong(5);
+			long tasksDraft = result.getLong(6);
+			long tasksInProgress24h = result.getLong(7);
+			long tasksInProgress30d = result.getLong(8);
+			long tasksInProgress = result.getLong(9);
+			long tasksCompleted24h = result.getLong(10);
+			long tasksCompleted30d = result.getLong(11);
+			long tasksCompleted = result.getLong(12);
+			long tasksFailed24h = result.getLong(13);
+			long tasksFailed30d = result.getLong(14);
+			long tasksFailed = result.getLong(15);
+			long questionnaireResponsesInProgress24h = result.getLong(16);
+			long questionnaireResponsesInProgress30d = result.getLong(17);
+			long questionnaireResponsesInProgress = result.getLong(18);
+			long questionnaireResponsesAmended24h = result.getLong(19);
+			long questionnaireResponsesAmended30d = result.getLong(20);
+			long questionnaireResponsesAmended = result.getLong(21);
+			long binaries = result.getLong(22);
+			long documentReferences = result.getLong(23);
+			long measureReports = result.getLong(24);
+			long measures = result.getLong(25);
+			long libraries = result.getLong(26);
+			long databaseSize = result.getLong(27);
+			long binariesSize = result.getLong(28);
+
+			return new Statistics(organizationsMember, organizationsParent, endpoints, organizationAffiliations,
+					activitDefinitions, tasksDraft, tasksInProgress24h, tasksInProgress30d, tasksInProgress,
+					tasksCompleted24h, tasksCompleted30d, tasksCompleted, tasksFailed24h, tasksFailed30d, tasksFailed,
+					questionnaireResponsesInProgress24h, questionnaireResponsesInProgress30d,
+					questionnaireResponsesInProgress, questionnaireResponsesAmended24h,
+					questionnaireResponsesAmended30d, questionnaireResponsesAmended, binaries, documentReferences,
+					measureReports, measures, libraries, databaseSize, binariesSize);
+		}
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/AdapterConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/AdapterConfig.java
@@ -24,6 +24,7 @@ import dev.dsf.fhir.adapter.ResourceLibrary;
 import dev.dsf.fhir.adapter.ResourceMeasure;
 import dev.dsf.fhir.adapter.ResourceMeasureReport;
 import dev.dsf.fhir.adapter.ResourceNamingSystem;
+import dev.dsf.fhir.adapter.ResourceOperationOutcome;
 import dev.dsf.fhir.adapter.ResourceOrganization;
 import dev.dsf.fhir.adapter.ResourceOrganizationAffiliation;
 import dev.dsf.fhir.adapter.ResourceQuestionnaire;
@@ -61,6 +62,15 @@ public class AdapterConfig
 	@Autowired
 	private ReferenceConfig referenceConfig;
 
+	@Autowired
+	private BuildInfoReaderConfig buildInfoReaderConfig;
+
+	@Autowired
+	private DaoConfig daoConfig;
+
+	@Autowired
+	private HelperConfig helperConfig;
+
 	@Bean
 	public FhirAdapter fhirAdapter()
 	{
@@ -74,6 +84,8 @@ public class AdapterConfig
 				new ResourceBinary(propertiesConfig.getDsfServerBaseUrl()), new ResourceCodeSystem(),
 				new ResourceDocumentReference(), new ResourceEndpoint(), new ResourceLibrary(), new ResourceMeasure(),
 				new ResourceMeasureReport(propertiesConfig.getDsfServerBaseUrl()), new ResourceNamingSystem(),
+				new ResourceOperationOutcome(buildInfoReaderConfig.buildInfoReader(), daoConfig.statisticsDao(),
+						helperConfig.exceptionHandler()),
 				new ResourceOrganizationAffiliation(), new ResourceOrganization(), new ResourceQuestionnaire(),
 				new ResourceQuestionnaireResponse(), new ResourceStructureDefinition(), new ResourceSubscription(),
 				new ResourceTask(), new ResourceValueSet(),

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/DaoConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/spring/config/DaoConfig.java
@@ -33,6 +33,7 @@ import dev.dsf.fhir.dao.QuestionnaireDao;
 import dev.dsf.fhir.dao.QuestionnaireResponseDao;
 import dev.dsf.fhir.dao.ReadAccessDao;
 import dev.dsf.fhir.dao.ResearchStudyDao;
+import dev.dsf.fhir.dao.StatisticsDao;
 import dev.dsf.fhir.dao.StructureDefinitionDao;
 import dev.dsf.fhir.dao.SubscriptionDao;
 import dev.dsf.fhir.dao.TaskDao;
@@ -61,6 +62,7 @@ import dev.dsf.fhir.dao.jdbc.QuestionnaireDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.QuestionnaireResponseDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.ReadAccessDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.ResearchStudyDaoJdbc;
+import dev.dsf.fhir.dao.jdbc.StatisticsDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.StructureDefinitionDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.StructureDefinitionSnapshotDaoJdbc;
 import dev.dsf.fhir.dao.jdbc.SubscriptionDaoJdbc;
@@ -300,5 +302,11 @@ public class DaoConfig
 	public ReadAccessDao readAccessDao()
 	{
 		return new ReadAccessDaoJdbc(dataSource());
+	}
+
+	@Bean
+	public StatisticsDao statisticsDao()
+	{
+		return new StatisticsDaoJdbc(dataSource());
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/filter/BrowserPolicyHeaderResponseFilter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/filter/BrowserPolicyHeaderResponseFilter.java
@@ -30,15 +30,22 @@ public class BrowserPolicyHeaderResponseFilter implements ContainerResponseFilte
 			headers.add("Cross-Origin-Resource-Policy", "same-site");
 			headers.add("Permissions-Policy", "geolocation=(), camera=(), microphone=()");
 
-			if (requestContext.getUriInfo() != null && requestContext.getUriInfo().getPath() != null
-					&& requestContext.getUriInfo().getPath().startsWith("Binary/"))
-				headers.add("Content-Security-Policy",
-						"base-uri 'self'; frame-ancestors 'none'; form-action 'self'; default-src 'none'; connect-src 'self'; img-src 'self';"
-								+ " script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'");
-			else
-				headers.add("Content-Security-Policy",
-						"base-uri 'self'; frame-ancestors 'none'; form-action 'self'; default-src 'none'; connect-src 'self'; img-src 'self';"
-								+ " script-src 'self'; style-src 'self'");
+			// Don't send Content-Security-Policy header for non html content
+			if (!requestContext.getUriInfo().getPath().startsWith("static/")
+					|| (requestContext.getUriInfo().getPath().startsWith("static/")
+							&& (requestContext.getUriInfo().getPath().endsWith(".html")
+									|| requestContext.getUriInfo().getPath().endsWith(".htm"))))
+			{
+				if (requestContext.getUriInfo() != null && requestContext.getUriInfo().getPath() != null
+						&& requestContext.getUriInfo().getPath().startsWith("Binary/"))
+					headers.add("Content-Security-Policy",
+							"base-uri 'self'; frame-ancestors 'none'; form-action 'self'; default-src 'none'; connect-src 'self'; img-src 'self';"
+									+ " script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'");
+				else
+					headers.add("Content-Security-Policy",
+							"base-uri 'self'; frame-ancestors 'none'; form-action 'self'; default-src 'none'; connect-src 'self'; img-src 'self';"
+									+ " script-src 'self'; style-src 'self'");
+			}
 		}
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/RootServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/webservice/impl/RootServiceImpl.java
@@ -25,6 +25,8 @@ import jakarta.ws.rs.core.UriInfo;
 
 public class RootServiceImpl extends AbstractBasicService implements RootService, InitializingBean
 {
+	public static final String ROOT_GET = RootServiceImpl.class.getCanonicalName() + ".get";
+
 	private final CommandFactory commandFactory;
 	private final ResponseGenerator responseGenerator;
 	private final ParameterConverter parameterConverter;
@@ -60,6 +62,8 @@ public class RootServiceImpl extends AbstractBasicService implements RootService
 	{
 		OperationOutcome outcome = responseGenerator.createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
 				"This is the base URL of the FHIR server. GET method not allowed, use POST to execute batch and transaction Bundle resources");
+		outcome.setUserData(ROOT_GET, true);
+
 		return responseGenerator
 				.response(Status.METHOD_NOT_ALLOWED, outcome,
 						parameterConverter.getMediaTypeThrowIfNotSupported(uri, headers))

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/db/db.binaries.changelog-2.0.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/db/db.binaries.changelog-2.0.0.xml
@@ -55,9 +55,9 @@
 
 	<changeSet author="retwet" id="db.binaries.changelog-2.0.0.recreate-current_binaries-and-dependent-views">
 		<createView viewName="current_binaries" replaceIfExists="true">
-			SELECT binary_id, version, binary_json, binary_oid
+			SELECT binary_id, version, binary_json, binary_oid, binary_size
 			FROM (
-			SELECT DISTINCT ON (binary_id) binary_id, version, deleted, binary_json, binary_oid
+			SELECT DISTINCT ON (binary_id) binary_id, version, deleted, binary_json, binary_oid, binary_size
 			FROM binaries ORDER BY binary_id, version DESC
 			) AS current_b
 			WHERE deleted IS NULL

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/dsf.css
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/dsf.css
@@ -160,7 +160,7 @@ body {
 	text-decoration: none;
 }
 
-#url h1 a:hover {
+#url a:hover {
 	text-decoration: underline;
 }
 
@@ -207,15 +207,6 @@ pre.lang-html {
 	border: 0;
 	font-family: monospace;
 }
-
-/*
-#icons {
-	position: absolute;
-	top: 2em;
-	right: 2em;
-	display: flex;
-	column-gap: 0.25em;
-}*/
 
 #hello-user {
 	margin-right: 0.5em;
@@ -377,52 +368,52 @@ pre.lang-html {
 	color: var(--color-prime);
 }
 
-.bundle>#header>table {
+.bundle #bundle-header table {
 	width: 100%
 }
 
-.bundle>#header>table td:nth-child(2) {
+.bundle #bundle-header table td:nth-child(2) {
 	text-align: center;
 	vertical-align: top;
 }
 
-.bundle>#header>table td:nth-child(3) {
+.bundle #bundle-header table td:nth-child(3) {
 	text-align: right;
 }
 
-.bundle>#header #resources {
+.bundle #bundle-header #resources {
 	padding-right: 1em;
 	color: #aaa
 }
 
-.bundle>#header #page {
+.bundle #bundle-header #page {
 	padding-left: 1em;
 	color: #aaa
 }
 
-.bundle>#list {
+.bundle #bundle-list {
 	overflow-x: auto;
 }
 
-.bundle>#list>table {
+.bundle>#bundle-list>table {
 	border-collapse: separate;
 	border-spacing: 0 1rem;
 	width: 100%
 }
 
-.bundle>#list>table tr:not(:first-child) {
+.bundle>#bundle-list>table tr:not(:first-child) {
 	cursor: pointer;
 }
 
-.bundle>#list>table th:first-child {
+.bundle>#bundle-list>table th:first-child {
 	border-left: 0.5rem solid var(--color-row-background-deep);
 }
 
-.bundle>#list>table td:first-child {
+.bundle>#bundle-list>table td:first-child {
 	border-left: 0.5rem solid var(--color-row-background);
 }
 
-.bundle>#list>table th {
+.bundle>#bundle-list>table th {
 	color: var(--color-prime);
 	background-color: var(--color-row-background-deep);
 	padding: 1rem 0 1rem 1rem;
@@ -430,164 +421,164 @@ pre.lang-html {
 	text-align: left;
 }
 
-.bundle>#list>table td {
+.bundle>#bundle-list>table td {
 	background-color: var(--color-row-background);
 	padding: 1rem 0 1rem 1rem;
 	white-space: nowrap;
 	text-align: left;
 }
 
-.bundle>#list>table tr:hover td {
+.bundle>#bundle-list>table tr:hover td {
 	background-color: var(--color-row-background-hover);
 }
 
-.bundle>#list>table th:last-child {
+.bundle>#bundle-list>table th:last-child {
 	padding-right: 1rem;
 }
 
-.bundle>#list>table td:last-child {
+.bundle>#bundle-list>table td:last-child {
 	padding-right: 1rem;
 }
 
-.bundle>#list>table tr[resource-type="ActivityDefinition"] td[status="draft"],
-.bundle>#list>table tr[resource-type="CodeSystem"] td[status="draft"],
-.bundle>#list>table tr[resource-type="Library"] td[status="draft"],
-.bundle>#list>table tr[resource-type="Measure"] td[status="draft"],
-.bundle>#list>table tr[resource-type="NamingSystem"] td[status="draft"],
-.bundle>#list>table tr[resource-type="Questionnaire"] td[status="draft"],
-.bundle>#list>table tr[resource-type="StructureDefinition"] td[status="draft"],
-.bundle>#list>table tr[resource-type="ValueSet"] td[status="draft"] {
+.bundle>#bundle-list>table tr[resource-type="ActivityDefinition"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="CodeSystem"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="Library"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="Measure"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="NamingSystem"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="Questionnaire"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="StructureDefinition"] td[status="draft"],
+.bundle>#bundle-list>table tr[resource-type="ValueSet"] td[status="draft"] {
 	border-left-color: var(--color-row-border-blue);
 }
 
-.bundle>#list>table tr[resource-type="ActivityDefinition"] td[status="active"],
-.bundle>#list>table tr[resource-type="CodeSystem"] td[status="active"],
-.bundle>#list>table tr[resource-type="Library"] td[status="active"],
-.bundle>#list>table tr[resource-type="Measure"] td[status="active"],
-.bundle>#list>table tr[resource-type="NamingSystem"] td[status="active"],
-.bundle>#list>table tr[resource-type="Questionnaire"] td[status="active"],
-.bundle>#list>table tr[resource-type="StructureDefinition"] td[status="active"],
-.bundle>#list>table tr[resource-type="ValueSet"] td[status="active"] {
+.bundle>#bundle-list>table tr[resource-type="ActivityDefinition"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="CodeSystem"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="Library"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="Measure"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="NamingSystem"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="Questionnaire"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="StructureDefinition"] td[status="active"],
+.bundle>#bundle-list>table tr[resource-type="ValueSet"] td[status="active"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="ActivityDefinition"] td[status="retired"],
-.bundle>#list>table tr[resource-type="CodeSystem"] td[status="retired"],
-.bundle>#list>table tr[resource-type="Library"] td[status="retired"],
-.bundle>#list>table tr[resource-type="Measure"] td[status="retired"],
-.bundle>#list>table tr[resource-type="NamingSystem"] td[status="retired"],
-.bundle>#list>table tr[resource-type="Questionnaire"] td[status="retired"],
-.bundle>#list>table tr[resource-type="StructureDefinition"] td[status="retired"],
-.bundle>#list>table tr[resource-type="ValueSet"] td[status="retired"] {
+.bundle>#bundle-list>table tr[resource-type="ActivityDefinition"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="CodeSystem"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="Library"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="Measure"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="NamingSystem"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="Questionnaire"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="StructureDefinition"] td[status="retired"],
+.bundle>#bundle-list>table tr[resource-type="ValueSet"] td[status="retired"] {
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="DocumentReference"] td[status="current"] {
+.bundle>#bundle-list>table tr[resource-type="DocumentReference"] td[status="current"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="DocumentReference"] td[status="superseded"] {
+.bundle>#bundle-list>table tr[resource-type="DocumentReference"] td[status="superseded"] {
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="DocumentReference"] td[status="entered-in-error"] {
+.bundle>#bundle-list>table tr[resource-type="DocumentReference"] td[status="entered-in-error"] {
 	border-left-color: var(--color-row-border-red);
 }
 
-.bundle>#list>table tr[resource-type="Endpoint"] td[status="active"] {
+.bundle>#bundle-list>table tr[resource-type="Endpoint"] td[status="active"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="Endpoint"] td[status="off"],
-.bundle>#list>table tr[resource-type="Endpoint"] td[status="suspended"]	{
+.bundle>#bundle-list>table tr[resource-type="Endpoint"] td[status="off"],
+.bundle>#bundle-list>table tr[resource-type="Endpoint"] td[status="suspended"]	{
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="Endpoint"] td[status="error"],
-.bundle>#list>table tr[resource-type="Endpoint"] td[status="entered-in-error"] {
+.bundle>#bundle-list>table tr[resource-type="Endpoint"] td[status="error"],
+.bundle>#bundle-list>table tr[resource-type="Endpoint"] td[status="entered-in-error"] {
 	border-left-color: var(--color-row-border-red);
 }
 
-.bundle>#list>table tr[resource-type="Endpoint"] td[status="test"] {
+.bundle>#bundle-list>table tr[resource-type="Endpoint"] td[status="test"] {
 	border-left-color: var(--color-row-border-blue);
 }
 
-.bundle>#list>table tr[resource-type="MeasureReport"] td[status="complete"] {
+.bundle>#bundle-list>table tr[resource-type="MeasureReport"] td[status="complete"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="MeasureReport"] td[status="pending"] {
+.bundle>#bundle-list>table tr[resource-type="MeasureReport"] td[status="pending"] {
 	border-left-color: var(--color-row-border-orange);
 }
 
-.bundle>#list>table tr[resource-type="MeasureReport"] td[status="error"] {
+.bundle>#bundle-list>table tr[resource-type="MeasureReport"] td[status="error"] {
 	border-left-color: var(--color-row-border-red);
 }
 
-.bundle>#list>table tr[resource-type="Organization"] td[active="true"],
-.bundle>#list>table tr[resource-type="OrganizationAffiliation"] td[active="true"] {
+.bundle>#bundle-list>table tr[resource-type="Organization"] td[active="true"],
+.bundle>#bundle-list>table tr[resource-type="OrganizationAffiliation"] td[active="true"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="Organization"] td[active="false"],
-.bundle>#list>table tr[resource-type="OrganizationAffiliation"] td[active="false"] {
+.bundle>#bundle-list>table tr[resource-type="Organization"] td[active="false"],
+.bundle>#bundle-list>table tr[resource-type="OrganizationAffiliation"] td[active="false"] {
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="QuestionnaireResponse"] td[status="in-progress"] {
+.bundle>#bundle-list>table tr[resource-type="QuestionnaireResponse"] td[status="in-progress"] {
 	border-left-color: var(--color-row-border-orange);
 }
 
-.bundle>#list>table tr[resource-type="QuestionnaireResponse"] td[status="completed"] {
+.bundle>#bundle-list>table tr[resource-type="QuestionnaireResponse"] td[status="completed"] {
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="QuestionnaireResponse"] td[status="amended"] {
+.bundle>#bundle-list>table tr[resource-type="QuestionnaireResponse"] td[status="amended"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="QuestionnaireResponse"] td[status="entered-in-error"],
-.bundle>#list>table tr[resource-type="QuestionnaireResponse"] td[status="stopped"] {
+.bundle>#bundle-list>table tr[resource-type="QuestionnaireResponse"] td[status="entered-in-error"],
+.bundle>#bundle-list>table tr[resource-type="QuestionnaireResponse"] td[status="stopped"] {
 	border-left-color: var(--color-row-border-red);
 }
 
-.bundle>#list>table tr[resource-type="Subscription"] td[status="requested"] {
+.bundle>#bundle-list>table tr[resource-type="Subscription"] td[status="requested"] {
 	border-left-color: var(--color-row-border-blue);
 }
 
-.bundle>#list>table tr[resource-type="Subscription"] td[status="active"] {
+.bundle>#bundle-list>table tr[resource-type="Subscription"] td[status="active"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="Subscription"] td[status="error"] {
+.bundle>#bundle-list>table tr[resource-type="Subscription"] td[status="error"] {
 	border-left-color: var(--color-row-border-red);
 }
 
-.bundle>#list>table tr[resource-type="Subscription"] td[status="off"] {
+.bundle>#bundle-list>table tr[resource-type="Subscription"] td[status="off"] {
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="Task"] td[status="draft"] {
+.bundle>#bundle-list>table tr[resource-type="Task"] td[status="draft"] {
 	border-left-color: var(--color-row-border-blue);
 }
 
-.bundle>#list>table tr[resource-type="Task"] td[status="requested"] {
+.bundle>#bundle-list>table tr[resource-type="Task"] td[status="requested"] {
 	border-left-color: var(--color-row-border-grey);
 }
 
-.bundle>#list>table tr[resource-type="Task"] td[status="in-progress"] {
+.bundle>#bundle-list>table tr[resource-type="Task"] td[status="in-progress"] {
 	border-left-color: var(--color-row-border-orange);
 }
 
-.bundle>#list>table tr[resource-type="Task"] td[status="completed"] {
+.bundle>#bundle-list>table tr[resource-type="Task"] td[status="completed"] {
 	border-left-color: var(--color-row-border-green);
 }
 
-.bundle>#list>table tr[resource-type="Task"] td[status="failed"] {
+.bundle>#bundle-list>table tr[resource-type="Task"] td[status="failed"] {
 	border-left-color: var(--color-row-border-red);
 }
 
-.bundle>#list>table td.id-value {
+.bundle>#bundle-list>table td.id-value {
 	font-family: monospace;
 }
 
@@ -602,14 +593,14 @@ pre.lang-html {
 	text-decoration: underline;
 }
 
-.bundle>#list>table td:first-child,
-.bundle>#list>table th:first-child {
+.bundle>#bundle-list>table td:first-child,
+.bundle>#bundle-list>table th:first-child {
 	border-top-left-radius: 5px;
 	border-bottom-left-radius: 5px;
 }
 
-.bundle>#list>table td:last-child,
-.bundle>#list>table th:last-child {
+.bundle>#bundle-list>table td:last-child,
+.bundle>#bundle-list>table th:last-child {
 	border-top-right-radius: 5px;
 	border-bottom-right-radius: 5px;
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/dsf.css
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/dsf.css
@@ -98,40 +98,69 @@ body {
 	background-color: var(--color-background);
 }
 
-table#header {
-	margin-bottom: 0.4em;
+#header {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto auto;
+	margin-bottom: 1em;
 }
 
-table#header img {
-	height: 7em;
-	padding-bottom: 0.38em;
-	display: block;
+#logo {
+	grid-row: 1 / span 2;
+	margin-bottom: 0.41em;
 }
 
-td#url {
-	vertical-align: bottom;
+#icons {
+	grid-column: 2;
+  	grid-row: 1;
+	display: flex;
+	column-gap: 0.25em;
+	justify-self: right;
 }
 
-td#url h1 {
+#url {
+	grid-column: 2;
+	grid-row: 2;
 	font-size: 2em;
 	font-family: monospace;
 	color: var(--color-prime);
+	align-self: end;
 	margin: 0 0 0 1em;
 	word-break: break-word;
 }
 
-td#url h1 a {
-	white-space: nowrap;
+@media ( max-width: 64rem) {
+	#header {
+		grid-template-columns: 1fr;
+		grid-template-rows: auto auto auto;
+		height: auto;
+	}
+	#icons {
+		grid-column: 1;
+		grid-row: 1;
+		margin: 0 0 1em 0;
+	}
+	#logo {
+		grid-column: 1;
+		grid-row: 2;
+		margin: 0;
+		height: 14vw;
+	}
+	#url {
+		grid-column: 1;
+		grid-row: 3;
+		margin: 1em 0 0 0;
+	}
 }
 
-td#url h1 a:link,
-td#url h1 a:visited,
-td#url h1 a:active {
+#url a:link,
+#url a:visited,
+#url a:active {
 	color: var(--color-prime);
 	text-decoration: none;
 }
 
-td#url h1 a:hover {
+#url h1 a:hover {
 	text-decoration: underline;
 }
 
@@ -179,13 +208,14 @@ pre.lang-html {
 	font-family: monospace;
 }
 
+/*
 #icons {
 	position: absolute;
 	top: 2em;
 	right: 2em;
 	display: flex;
 	column-gap: 0.25em;
-}
+}*/
 
 #hello-user {
 	margin-right: 0.5em;
@@ -1086,6 +1116,82 @@ pre.lang-html {
 #resource .element-sub1-50 {
 	background-color: var(--color-row-background-deep);
 	width: calc(50% - 2.5em);
+}
+
+#root {
+	border: 1px solid #ccc;
+	padding: 20px;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(17.2rem, 1fr));
+	gap: 20px;
+	margin: 0 auto;
+}
+
+#root .element {
+	border-radius: 0.4em;
+	aspect-ratio: 2.8 / 1;
+	padding: 0.5rem;
+	display: grid;
+	grid-template-columns: auto 1fr;
+  	grid-template-rows: auto auto 1fr;
+	background-color: var(--color-info-background-grey);
+	color: var(--color-info-grey);
+}
+
+#root a {
+	text-decoration: none;
+}
+
+#root .element[resource-type="Task"][status="draft"] {
+	background-color: var(--color-info-background-blue);
+	color: var(--color-info-blue);
+}
+
+#root .element[resource-type="Endpoint"][status="active"],
+#root .element[resource-type="Organization"][active="true"],
+#root .element[resource-type="OrganizationAffiliation"][active="true"],
+#root .element[resource-type="QuestionnaireResponse"][status="amended"],
+#root .element[resource-type="Task"][status="completed"] {
+	background-color: var(--color-info-background-green);
+	color: var(--color-info-green);
+}
+
+#root .element[resource-type="QuestionnaireResponse"][status="in-progress"],
+#root .element[resource-type="Task"][status="in-progress"] {
+	background-color: var(--color-info-background-orange);
+	color: var(--color-info-orange);
+}
+
+#root .element[resource-type="Task"][status="failed"] {
+	background-color: var(--color-info-background-red);
+	color: var(--color-info-red);
+}
+
+#root .element h1 {
+	font-size: 1.2rem;
+	font-weight: bold;
+	margin: 0 0 0.2em 0;
+	grid-column: 1 / span 2;
+}
+
+#root .element h2 {
+	font-size: 1rem;
+	font-weight: normal;
+	margin: 0;
+	grid-column: 1 / span 2;
+}
+
+#root .element .unit {
+	font-size: 1rem;
+	margin: 0.2em 0 0 0;
+	align-self: end;
+}
+
+#root .element .value {
+	font-size: 1.5rem;
+	margin: 0.2em 0 0 0;
+	align-self: end;
+	text-align: right;
 }
 
 .meta {

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/main.js
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/main.js
@@ -45,7 +45,7 @@ window.addEventListener('DOMContentLoaded', () => {
 	if (resourceType != null && resourceType[1] && resourceType[2] === undefined && resourceType[3] === undefined && resourceType[4] === undefined) {
 
 		// search bundle rows
-		document.querySelectorAll('div#html > div.bundle > div#list td.id-value:first-child').forEach(td => {
+		document.querySelectorAll('div#html > div.bundle > div#bundle-list td.id-value:first-child').forEach(td => {
 			if (td?.firstChild?.href) {
 				td.parentElement.addEventListener('click', event => {
 					if (event.target?.tagName?.toLowerCase() !== 'a')

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/main.js
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/static/main.js
@@ -67,8 +67,10 @@ window.addEventListener('DOMContentLoaded', () => {
 					if (input?.placeholder !== '') {
 						if (input.type === 'radio')
 							input.checked = input.placeholder === 'true'
-						else
+						else {
 							input.value = input.placeholder
+							input.focus()
+						}
 					}
 				})
 			})
@@ -103,8 +105,10 @@ window.addEventListener('DOMContentLoaded', () => {
 					if (input?.placeholder !== '') {
 						if (input.type === 'radio')
 							input.checked = input.placeholder === 'true'
-						else
+						else {
 							input.value = input.placeholder
+							input.focus()
+						}
 					}
 				})
 			})

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/main.html
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/main.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:attr="theme=${theme}" lang="en">
 <head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#326F95">
 <base th:href="(${basePath} + '/')" href="/">
 <link rel="icon" type="image/svg+xml" href="static/favicon.svg">
 <link rel="icon" type="image/png" href="static/favicon_32x32.png" sizes="32x32">
 <link rel="icon" type="image/png" href="static/favicon_96x96.png" sizes="96x96">
-<meta name="theme-color" content="#326F95">
-<meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="static/main.js"></script>
 <script src="static/util.js"></script>
 <script src="static/prettify.js"></script>
@@ -21,18 +22,6 @@
 <title th:text="${title}">DSF</title>
 </head>
 <body>
-	<!--
-	<div id="icons">
-		<span id="hello-user" th:if="${username}" th:title="${usernameTitle}">Hello, [[${username}]]</span><a href="logout" th:if="${openid}"><svg class="icon" id="logout-icon" viewBox="0 0 24 24"><title>Logout</title><path d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h7v2Zm11-4-1.375-1.45 2.55-2.55H9v-2h8.175l-2.55-2.55L16 7l5 5Z" /></svg></a>
-		<svg class="icon" id="help-icon" viewBox="0 0 24 24"><title>Show Help</title><path d="M11.07,12.85c0.77-1.39,2.25-2.21,3.11-3.44c0.91-1.29,0.4-3.7-2.18-3.7c-1.69,0-2.52,1.28-2.87,2.34L6.54,6.96 C7.25,4.83,9.18,3,11.99,3c2.35,0,3.96,1.07,4.78,2.41c0.7,1.15,1.11,3.3,0.03,4.9c-1.2,1.77-2.35,2.31-2.97,3.45 c-0.25,0.46-0.35,0.76-0.35,2.24h-2.89C10.58,15.22,10.46,13.95,11.07,12.85z M14,20c0,1.1-0.9,2-2,2s-2-0.9-2-2c0-1.1,0.9-2,2-2 S14,18.9,14,20z" /></svg>
-		<svg class="icon" id="light-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Light Mode</title><path d="M479.765-340Q538-340 579-380.765q41-40.764 41-99Q620-538 579.235-579q-40.764-41-99-41Q422-620 381-579.235q-41 40.764-41 99Q340-422 380.765-381q40.764 41 99 41Zm.235 60q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM70-450q-12.75 0-21.375-8.675Q40-467.351 40-480.175 40-493 48.625-501.5T70-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T170-450H70Zm720 0q-12.75 0-21.375-8.675-8.625-8.676-8.625-21.5 0-12.825 8.625-21.325T790-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T890-450H790ZM479.825-760Q467-760 458.5-768.625T450-790v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-890v100q0 12.75-8.675 21.375-8.676 8.625-21.5 8.625Zm0 720Q467-40 458.5-48.625T450-70v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-170v100q0 12.75-8.675 21.375Q492.649-40 479.825-40ZM240-678l-57-56q-9-9-8.629-21.603.37-12.604 8.526-21.5 8.896-8.897 21.5-8.897Q217-786 226-777l56 57q8 9 8 21t-8 20.5q-8 8.5-20.5 8.5t-21.5-8Zm494 495-56-57q-8-9-8-21.375T678.5-282q8.5-9 20.5-9t21 9l57 56q9 9 8.629 21.603-.37 12.604-8.526 21.5-8.896 8.897-21.5 8.897Q743-174 734-183Zm-56-495q-9-9-9-21t9-21l56-57q9-9 21.603-8.629 12.604.37 21.5 8.526 8.897 8.896 8.897 21.5Q786-743 777-734l-57 56q-8 8-20.364 8-12.363 0-21.636-8ZM182.897-182.897q-8.897-8.896-8.897-21.5Q174-217 183-226l57-56q8.8-9 20.9-9 12.1 0 20.709 9Q291-273 291-261t-9 21l-56 57q-9 9-21.603 8.629-12.604-.37-21.5-8.526ZM480-480Z" /></svg>
-		<svg class="icon" id="dark-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Dark Mode</title><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q8 0 17 .5t23 1.5q-36 32-56 79t-20 99q0 90 63 153t153 63q52 0 99-18.5t79-51.5q1 12 1.5 19.5t.5 14.5q0 150-105 255T480-120Zm0-60q109 0 190-67.5T771-406q-25 11-53.667 16.5Q688.667-384 660-384q-114.689 0-195.345-80.655Q384-545.311 384-660q0-24 5-51.5t18-62.5q-98 27-162.5 109.5T180-480q0 125 87.5 212.5T480-180Zm-4-297Z" /></svg>
-		<a href="" download="" id="download-link" title=""><svg class="icon" id="download" viewBox="0 0 24 24"><path d="M18,15v3H6v-3H4v3c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2v-3H18z M17,11l-1.41-1.41L13,12.17V4h-2v8.17L8.41,9.59L7,11l5,5 L17,11z" /></svg></a>
-		<svg class="icon" id="bookmark-add" viewBox="0 0 24 24"><title>Add Bookmark</title><path d="M17,11v6.97l-5-2.14l-5,2.14V5h6V3H7C5.9,3,5,3.9,5,5v16l7-3l7,3V11H17z M21,7h-2v2h-2V7h-2V5h2V3h2v2h2V7z" /></svg>
-		<svg class="icon" id="bookmark-remove" viewBox="0 0 24 24"><title>Remove Bookmark</title><path d="M17,11v6.97l-5-2.14l-5,2.14V5h6V3H7C5.9,3,5,3.9,5,5v16l7-3l7,3V11H17z M21,7h-6V5h6V7z" /></svg>
-		<svg class="icon" id="bookmark-list" viewBox="0 0 24 24"><title>Show Bookmarks</title><path d="M9,1H19A2,2 0 0,1 21,3V19L19,18.13V3H7A2,2 0 0,1 9,1M15,20V7H5V20L10,17.82L15,20M15,5C16.11,5 17,5.9 17,7V23L10,20L3,23V7A2,2 0 0,1 5,5H15Z" /></svg>
-	</div>
-	-->
 	<div id="help">
 		<h3 id="help-title">Query Parameters</h3>
 		<svg class="icon" id="help-close" viewBox="0 0 24 24"><title>Close Help</title><path fill="currentColor" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
@@ -43,14 +32,6 @@
 		<svg class="icon" id="bookmark-list-close" viewBox="0 0 24 24"><title>Close Bookmarks</title><path fill="currentColor" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
 		<div id="bookmarks-list"></div>
 	</div>
-	<!-- <table id="header">
-		<tr>
-			<td><image src="static/logo.svg"></td>
-			<td id="url">
-				<h1 th:utext="${heading}"></h1>
-			</td>
-		</tr>
-	</table>-->
 	<div id="header">
 		<div id="icons">
 			<span id="hello-user" th:if="${username}" th:title="${usernameTitle}">Hello, [[${username}]]</span><a href="logout" th:if="${openid}"><svg class="icon" id="logout-icon" viewBox="0 0 24 24"><title>Logout</title><path d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h7v2Zm11-4-1.375-1.45 2.55-2.55H9v-2h8.175l-2.55-2.55L16 7l5 5Z" /></svg></a>
@@ -62,13 +43,13 @@
 			<svg class="icon" id="bookmark-remove" viewBox="0 0 24 24"><title>Remove Bookmark</title><path d="M17,11v6.97l-5-2.14l-5,2.14V5h6V3H7C5.9,3,5,3.9,5,5v16l7-3l7,3V11H17z M21,7h-6V5h6V7z" /></svg>
 			<svg class="icon" id="bookmark-list" viewBox="0 0 24 24"><title>Show Bookmarks</title><path d="M9,1H19A2,2 0 0,1 21,3V19L19,18.13V3H7A2,2 0 0,1 9,1M15,20V7H5V20L10,17.82L15,20M15,5C16.11,5 17,5.9 17,7V23L10,20L3,23V7A2,2 0 0,1 5,5H15Z" /></svg>
 		</div>
-		<image id="logo" src="static/logo.svg">
+		<img id="logo" src="static/logo.svg" title="Logo">
 		<h1 id="url" th:utext="${heading}"></h1>
 	</div>
 	<div class="tab">
-		<button id="html-button" class="tablinks" th:if="${htmlFragment}" accesskey="h" title="Show HTML [h]">html</button>
-		<button id="json-button" class="tablinks" accesskey="j" title="Show JSON [j]">json</button>
-		<button id="xml-button" class="tablinks" accesskey="x" title="Show XML [x]">xml</button>
+		<button id="html-button" class="tablinks" type="button" th:if="${htmlFragment}" accesskey="h" title="Show HTML [h]">html</button>
+		<button id="json-button" class="tablinks" type="button" accesskey="j" title="Show JSON [j]">json</button>
+		<button id="xml-button" class="tablinks" type="button" accesskey="x" title="Show XML [x]">xml</button>
 	</div>
 	<pre id="xml" class="prettyprint linenums lang-xml" th:utext="${xml}"></pre>
 	<pre id="json" class="prettyprint linenums lang-json" th:utext="${json}"></pre>

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/main.html
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/main.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:attr="theme=${theme}">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="theme=${theme}" lang="en">
 <head>
 <base th:href="(${basePath} + '/')" href="/">
 <link rel="icon" type="image/svg+xml" href="static/favicon.svg">
 <link rel="icon" type="image/png" href="static/favicon_32x32.png" sizes="32x32">
 <link rel="icon" type="image/png" href="static/favicon_96x96.png" sizes="96x96">
 <meta name="theme-color" content="#326F95">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="static/main.js"></script>
 <script src="static/util.js"></script>
 <script src="static/prettify.js"></script>
@@ -20,6 +21,7 @@
 <title th:text="${title}">DSF</title>
 </head>
 <body>
+	<!--
 	<div id="icons">
 		<span id="hello-user" th:if="${username}" th:title="${usernameTitle}">Hello, [[${username}]]</span><a href="logout" th:if="${openid}"><svg class="icon" id="logout-icon" viewBox="0 0 24 24"><title>Logout</title><path d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h7v2Zm11-4-1.375-1.45 2.55-2.55H9v-2h8.175l-2.55-2.55L16 7l5 5Z" /></svg></a>
 		<svg class="icon" id="help-icon" viewBox="0 0 24 24"><title>Show Help</title><path d="M11.07,12.85c0.77-1.39,2.25-2.21,3.11-3.44c0.91-1.29,0.4-3.7-2.18-3.7c-1.69,0-2.52,1.28-2.87,2.34L6.54,6.96 C7.25,4.83,9.18,3,11.99,3c2.35,0,3.96,1.07,4.78,2.41c0.7,1.15,1.11,3.3,0.03,4.9c-1.2,1.77-2.35,2.31-2.97,3.45 c-0.25,0.46-0.35,0.76-0.35,2.24h-2.89C10.58,15.22,10.46,13.95,11.07,12.85z M14,20c0,1.1-0.9,2-2,2s-2-0.9-2-2c0-1.1,0.9-2,2-2 S14,18.9,14,20z" /></svg>
@@ -30,6 +32,7 @@
 		<svg class="icon" id="bookmark-remove" viewBox="0 0 24 24"><title>Remove Bookmark</title><path d="M17,11v6.97l-5-2.14l-5,2.14V5h6V3H7C5.9,3,5,3.9,5,5v16l7-3l7,3V11H17z M21,7h-6V5h6V7z" /></svg>
 		<svg class="icon" id="bookmark-list" viewBox="0 0 24 24"><title>Show Bookmarks</title><path d="M9,1H19A2,2 0 0,1 21,3V19L19,18.13V3H7A2,2 0 0,1 9,1M15,20V7H5V20L10,17.82L15,20M15,5C16.11,5 17,5.9 17,7V23L10,20L3,23V7A2,2 0 0,1 5,5H15Z" /></svg>
 	</div>
+	-->
 	<div id="help">
 		<h3 id="help-title">Query Parameters</h3>
 		<svg class="icon" id="help-close" viewBox="0 0 24 24"><title>Close Help</title><path fill="currentColor" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
@@ -40,14 +43,28 @@
 		<svg class="icon" id="bookmark-list-close" viewBox="0 0 24 24"><title>Close Bookmarks</title><path fill="currentColor" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
 		<div id="bookmarks-list"></div>
 	</div>
-	<table id="header">
+	<!-- <table id="header">
 		<tr>
 			<td><image src="static/logo.svg"></td>
 			<td id="url">
 				<h1 th:utext="${heading}"></h1>
 			</td>
 		</tr>
-	</table>
+	</table>-->
+	<div id="header">
+		<div id="icons">
+			<span id="hello-user" th:if="${username}" th:title="${usernameTitle}">Hello, [[${username}]]</span><a href="logout" th:if="${openid}"><svg class="icon" id="logout-icon" viewBox="0 0 24 24"><title>Logout</title><path d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h7v2Zm11-4-1.375-1.45 2.55-2.55H9v-2h8.175l-2.55-2.55L16 7l5 5Z" /></svg></a>
+			<svg class="icon" id="help-icon" viewBox="0 0 24 24"><title>Show Help</title><path d="M11.07,12.85c0.77-1.39,2.25-2.21,3.11-3.44c0.91-1.29,0.4-3.7-2.18-3.7c-1.69,0-2.52,1.28-2.87,2.34L6.54,6.96 C7.25,4.83,9.18,3,11.99,3c2.35,0,3.96,1.07,4.78,2.41c0.7,1.15,1.11,3.3,0.03,4.9c-1.2,1.77-2.35,2.31-2.97,3.45 c-0.25,0.46-0.35,0.76-0.35,2.24h-2.89C10.58,15.22,10.46,13.95,11.07,12.85z M14,20c0,1.1-0.9,2-2,2s-2-0.9-2-2c0-1.1,0.9-2,2-2 S14,18.9,14,20z" /></svg>
+			<svg class="icon" id="light-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Light Mode</title><path d="M479.765-340Q538-340 579-380.765q41-40.764 41-99Q620-538 579.235-579q-40.764-41-99-41Q422-620 381-579.235q-41 40.764-41 99Q340-422 380.765-381q40.764 41 99 41Zm.235 60q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM70-450q-12.75 0-21.375-8.675Q40-467.351 40-480.175 40-493 48.625-501.5T70-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T170-450H70Zm720 0q-12.75 0-21.375-8.675-8.625-8.676-8.625-21.5 0-12.825 8.625-21.325T790-510h100q12.75 0 21.375 8.675 8.625 8.676 8.625 21.5 0 12.825-8.625 21.325T890-450H790ZM479.825-760Q467-760 458.5-768.625T450-790v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-890v100q0 12.75-8.675 21.375-8.676 8.625-21.5 8.625Zm0 720Q467-40 458.5-48.625T450-70v-100q0-12.75 8.675-21.375 8.676-8.625 21.5-8.625 12.825 0 21.325 8.625T510-170v100q0 12.75-8.675 21.375Q492.649-40 479.825-40ZM240-678l-57-56q-9-9-8.629-21.603.37-12.604 8.526-21.5 8.896-8.897 21.5-8.897Q217-786 226-777l56 57q8 9 8 21t-8 20.5q-8 8.5-20.5 8.5t-21.5-8Zm494 495-56-57q-8-9-8-21.375T678.5-282q8.5-9 20.5-9t21 9l57 56q9 9 8.629 21.603-.37 12.604-8.526 21.5-8.896 8.897-21.5 8.897Q743-174 734-183Zm-56-495q-9-9-9-21t9-21l56-57q9-9 21.603-8.629 12.604.37 21.5 8.526 8.897 8.896 8.897 21.5Q786-743 777-734l-57 56q-8 8-20.364 8-12.363 0-21.636-8ZM182.897-182.897q-8.897-8.896-8.897-21.5Q174-217 183-226l57-56q8.8-9 20.9-9 12.1 0 20.709 9Q291-273 291-261t-9 21l-56 57q-9 9-21.603 8.629-12.604-.37-21.5-8.526ZM480-480Z" /></svg>
+			<svg class="icon" id="dark-mode" height="24" viewBox="0 -960 960 960" width="24"><title>Enable Dark Mode</title><path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q8 0 17 .5t23 1.5q-36 32-56 79t-20 99q0 90 63 153t153 63q52 0 99-18.5t79-51.5q1 12 1.5 19.5t.5 14.5q0 150-105 255T480-120Zm0-60q109 0 190-67.5T771-406q-25 11-53.667 16.5Q688.667-384 660-384q-114.689 0-195.345-80.655Q384-545.311 384-660q0-24 5-51.5t18-62.5q-98 27-162.5 109.5T180-480q0 125 87.5 212.5T480-180Zm-4-297Z" /></svg>
+			<a href="" download="" id="download-link" title=""><svg class="icon" id="download" viewBox="0 0 24 24"><path d="M18,15v3H6v-3H4v3c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2v-3H18z M17,11l-1.41-1.41L13,12.17V4h-2v8.17L8.41,9.59L7,11l5,5 L17,11z" /></svg></a>
+			<svg class="icon" id="bookmark-add" viewBox="0 0 24 24"><title>Add Bookmark</title><path d="M17,11v6.97l-5-2.14l-5,2.14V5h6V3H7C5.9,3,5,3.9,5,5v16l7-3l7,3V11H17z M21,7h-2v2h-2V7h-2V5h2V3h2v2h2V7z" /></svg>
+			<svg class="icon" id="bookmark-remove" viewBox="0 0 24 24"><title>Remove Bookmark</title><path d="M17,11v6.97l-5-2.14l-5,2.14V5h6V3H7C5.9,3,5,3.9,5,5v16l7-3l7,3V11H17z M21,7h-6V5h6V7z" /></svg>
+			<svg class="icon" id="bookmark-list" viewBox="0 0 24 24"><title>Show Bookmarks</title><path d="M9,1H19A2,2 0 0,1 21,3V19L19,18.13V3H7A2,2 0 0,1 9,1M15,20V7H5V20L10,17.82L15,20M15,5C16.11,5 17,5.9 17,7V23L10,20L3,23V7A2,2 0 0,1 5,5H15Z" /></svg>
+		</div>
+		<image id="logo" src="static/logo.svg">
+		<h1 id="url" th:utext="${heading}"></h1>
+	</div>
 	<div class="tab">
 		<button id="html-button" class="tablinks" th:if="${htmlFragment}" accesskey="h" title="Show HTML [h]">html</button>
 		<button id="json-button" class="tablinks" accesskey="j" title="Show JSON [j]">json</button>

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/root.html
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/root.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+	<div id="root" th:fragment="content">
+		<th:block th:each="e : ${elements}">
+			<th:block th:if="${e.link != null}">
+				<a href="link" th:href="${e.link}">
+					<div class="element"
+						th:attr="resource-type=${e.type},active=${e.active},status=${e.status}">
+						<h1 th:text="${e.title}">title</h1>
+						<h2 th:text="${e.subtitle}">subtitle</h2>
+						<p class="unit" th:text="${e.unit}">unit</p>
+						<p class="value" th:text="${e.value}">value</p>
+					</div>
+				</a>
+			</th:block>
+
+			<th:block th:if="${e.link == null}">
+				<div class="element"
+					th:attr="resource-type=${e.type},active=${e.active},status=${e.status}">
+					<h1 th:text="${e.title}">title</h1>
+					<h2 th:text="${e.subtitle}">subtitle</h2>
+					<p class="unit" th:text="${e.unit}">unit</p>
+					<p class="value" th:text="${e.value}">value</p>
+				</div>
+			</th:block>
+		</th:block>
+	</div>
+</body>
+</html>

--- a/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/searchset.html
+++ b/dsf-fhir/dsf-fhir-server/src/main/resources/fhir/template/searchset.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 	<div class="bundle" th:fragment="content">
-		<div id="header">
+		<div id="bundle-header">
 			<table>
 				<tr>
 					<td>
@@ -20,7 +20,7 @@
 				</tr>
 			</table>
 		</div>
-		<div id="list">
+		<div id="bundle-list">
 			<table>
 				<tr th:replace="~{${searchset.htmlRowFragment}::header}"></tr>
 				<tr th:each="e : ${searchset.elements}" th:insert="~{${searchset.htmlRowFragment}::row}" th:with="element=${e}" th:remove="tag"></tr>


### PR DESCRIPTION
- reworked layout of the header elements (icons, logo, url) to be more responsive
- adds some statistics to the start screen, stats are visible for the local organization user and practitioner users with role `DSF_ADMIN`.
- small modification to the binary 2.0.0 db migration script, developers may need to delete local dev databases

<img width="3576" height="1744" alt="image" src="https://github.com/user-attachments/assets/539bb1d9-f306-45ed-998d-561177e6714c" />

<img width="3576" height="1744" alt="image" src="https://github.com/user-attachments/assets/d0eb834a-f64a-4e9f-89c1-054932a813ba" />


closes #388