### PR TITLE
Improvements to Dependabot and Workflow Configs, New .trivyignore File

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,10 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Dockerfile base image updates
   - package-ecosystem: "docker"
@@ -72,9 +76,13 @@ updates:
       interval: "weekly"
       day: "sunday"
     groups:
-      dockerfiles:
+      docker:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "azul/zulu-openjdk"
+        versions:
+          - "26-jre-headless"
 
   # docker-compose image updates
   - package-ecosystem: "docker-compose"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,26 +32,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java-kotlin', 'javascript-typescript' ]
-    name: ${{ matrix.language }}
+        include:
+        - language: actions
+          build-mode: none
+        - language: java-kotlin
+          build-mode: manual
+        - language: javascript-typescript
+          build-mode: none
+    name: 'codeql: ${{ matrix.language }}'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 25
+        if: ${{ matrix.language == 'java-kotlin' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: 25
           cache: 'maven'
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-extended, security-and-quality
       - name: Minimal Maven Build
+        if: ${{ matrix.language == 'java-kotlin' }}
         run: mvn package $MVN_BATCH_MODE_FAIL_AT_END $MVN_SKIP_MOST -DskipTests
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{matrix.language}}"
 
@@ -74,7 +83,7 @@ jobs:
       - name: Minimal Maven Build
         run: mvn install $MVN_BATCH_MODE_FAIL_AT_END $MVN_SKIP_MOST -DskipTests -DbuildNumber=${GITHUB_SHA} -DscmBranch=${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}
       - name: Upload quick-build results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quick_build
           path: |
@@ -135,7 +144,7 @@ jobs:
       - name: Checkout repository 
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download quick-build results
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick_build
           path: ./
@@ -166,12 +175,12 @@ jobs:
             context: dsf-bpe/dsf-bpe-server-jetty/docker
           - name: fhir
             context: dsf-fhir/dsf-fhir-server-jetty/docker
-    name: ${{ matrix.image.name }}
+    name: 'trivy: ${{ matrix.image.name }}'
     steps:
       - name: Checkout repository 
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download quick-build results
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick_build
           path: ./
@@ -184,12 +193,14 @@ jobs:
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}:${{ github.sha }}
           format: 'sarif'
-          output: 'trivy-results.sarif'
+          output: 'trivy-results-${{ matrix.image.name }}.sarif'
+          trivyignores: './.trivyignore'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: 'trivy-results-${{ matrix.image.name }}.sarif'
+          category: 'trivy-${{ matrix.image.name }}'
 
   docker-deploy:
     if: ${{ (!endsWith(needs.maven-quick.outputs.version, '-SNAPSHOT') && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop') }}
@@ -211,12 +222,12 @@ jobs:
             context: dsf-docker/bpe_proxy
           - name: fhir_proxy
             context: dsf-docker/fhir_proxy
-    name: ${{ matrix.image.name }}
+    name: 'docker-deploy: ${{ matrix.image.name }}'
     steps:
       - name: Checkout repository 
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download quick-build results
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick_build
           path: ./
@@ -225,7 +236,7 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -246,7 +257,7 @@ jobs:
           # latest only for stable releases
           # develop builds
       - name: Build and Push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         id: push
         with:
           push: true
@@ -258,11 +269,11 @@ jobs:
       - name: Export digest
         run: echo "DIGEST=${{ steps.push.outputs.digest }}" >> $GITHUB_ENV
       - name: Set up syft
-        uses: anchore/sbom-action/download-syft@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Generate SBOM
         run: syft ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}@${DIGEST} -o cyclonedx-json > sbom.json
       - name: Set up cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - name: Attach SBOM
         run: cosign attest --yes --predicate sbom.json --type cyclonedx ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}@${DIGEST}
       - name: Sign image
@@ -278,7 +289,7 @@ jobs:
       - name: Checkout repository 
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download quick-build results
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick_build
           path: ./

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,35 @@
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: FHIR Validator HTTP service has SSRF via /loadIG Chains with startsWith() Credential Leak for Authentication Token Theft
+CVE-2026-34361
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: HAPI FHIR: hapifhir/org.hl7.fhir.core: HAPI FHIR: Information disclosure and potential impersonation via HTTP redirects sending sensitive headers
+CVE-2026-33180
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: MITM based Zip Slip in `ca.uhn.hapi.fhir:org.hl7.fhir.core`
+CVE-2023-24057
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: HL7 FHIR Partial Path Zip Slip due to bypass of CVE-2023-24057
+CVE-2023-28465
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: HAPI FHIR Core has Authentication Credential Leakage via Improper URL Prefix Matching on HTTP Redirect
+CVE-2026-34359
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: org.hl7.fhir.dstu2016may: org.hl7.fhir.dstu3: org.hl7.fhir.r4: org.hl7.fhir.r5: org.hl7.fhir.utilities: org.hl7.fhir.core: XXE vulnerability in XSLT parsing in `org.hl7.fhir.core`
+CVE-2024-52007
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: org.hl7.fhir.core: org.hl7.fhir.dstu3: org.hl7.fhir.r4: org.hl7.fhir.r4b: org.hl7.fhir.r5: org.hl7.fhir.utilities: XXE vulnerability in XSLT transforms in `org.hl7.fhir.core`
+CVE-2024-45294
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: org.hl7.fhir.convertors: org.hl7.fhir.dstu2: org.hl7.fhir.dstu2016may: org.hl7.fhir.dstu3: org.hl7.fhir.r4: org.hl7.fhir.r5: org.hl7.fhir.utilities: org.hl7.fhir.validation: org.hl7.fhir.core: FHIR arbitrary code execution via specially-crafted request
+CVE-2024-51132
+
+# Ignore reason: Vulnerable code not used in DSF
+# CVE title: ucum: Ucum-java has an XXE vulnerability in XML parsing 
+CVE-2024-55887


### PR DESCRIPTION
- added dependabot group for github-actions
- added org.hl7.fhir CVE IDs to .trivyignore
- actions version upgrades
- reconfigured codeql, added actions scan
- added category for trivy scan result upload

Merge direct to main so that we don't have to wait for the next release.