### PR TITLE
added back workflow level permissions config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: '11 15 * * 0' # Sundays, 15:11
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
- Revert of commit 3760d1a.
- Access via actions workflows needs to be enabled per repository in package settings.
- Packages `bpe`, `bpe_proxy`, `fhir` and `fhir_proxy` have been configured for access via actions workflows of the `dsf` repository.