### PR TITLE
removed workflow level permissions config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ on:
   schedule:
     - cron: '11 15 * * 0' # Sundays, 15:11
 
-permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Removed workflow level permissions config to try to fix the `failed to push ...:develop: denied: permission_denied: write_package` errors in run [24043970335](https://github.com/datasharingframework/dsf/actions/runs/24043970335).