### PR TITLE
Issue/415 NoClassDefFoundError num-process-dashboard-report

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v1/allowed-bpe-classes.list
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v1/allowed-bpe-classes.list
@@ -42,8 +42,10 @@ org.springframework.beans
 org.springframework.cglib
 org.springframework.context
 org.springframework.core
+org.springframework.http
 org.springframework.lang
 org.springframework.util
+org.springframework.web.client
 org.springframework.web.util.UriComponents
 org.springframework.web.util.UriComponentsBuilder
 org.w3c.dom


### PR DESCRIPTION
* Adds packages `org.springframework.web.client` and `org.springframework.http` to process plugin v1 allowed bpe classes list.

Fixes #415 