### PR TITLE
Issue/480 upgrade dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,16 +42,16 @@ jobs:
     name: 'codeql: ${{ matrix.language }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 25
         if: ${{ matrix.language == 'java-kotlin' }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: 25
           cache: 'maven'
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -60,7 +60,7 @@ jobs:
         if: ${{ matrix.language == 'java-kotlin' }}
         run: mvn package $MVN_BATCH_MODE_FAIL_AT_END $MVN_SKIP_MOST -DskipTests
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{matrix.language}}"
 
@@ -73,9 +73,9 @@ jobs:
       main: ${{ steps.main.outputs.main }}
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: 25
@@ -106,7 +106,7 @@ jobs:
         id: version
         run: echo "version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:3.6.3:exec)" >> $GITHUB_OUTPUT
       - name: Checkout main branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
       - name: Check if ref is main HEAD
@@ -142,14 +142,14 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Download quick-build results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick_build
           path: ./
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: 25
@@ -178,7 +178,7 @@ jobs:
     name: 'trivy: ${{ matrix.image.name }}'
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Download quick-build results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -196,7 +196,7 @@ jobs:
           output: 'trivy-results-${{ matrix.image.name }}.sarif'
           trivyignores: './.trivyignore'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: always()
         with:
           sarif_file: 'trivy-results-${{ matrix.image.name }}.sarif'
@@ -225,7 +225,7 @@ jobs:
     name: 'docker-deploy: ${{ matrix.image.name }}'
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Download quick-build results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -287,14 +287,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Download quick-build results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick_build
           path: ./
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: 25

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 25
         if: ${{ matrix.language == 'java-kotlin' }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'zulu'
           java-version: 25
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout repository 
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 25
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'zulu'
           java-version: 25
@@ -149,7 +149,7 @@ jobs:
           name: quick_build
           path: ./
       - name: Set up JDK 25
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'zulu'
           java-version: 25
@@ -294,7 +294,7 @@ jobs:
           name: quick_build
           path: ./
       - name: Set up JDK 25
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'zulu'
           java-version: 25

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           java-version: 25
           cache: 'maven'
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -60,7 +60,7 @@ jobs:
         if: ${{ matrix.language == 'java-kotlin' }}
         run: mvn package $MVN_BATCH_MODE_FAIL_AT_END $MVN_SKIP_MOST -DskipTests
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{matrix.language}}"
 
@@ -185,18 +185,18 @@ jobs:
           name: quick_build
           path: ./
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Build Docker image
         run:  docker build -t ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}:${{ github.sha }} ${{ matrix.image.context }}
       - name: Scan Docker image with Trivy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}:${{ github.sha }}
           format: 'sarif'
           output: 'trivy-results-${{ matrix.image.name }}.sarif'
           trivyignores: './.trivyignore'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         if: always()
         with:
           sarif_file: 'trivy-results-${{ matrix.image.name }}.sarif'
@@ -232,17 +232,17 @@ jobs:
           name: quick_build
           path: ./
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker metadata
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
@@ -257,7 +257,7 @@ jobs:
           # latest only for stable releases
           # develop builds
       - name: Build and Push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: push
         with:
           push: true
@@ -273,7 +273,7 @@ jobs:
       - name: Generate SBOM
         run: syft ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}@${DIGEST} -o cyclonedx-json > sbom.json
       - name: Set up cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Attach SBOM
         run: cosign attest --yes --predicate sbom.json --type cyclonedx ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}@${DIGEST}
       - name: Sign image

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,19 @@
+#
+# Copyright 2018-2025 Heilbronn University of Applied Sciences
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Ignore reason: Vulnerable code not used in DSF
 # CVE title: FHIR Validator HTTP service has SSRF via /loadIG Chains with startsWith() Credential Leak for Authentication Token Theft
 CVE-2026-34361

--- a/dsf-bpe/dsf-bpe-process-api-v1-base/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1-base/pom.xml
@@ -41,6 +41,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/dsf-bpe/dsf-bpe-process-api-v1-base/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1-base/pom.xml
@@ -59,6 +59,7 @@
 		<dependency>
 			<artifactId>jakarta.ws.rs-api</artifactId>
 			<groupId>jakarta.ws.rs</groupId>
+			<version>${jakarta.ws.rs.version.v1}</version>
 		</dependency>
 
 		<!-- optional dependencies provided by the DSF bpe -->

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/pom.xml
@@ -159,11 +159,6 @@
 									<version>${hapi.fhir.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>net.sf.saxon</groupId>
-									<artifactId>Saxon-HE</artifactId>
-									<version>9.5.1-5</version>
-								</artifactItem>
-								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
 									<artifactId>org.hl7.fhir.validation</artifactId>
 									<version>${hapi.fhir.version.v1}</version>

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/pom.xml
@@ -45,18 +45,22 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version.v1}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version.v1}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version.v1}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
 			<artifactId>jersey-apache-connector</artifactId>
+			<version>${jersey.version.v1}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
@@ -125,22 +129,7 @@
 								</artifactItem>
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-structures-r4</artifactId>
-									<version>${hapi.fhir.version.v1}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.utilities</artifactId>
-									<version>${hapi.fhir.version.v1}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.r4</artifactId>
-									<version>${hapi.fhir.version.v1}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-validation</artifactId>
+									<artifactId>hapi-fhir-base</artifactId>
 									<version>${hapi.fhir.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
@@ -150,7 +139,27 @@
 								</artifactItem>
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-structures-r4</artifactId>
+									<version>${hapi.fhir.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-validation</artifactId>
+									<version>${hapi.fhir.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-validation-resources-r4</artifactId>
+									<version>${hapi.fhir.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
 									<artifactId>org.hl7.fhir.convertors</artifactId>
+									<version>${hapi.fhir.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.r4</artifactId>
 									<version>${hapi.fhir.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
@@ -160,45 +169,13 @@
 								</artifactItem>
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.validation</artifactId>
+									<artifactId>org.hl7.fhir.utilities</artifactId>
 									<version>${hapi.fhir.version.v1}</version>
 								</artifactItem>
-								<!--<artifactItem>
-									<groupId>xpp3</groupId>
-									<artifactId>xpp3</artifactId>
-									<version>1.1.4c</version>
-								</artifactItem>
 								<artifactItem>
-									<groupId>xpp3</groupId>
-									<artifactId>xpp3_xpath</artifactId>
-									<version>1.1.4c</version>
-								</artifactItem>-->
-								<!--<artifactItem>
-									<groupId>org.apache.commons</groupId>
-									<artifactId>commons-compress</artifactId>
-								</artifactItem>-->
-								<artifactItem>
-									<groupId>org.fhir</groupId>
-									<artifactId>ucum</artifactId>
-								</artifactItem>
-								<artifactItem>
-									<groupId>com.github.ben-manes.caffeine</groupId>
-									<artifactId>caffeine</artifactId>
-									<version>2.7.0</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.checkerframework</groupId>
-									<artifactId>checker-qual</artifactId>
-									<version>2.6.0</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>com.google.errorprone</groupId>
-									<artifactId>error_prone_annotations</artifactId>
-									<version>2.3.3</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>com.google.code.gson</groupId>
-									<artifactId>gson</artifactId>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.validation</artifactId>
+									<version>${hapi.fhir.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
 									<groupId>de.hs-heilbronn.mi</groupId>
@@ -206,17 +183,93 @@
 									<version>${crypto-utils.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-validation-resources-r4</artifactId>
+									<groupId>jakarta.annotation</groupId>
+									<artifactId>jakarta.annotation-api</artifactId>
+									<version>${jakarta.annotation.api.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-base</artifactId>
-									<version>${hapi.fhir.version.v1}</version>
+									<groupId>jakarta.ws.rs</groupId>
+									<artifactId>jakarta.ws.rs-api</artifactId>
+									<version>${jakarta.ws.rs.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.commons</groupId>
+									<artifactId>commons-compress</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.httpcomponents</groupId>
+									<artifactId>httpclient</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.httpcomponents</groupId>
+									<artifactId>httpcore</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.fhir</groupId>
+									<artifactId>ucum</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.hk2.external</groupId>
+									<artifactId>aopalliance-repackaged</artifactId>
+									<version>3.0.6</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.hk2</groupId>
+									<artifactId>hk2-api</artifactId>
+									<version>3.0.6</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.hk2</groupId>
+									<artifactId>hk2-locator</artifactId>
+									<version>3.0.6</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.hk2</groupId>
+									<artifactId>hk2-utils</artifactId>
+									<version>3.0.6</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.hk2</groupId>
+									<artifactId>osgi-resource-locator</artifactId>
+									<version>1.0.3</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.jersey.connectors</groupId>
+									<artifactId>jersey-apache-connector</artifactId>
+									<version>${jersey.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.jersey.core</groupId>
+									<artifactId>jersey-client</artifactId>
+									<version>${jersey.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.jersey.core</groupId>
+									<artifactId>jersey-common</artifactId>
+									<version>${jersey.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.jersey.ext</groupId>
+									<artifactId>jersey-entity-filtering</artifactId>
+									<version>${jersey.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.jersey.inject</groupId>
+									<artifactId>jersey-hk2</artifactId>
+									<version>${jersey.version.v1}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.glassfish.jersey.media</groupId>
+									<artifactId>jersey-media-json-jackson</artifactId>
+									<version>${jersey.version.v1}</version>
 								</artifactItem>
 								<artifactItem>
 									<groupId>org.ow2.asm</groupId>
 									<artifactId>asm</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>com.github.ben-manes.caffeine</groupId>
+									<artifactId>caffeine</artifactId>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/context/PluginContextImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/context/PluginContextImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.dsf.bpe.v2.logging;
+package dev.dsf.bpe.v1.context;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -26,11 +26,11 @@ import org.hl7.fhir.r4.model.Task.ParameterComponent;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 
 import dev.dsf.bpe.api.Constants;
-import dev.dsf.bpe.api.logging.AbstractPluginMdc;
-import dev.dsf.bpe.v2.constants.CodeSystems.BpmnMessage;
-import dev.dsf.bpe.v2.variables.Variables;
+import dev.dsf.bpe.api.context.AbstractPluginContext;
+import dev.dsf.bpe.v1.constants.CodeSystems.BpmnMessage;
+import dev.dsf.bpe.v1.variables.Variables;
 
-public class PluginMdcImpl extends AbstractPluginMdc
+public class PluginContextImpl extends AbstractPluginContext
 {
 	private final String serverBaseUrl;
 	private final Function<DelegateExecution, Variables> variablesFactory;
@@ -43,15 +43,17 @@ public class PluginMdcImpl extends AbstractPluginMdc
 	 *            not <code>null</code>
 	 * @param jar
 	 *            not <code>null</code>
+	 * @param pluginClassLoader
+	 *            not <code>null</code>
 	 * @param serverBaseUrl
 	 *            not <code>null</code>
 	 * @param variablesFactory
 	 *            not <code>null</code>
 	 */
-	public PluginMdcImpl(int apiVersion, String name, String version, String jar, String serverBaseUrl,
-			Function<DelegateExecution, Variables> variablesFactory)
+	public PluginContextImpl(int apiVersion, String name, String version, String jar, ClassLoader pluginClassLoader,
+			String serverBaseUrl, Function<DelegateExecution, Variables> variablesFactory)
 	{
-		super(apiVersion, name, version, jar);
+		super(apiVersion, name, version, jar, pluginClassLoader);
 
 		this.serverBaseUrl = Objects.requireNonNull(serverBaseUrl, "serverBaseUrl");
 		this.variablesFactory = Objects.requireNonNull(variablesFactory, "variablesFactory");
@@ -64,7 +66,7 @@ public class PluginMdcImpl extends AbstractPluginMdc
 
 		Task startTask = variables.getStartTask();
 		if (startTask == null)
-			startTask = variables.getFhirResource(Constants.TASK_VARIABLE);
+			startTask = variables.getResource(Constants.TASK_VARIABLE);
 
 		Task latestTask = variables.getLatestTask();
 		if (startTask == latestTask)

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/listener/EndListener.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/listener/EndListener.java
@@ -27,20 +27,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dev.dsf.bpe.v1.constants.CodeSystems.BpmnMessage;
-import dev.dsf.fhir.client.FhirWebserviceClient;
+import dev.dsf.bpe.v1.service.FhirWebserviceClientProvider;
 
 public class EndListener extends AbstractListener implements ExecutionListener
 {
 	private static final Logger logger = LoggerFactory.getLogger(EndListener.class);
 
-	private final FhirWebserviceClient webserviceClient;
+	private final FhirWebserviceClientProvider fhirWebserviceClientProvider;
 
 	public EndListener(String serverBaseUrl, Function<DelegateExecution, ListenerVariables> variablesFactory,
-			FhirWebserviceClient fhirWebserviceClient)
+			FhirWebserviceClientProvider fhirWebserviceClientProvider)
 	{
 		super(serverBaseUrl, variablesFactory);
 
-		this.webserviceClient = fhirWebserviceClient;
+		this.fhirWebserviceClientProvider = fhirWebserviceClientProvider;
 	}
 
 	@Override
@@ -48,7 +48,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 	{
 		super.afterPropertiesSet();
 
-		Objects.requireNonNull(webserviceClient, "webserviceClient");
+		Objects.requireNonNull(fhirWebserviceClientProvider, "fhirWebserviceClientProvider");
 	}
 
 	@Override
@@ -89,7 +89,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 			logger.debug("Updating Task {}, new status: {}", getLocalVersionlessAbsoluteUrl(task),
 					task.getStatus().toCode());
 
-			webserviceClient.withMinimalReturn().update(task);
+			fhirWebserviceClientProvider.getLocalWebserviceClient().withMinimalReturn().update(task);
 		}
 		catch (Exception e)
 		{

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/plugin/ProcessPluginImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/plugin/ProcessPluginImpl.java
@@ -65,7 +65,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
-import dev.dsf.bpe.api.logging.PluginMdc;
+import dev.dsf.bpe.api.context.PluginContext;
 import dev.dsf.bpe.api.plugin.AbstractProcessPlugin;
 import dev.dsf.bpe.api.plugin.FhirResourceModifier;
 import dev.dsf.bpe.api.plugin.ProcessPlugin;
@@ -78,7 +78,7 @@ import dev.dsf.bpe.v1.activity.DefaultUserTaskListener;
 import dev.dsf.bpe.v1.constants.CodeSystems.BpmnMessage;
 import dev.dsf.bpe.v1.constants.NamingSystems.OrganizationIdentifier;
 import dev.dsf.bpe.v1.constants.NamingSystems.TaskIdentifier;
-import dev.dsf.bpe.v1.logging.PluginMdcImpl;
+import dev.dsf.bpe.v1.context.PluginContextImpl;
 import dev.dsf.bpe.v1.variables.FhirResourceValues;
 import dev.dsf.bpe.v1.variables.VariablesImpl;
 
@@ -89,7 +89,7 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<TaskListener> imple
 	private final ProcessPluginDefinition processPluginDefinition;
 	private final ProcessPluginApi processPluginApi;
 
-	private final PluginMdcImpl pluginMdc;
+	private final PluginContextImpl pluginContext;
 
 	public ProcessPluginImpl(ProcessPluginDefinition processPluginDefinition, int processPluginApiVersion,
 			boolean draft, Path jarFile, ClassLoader classLoader, ConfigurableEnvironment environment,
@@ -103,14 +103,15 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<TaskListener> imple
 		this.processPluginDefinition = processPluginDefinition;
 		processPluginApi = apiApplicationContext.getBean(ProcessPluginApi.class);
 
-		pluginMdc = new PluginMdcImpl(processPluginApiVersion, processPluginDefinition.getName(),
-				processPluginDefinition.getVersion(), jarFile.toString(), serverBaseUrl, VariablesImpl::new);
+		pluginContext = new PluginContextImpl(processPluginApiVersion, processPluginDefinition.getName(),
+				processPluginDefinition.getVersion(), jarFile.toString(), classLoader, serverBaseUrl,
+				VariablesImpl::new);
 	}
 
 	@Override
-	public PluginMdc getPluginMdc()
+	public PluginContext getPluginContext()
 	{
-		return pluginMdc;
+		return pluginContext;
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/spring/ApiServiceConfig.java
+++ b/dsf-bpe/dsf-bpe-process-api-v1-impl/src/main/java/dev/dsf/bpe/v1/spring/ApiServiceConfig.java
@@ -193,8 +193,7 @@ public class ApiServiceConfig
 	@Bean
 	public ExecutionListener endListener()
 	{
-		return new EndListener(dsfClientConfig.getLocalConfig().getBaseUrl(), VariablesImpl::new,
-				clientProvider().getLocalWebserviceClient());
+		return new EndListener(dsfClientConfig.getLocalConfig().getBaseUrl(), VariablesImpl::new, clientProvider());
 	}
 
 	@Bean

--- a/dsf-bpe/dsf-bpe-process-api-v1-operaton/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1-operaton/pom.xml
@@ -67,6 +67,7 @@
 		<dependency>
 			<artifactId>jakarta.ws.rs-api</artifactId>
 			<groupId>jakarta.ws.rs</groupId>
+			<version>${jakarta.ws.rs.version.v1}</version>
 		</dependency>
 
 		<!-- optional dependencies provided by the DSF bpe -->

--- a/dsf-bpe/dsf-bpe-process-api-v1-operaton/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1-operaton/pom.xml
@@ -49,6 +49,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
@@ -92,6 +92,10 @@
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.sf.saxon</groupId>
+					<artifactId>Saxon-HE</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
@@ -68,6 +68,7 @@
 		<dependency>
 			<artifactId>jakarta.ws.rs-api</artifactId>
 			<groupId>jakarta.ws.rs</groupId>
+			<version>${jakarta.ws.rs.version.v1}</version>
 		</dependency>
 
 		<!-- optional dependencies provided by the DSF bpe -->
@@ -95,6 +96,14 @@
 				<exclusion>
 					<groupId>net.sf.saxon</groupId>
 					<artifactId>Saxon-HE</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>xpp3</groupId>
+					<artifactId>xpp3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>xpp3</groupId>
+					<artifactId>xpp3_xpath</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v1/pom.xml
@@ -50,6 +50,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/pom.xml
@@ -89,11 +89,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.auth0</groupId>
-			<artifactId>java-jwt</artifactId>
-		</dependency>
-		
-		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>
 			<artifactId>crypto-utils</artifactId>
 			<version>${crypto-utils.version.v2}</version>

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/pom.xml
@@ -45,18 +45,22 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version.v2}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version.v2}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version.v2}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
-			<artifactId>jersey-apache-connector</artifactId>
+			<artifactId>jersey-apache5-connector</artifactId>
+			<version>${jersey.version.v2}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
@@ -136,29 +140,9 @@
 									<artifactId>dsf-bpe-process-api-v2-impl</artifactId>
 								</artifactItem>
 								<artifactItem>
-									<groupId>de.hs-heilbronn.mi</groupId>
-									<artifactId>crypto-utils</artifactId>
-									<version>${crypto-utils.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-structures-r4</artifactId>
+									<artifactId>hapi-fhir-base</artifactId>
 									<version>${hapi.fhir.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.utilities</artifactId>
-									<version>${hapi.fhir.org.hl7.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>com.ibm.icu</groupId>
-									<artifactId>icu4j</artifactId>
-									<version>77.1</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.r4</artifactId>
-									<version>${hapi.fhir.org.hl7.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
@@ -167,83 +151,7 @@
 								</artifactItem>
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-validation</artifactId>
-									<version>${hapi.fhir.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-converter</artifactId>
-									<version>${hapi.fhir.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.convertors</artifactId>
-									<version>${hapi.fhir.org.hl7.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.validation</artifactId>
-									<version>${hapi.fhir.org.hl7.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>org.hl7.fhir.r5</artifactId>
-									<version>${hapi.fhir.org.hl7.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>com.nimbusds</groupId>
-									<artifactId>nimbus-jose-jwt</artifactId>
-									<version>10.0.2</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>net.sourceforge.plantuml</groupId>
-									<artifactId>plantuml-mit</artifactId>
-									<version>1.2023.9</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>jakarta-regexp</groupId>
-									<artifactId>jakarta-regexp</artifactId>
-									<version>1.4</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.apache.commons</groupId>
-									<artifactId>commons-compress</artifactId>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.tukaani</groupId>
-									<artifactId>xz</artifactId>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.fhir</groupId>
-									<artifactId>ucum</artifactId>
-								</artifactItem>
-								<!--<artifactItem>
-									<groupId>com.google.code.gson</groupId>
-									<artifactId>gson</artifactId>
-								</artifactItem>-->
-								<artifactItem>
-									<groupId>com.google.errorprone</groupId>
-									<artifactId>error_prone_annotations</artifactId>
-									<version>2.41.0</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-structures-r5</artifactId>
-									<version>${hapi.fhir.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-client</artifactId>
-									<version>${hapi.fhir.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-validation-resources-r4</artifactId>
-									<version>${hapi.fhir.version.v2}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-base</artifactId>
+									<artifactId>hapi-fhir-caching-api</artifactId>
 									<version>${hapi.fhir.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
@@ -253,31 +161,86 @@
 								</artifactItem>
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
-									<artifactId>hapi-fhir-caching-api</artifactId>
+									<artifactId>hapi-fhir-client</artifactId>
 									<version>${hapi.fhir.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>com.github.ben-manes.caffeine</groupId>
-									<artifactId>caffeine</artifactId>
-									<version>3.1.8</version>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-converter</artifactId>
+									<version>${hapi.fhir.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>org.checkerframework</groupId>
-									<artifactId>checker-qual</artifactId>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-structures-r4</artifactId>
+									<version>${hapi.fhir.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>com.google.j2objc</groupId>
-									<artifactId>j2objc-annotations</artifactId>
-									<version>3.1</version>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-structures-r5</artifactId>
+									<version>${hapi.fhir.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-validation</artifactId>
+									<version>${hapi.fhir.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>hapi-fhir-validation-resources-r4</artifactId>
+									<version>${hapi.fhir.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.convertors</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.model</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.r4</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.r5</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.support</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.utilities</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>ca.uhn.hapi.fhir</groupId>
+									<artifactId>org.hl7.fhir.validation</artifactId>
+									<version>${hapi.fhir.org.hl7.version.v2}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>com.fasterxml.woodstox</groupId>
+									<artifactId>woodstox-core</artifactId>
+									<version>7.1.0</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>com.nimbusds</groupId>
+									<artifactId>nimbus-jose-jwt</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>de.hs-heilbronn.mi</groupId>
+									<artifactId>crypto-utils</artifactId>
+									<version>${crypto-utils.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
 									<groupId>io.opentelemetry</groupId>
 									<artifactId>opentelemetry-api</artifactId>
-									<version>1.44.1</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>io.opentelemetry</groupId>
-									<artifactId>opentelemetry-context</artifactId>
 									<version>1.44.1</version>
 								</artifactItem>
 								<artifactItem>
@@ -286,8 +249,40 @@
 									<version>2.10.0</version>
 								</artifactItem>
 								<artifactItem>
+									<groupId>org.apache.commons</groupId>
+									<artifactId>commons-compress</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.httpcomponents</groupId>
+									<artifactId>httpclient</artifactId>
+									<version>4.5.14</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.httpcomponents</groupId>
+									<artifactId>httpcore</artifactId>
+									<version>4.4.16</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.santuario</groupId>
+									<artifactId>xmlsec</artifactId>
+									<version>4.0.4</version>
+								</artifactItem>
+								<artifactItem>
 									<groupId>org.apache.tika</groupId>
 									<artifactId>tika-core</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.codehaus.woodstox</groupId>
+									<artifactId>stax2-api</artifactId>
+									<version>4.2.2</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.fhir</groupId>
+									<artifactId>ucum</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.tukaani</groupId>
+									<artifactId>xz</artifactId>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/pom.xml
@@ -86,6 +86,12 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-r4</artifactId>
 			<version>${hapi.fhir.version.v2}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -175,11 +181,6 @@
 									<version>${hapi.fhir.org.hl7.version.v2}</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>org.xerial</groupId>
-									<artifactId>sqlite-jdbc</artifactId>
-									<version>3.50.3.0</version>
-								</artifactItem>
-								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
 									<artifactId>org.hl7.fhir.validation</artifactId>
 									<version>${hapi.fhir.org.hl7.version.v2}</version>
@@ -199,16 +200,6 @@
 									<artifactId>plantuml-mit</artifactId>
 									<version>1.2023.9</version>
 								</artifactItem>
-								<artifactItem>
-									<groupId>net.sf.saxon</groupId>
-									<artifactId>Saxon-HE</artifactId>
-									<version>11.6</version>
-								</artifactItem>
-								<!--<artifactItem>
-									<groupId>org.ogce</groupId>
-									<artifactId>xpp3</artifactId>
-									<version>1.1.6</version>
-								</artifactItem>-->
 								<artifactItem>
 									<groupId>jakarta-regexp</groupId>
 									<artifactId>jakarta-regexp</artifactId>

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/client/dsf/AbstractDsfClientJerseyWithRetry.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/client/dsf/AbstractDsfClientJerseyWithRetry.java
@@ -19,8 +19,8 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.function.Supplier;
 
-import org.apache.http.conn.ConnectTimeoutException;
-import org.apache.http.conn.HttpHostConnectException;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.client5.http.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/client/dsf/DsfClientJersey.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/client/dsf/DsfClientJersey.java
@@ -47,7 +47,7 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.SslConfigurator;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
@@ -227,7 +227,7 @@ public class DsfClientJersey implements DsfClient
 			builder.sslContext(sslContext);
 
 		ClientConfig config = new ClientConfig();
-		config.connectorProvider(new ApacheConnectorProvider());
+		config.connectorProvider(new Apache5ConnectorProvider());
 		config.property(ClientProperties.PROXY_URI, proxySchemeHostPort);
 		config.property(ClientProperties.PROXY_USERNAME, proxyUserName);
 		config.property(ClientProperties.PROXY_PASSWORD, proxyPassword == null ? null : String.valueOf(proxyPassword));

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/context/PluginContextImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/context/PluginContextImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.dsf.bpe.v1.logging;
+package dev.dsf.bpe.v2.context;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -26,11 +26,11 @@ import org.hl7.fhir.r4.model.Task.ParameterComponent;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 
 import dev.dsf.bpe.api.Constants;
-import dev.dsf.bpe.api.logging.AbstractPluginMdc;
-import dev.dsf.bpe.v1.constants.CodeSystems.BpmnMessage;
-import dev.dsf.bpe.v1.variables.Variables;
+import dev.dsf.bpe.api.context.AbstractPluginContext;
+import dev.dsf.bpe.v2.constants.CodeSystems.BpmnMessage;
+import dev.dsf.bpe.v2.variables.Variables;
 
-public class PluginMdcImpl extends AbstractPluginMdc
+public class PluginContextImpl extends AbstractPluginContext
 {
 	private final String serverBaseUrl;
 	private final Function<DelegateExecution, Variables> variablesFactory;
@@ -43,15 +43,17 @@ public class PluginMdcImpl extends AbstractPluginMdc
 	 *            not <code>null</code>
 	 * @param jar
 	 *            not <code>null</code>
+	 * @param pluginClassLoader
+	 *            not <code>null</code>
 	 * @param serverBaseUrl
 	 *            not <code>null</code>
 	 * @param variablesFactory
 	 *            not <code>null</code>
 	 */
-	public PluginMdcImpl(int apiVersion, String name, String version, String jar, String serverBaseUrl,
-			Function<DelegateExecution, Variables> variablesFactory)
+	public PluginContextImpl(int apiVersion, String name, String version, String jar, ClassLoader pluginClassLoader,
+			String serverBaseUrl, Function<DelegateExecution, Variables> variablesFactory)
 	{
-		super(apiVersion, name, version, jar);
+		super(apiVersion, name, version, jar, pluginClassLoader);
 
 		this.serverBaseUrl = Objects.requireNonNull(serverBaseUrl, "serverBaseUrl");
 		this.variablesFactory = Objects.requireNonNull(variablesFactory, "variablesFactory");
@@ -64,7 +66,7 @@ public class PluginMdcImpl extends AbstractPluginMdc
 
 		Task startTask = variables.getStartTask();
 		if (startTask == null)
-			startTask = variables.getResource(Constants.TASK_VARIABLE);
+			startTask = variables.getFhirResource(Constants.TASK_VARIABLE);
 
 		Task latestTask = variables.getLatestTask();
 		if (startTask == latestTask)

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/listener/EndListener.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/listener/EndListener.java
@@ -26,21 +26,21 @@ import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dev.dsf.bpe.v2.client.dsf.DsfClient;
 import dev.dsf.bpe.v2.constants.CodeSystems.BpmnMessage;
+import dev.dsf.bpe.v2.service.DsfClientProvider;
 
 public class EndListener extends AbstractListener implements ExecutionListener
 {
 	private static final Logger logger = LoggerFactory.getLogger(EndListener.class);
 
-	private final DsfClient webserviceClient;
+	private final DsfClientProvider dsfClientProvider;
 
 	public EndListener(String serverBaseUrl, Function<DelegateExecution, ListenerVariables> variablesFactory,
-			DsfClient fhirWebserviceClient)
+			DsfClientProvider dsfClientProvider)
 	{
 		super(serverBaseUrl, variablesFactory);
 
-		this.webserviceClient = fhirWebserviceClient;
+		this.dsfClientProvider = dsfClientProvider;
 	}
 
 	@Override
@@ -48,7 +48,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 	{
 		super.afterPropertiesSet();
 
-		Objects.requireNonNull(webserviceClient, "webserviceClient");
+		Objects.requireNonNull(dsfClientProvider, "dsfClientProvider");
 	}
 
 	@Override
@@ -89,7 +89,7 @@ public class EndListener extends AbstractListener implements ExecutionListener
 			logger.debug("Updating Task {}, new status: {}", getLocalVersionlessAbsoluteUrl(task),
 					task.getStatus().toCode());
 
-			webserviceClient.withMinimalReturn().update(task);
+			dsfClientProvider.getLocal().withMinimalReturn().update(task);
 		}
 		catch (Exception e)
 		{

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/plugin/ProcessPluginImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/plugin/ProcessPluginImpl.java
@@ -75,7 +75,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
-import dev.dsf.bpe.api.logging.PluginMdc;
+import dev.dsf.bpe.api.context.PluginContext;
 import dev.dsf.bpe.api.plugin.AbstractProcessPlugin;
 import dev.dsf.bpe.api.plugin.FhirResourceModifier;
 import dev.dsf.bpe.api.plugin.FhirResourceModifiers;
@@ -103,8 +103,8 @@ import dev.dsf.bpe.v2.activity.values.SendTaskValues;
 import dev.dsf.bpe.v2.constants.CodeSystems.BpmnMessage;
 import dev.dsf.bpe.v2.constants.NamingSystems.OrganizationIdentifier;
 import dev.dsf.bpe.v2.constants.NamingSystems.TaskIdentifier;
+import dev.dsf.bpe.v2.context.PluginContextImpl;
 import dev.dsf.bpe.v2.fhir.FhirResourceModifierDelegate;
-import dev.dsf.bpe.v2.logging.PluginMdcImpl;
 import dev.dsf.bpe.v2.variables.FhirResourceValues;
 import dev.dsf.bpe.v2.variables.Variables;
 import dev.dsf.bpe.v2.variables.VariablesImpl;
@@ -116,7 +116,7 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<UserTaskListener> i
 	private final ProcessPluginDefinition processPluginDefinition;
 
 	private final Function<DelegateExecution, Variables> variablesFactory;
-	private final PluginMdc pluginMdc;
+	private final PluginContext pluginContext;
 
 	private final AtomicReference<ProcessPluginApi> processPluginApi = new AtomicReference<>();
 	private final AtomicReference<FhirContext> fhirContext = new AtomicReference<>();
@@ -134,9 +134,9 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<UserTaskListener> i
 		this.processPluginDefinition = processPluginDefinition;
 
 		variablesFactory = delegateExecution -> new VariablesImpl(delegateExecution, getObjectMapper(),
-				getProcessPluginApi().getDsfClientProvider().getLocal());
-		pluginMdc = new PluginMdcImpl(processPluginApiVersion, processPluginDefinition.getName(),
-				processPluginDefinition.getVersion(), jarFile.toString(), serverBaseUrl, variablesFactory);
+				getProcessPluginApi().getDsfClientProvider());
+		pluginContext = new PluginContextImpl(processPluginApiVersion, processPluginDefinition.getName(),
+				processPluginDefinition.getVersion(), jarFile.toString(), classLoader, serverBaseUrl, variablesFactory);
 	}
 
 	@Override
@@ -185,9 +185,9 @@ public class ProcessPluginImpl extends AbstractProcessPlugin<UserTaskListener> i
 	}
 
 	@Override
-	public PluginMdc getPluginMdc()
+	public PluginContext getPluginContext()
 	{
-		return pluginMdc;
+		return pluginContext;
 	}
 
 	@Override

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/StartTaskUpdaterImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/service/StartTaskUpdaterImpl.java
@@ -27,18 +27,17 @@ import org.hl7.fhir.r4.model.Task;
 import org.hl7.fhir.r4.model.Task.TaskOutputComponent;
 import org.hl7.fhir.r4.model.Type;
 
-import dev.dsf.bpe.v2.client.dsf.DsfClient;
-
 public class StartTaskUpdaterImpl implements StartTaskUpdater
 {
-	private final DsfClient client;
+	private final DsfClientProvider dsfClientProvider;
 
 	private final Supplier<Task> getStartTask;
 	private final Consumer<Task> updateTask;
 
-	public StartTaskUpdaterImpl(DsfClient client, Supplier<Task> getStartTask, Consumer<Task> updateTask)
+	public StartTaskUpdaterImpl(DsfClientProvider dsfClientProvider, Supplier<Task> getStartTask,
+			Consumer<Task> updateTask)
 	{
-		this.client = Objects.requireNonNull(client, "client");
+		this.dsfClientProvider = Objects.requireNonNull(dsfClientProvider, "dsfClientProvider");
 
 		this.getStartTask = Objects.requireNonNull(getStartTask, "getStartTask");
 		this.updateTask = Objects.requireNonNull(updateTask, "updateTask");
@@ -50,7 +49,7 @@ public class StartTaskUpdaterImpl implements StartTaskUpdater
 		Task task = getStartTask.get();
 		task.addOutput().setValue(outputValue).getType().addCoding(outputType);
 
-		Task updated = client.update(task);
+		Task updated = dsfClientProvider.getLocal().update(task);
 		updateTask.accept(updated);
 	}
 
@@ -90,7 +89,7 @@ public class StartTaskUpdaterImpl implements StartTaskUpdater
 						+ (outputType.hasVersion() ? " (version: " + outputType.getVersion() + ") not found" : "")))
 				.setValue(outputValue);
 
-		Task updated = client.update(task);
+		Task updated = dsfClientProvider.getLocal().update(task);
 		updateTask.accept(updated);
 	}
 
@@ -110,7 +109,7 @@ public class StartTaskUpdaterImpl implements StartTaskUpdater
 
 		task.setOutput(filtered);
 
-		Task updated = client.update(task);
+		Task updated = dsfClientProvider.getLocal().update(task);
 		updateTask.accept(updated);
 	}
 

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/spring/ApiServiceConfig.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/spring/ApiServiceConfig.java
@@ -286,7 +286,7 @@ public class ApiServiceConfig
 	@Bean
 	public Function<DelegateExecution, ListenerVariables> listenerVariablesFactory()
 	{
-		return execution -> new VariablesImpl(execution, objectMapper(), dsfClientProvider().getLocal());
+		return execution -> new VariablesImpl(execution, objectMapper(), dsfClientProvider());
 	}
 
 	@Bean
@@ -299,7 +299,7 @@ public class ApiServiceConfig
 	public ExecutionListener endListener()
 	{
 		return new EndListener(dsfClientConfig.getLocalConfig().getBaseUrl(), listenerVariablesFactory(),
-				dsfClientProvider().getLocal());
+				dsfClientProvider());
 	}
 
 	@Bean

--- a/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/VariablesImpl.java
+++ b/dsf-bpe/dsf-bpe-process-api-v2-impl/src/main/java/dev/dsf/bpe/v2/variables/VariablesImpl.java
@@ -38,9 +38,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.dsf.bpe.api.Constants;
-import dev.dsf.bpe.v2.client.dsf.DsfClient;
 import dev.dsf.bpe.v2.constants.BpmnExecutionVariables;
 import dev.dsf.bpe.v2.listener.ListenerVariables;
+import dev.dsf.bpe.v2.service.DsfClientProvider;
 import dev.dsf.bpe.v2.service.StartTaskUpdater;
 import dev.dsf.bpe.v2.service.StartTaskUpdaterImpl;
 import dev.dsf.bpe.v2.variables.FhirResourceValues.FhirResourceValue;
@@ -94,15 +94,15 @@ public class VariablesImpl implements Variables, ListenerVariables
 	 *            not <code>null</code>
 	 * @param objectMapper
 	 *            not <code>null</code>
-	 * @param client
+	 * @param dsfClientProvider
 	 *            not <code>null</code>
 	 */
-	public VariablesImpl(DelegateExecution execution, ObjectMapper objectMapper, DsfClient client)
+	public VariablesImpl(DelegateExecution execution, ObjectMapper objectMapper, DsfClientProvider dsfClientProvider)
 	{
 		this.execution = Objects.requireNonNull(execution, "execution");
 		this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
 
-		startTaskUpdater = new StartTaskUpdaterImpl(client, this::getStartTask, this::updateTask);
+		startTaskUpdater = new StartTaskUpdaterImpl(dsfClientProvider, this::getStartTask, this::updateTask);
 	}
 
 	private JsonHolder toJsonHolder(Object json)

--- a/dsf-bpe/dsf-bpe-process-api-v2/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v2/pom.xml
@@ -57,6 +57,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/dsf-bpe/dsf-bpe-process-api-v2/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v2/pom.xml
@@ -37,6 +37,16 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.fhir.version.v2}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
@@ -47,12 +57,29 @@
 					<artifactId>commons-logging</artifactId>
 					<groupId>commons-logging</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.sf.saxon</groupId>
+					<artifactId>Saxon-HE</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.ogce</groupId>
+					<artifactId>xpp3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.xerial</groupId>
+					<artifactId>sqlite-jdbc</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-client</artifactId>
 			<version>${hapi.fhir.version.v2}</version>
+			<!-- needs io.opentelemetry dependencies -->
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/dsf-bpe/dsf-bpe-process-api-v2/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api-v2/pom.xml
@@ -73,6 +73,18 @@
 					<groupId>org.xerial</groupId>
 					<artifactId>sqlite-jdbc</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.sourceforge.plantuml</groupId>
+					<artifactId>plantuml-mit</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.commonmark</groupId>
+					<artifactId>commonmark</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.commonmark</groupId>
+					<artifactId>commonmark-ext-gfm-tables</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -102,6 +114,7 @@
 		<dependency>
 			<artifactId>jakarta.ws.rs-api</artifactId>
 			<groupId>jakarta.ws.rs</groupId>
+			<version>${jakarta.ws.rs.version.v2}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/dsf-bpe/dsf-bpe-process-api/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-api/pom.xml
@@ -46,10 +46,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.auth0</groupId>
-			<artifactId>java-jwt</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/context/AbstractPluginContext.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/context/AbstractPluginContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.dsf.bpe.api.logging;
+package dev.dsf.bpe.api.context;
 
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -23,7 +23,7 @@ import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.DelegateTask;
 import org.slf4j.MDC;
 
-public abstract class AbstractPluginMdc implements PluginMdc
+public abstract class AbstractPluginContext implements PluginContext
 {
 	public static final String DSF_PLUGIN_API = "dsf.plugin.api";
 	public static final String DSF_PLUGIN_JAR = "dsf.plugin.jar";
@@ -42,6 +42,7 @@ public abstract class AbstractPluginMdc implements PluginMdc
 	private final String jar;
 	private final String name;
 	private final String version;
+	private final ClassLoader pluginClassLoader;
 
 	/**
 	 * @param apiVersion
@@ -51,13 +52,16 @@ public abstract class AbstractPluginMdc implements PluginMdc
 	 *            not <code>null</code>
 	 * @param jar
 	 *            not <code>null</code>
+	 * @param pluginClassLoader
+	 *            not <code>null</code>
 	 */
-	public AbstractPluginMdc(int apiVersion, String name, String version, String jar)
+	public AbstractPluginContext(int apiVersion, String name, String version, String jar, ClassLoader pluginClassLoader)
 	{
 		this.apiVersion = apiVersion;
 		this.name = Objects.requireNonNull(name, "name");
 		this.version = Objects.requireNonNull(version, "version");
 		this.jar = Objects.requireNonNull(jar, "jar");
+		this.pluginClassLoader = Objects.requireNonNull(pluginClassLoader, "pluginClassLoader");
 	}
 
 	private void putPluginMdc()
@@ -115,44 +119,81 @@ public abstract class AbstractPluginMdc implements PluginMdc
 	protected abstract ProcessValues getProcessValues(DelegateExecution delegateExecution);
 
 	@Override
-	public void executeWithProcessMdc(DelegateTask delegateTask, Consumer<DelegateTask> executable)
+	public void executeWithProcessContext(DelegateTask delegateTask, Consumer<DelegateTask> executable)
 	{
-		putPluginMdc();
-		putProcessMdc(delegateTask.getExecution());
-
-		try
-		{
-			executable.accept(delegateTask);
-		}
-		finally
-		{
-			removePluginMdc();
-			removeProcessMdc();
-		}
+		withPluginClassLoader(withProcessMdc(delegateTask, executable));
 	}
 
 	@Override
-	public void executeWithProcessMdc(DelegateExecution delegateExecution,
+	public void executeWithProcessContext(DelegateExecution delegateExecution,
 			ConsumerWithException<DelegateExecution> executable) throws Exception
 	{
-		putPluginMdc();
-		putProcessMdc(delegateExecution);
-
-		try
-		{
-			executable.accept(delegateExecution);
-		}
-		finally
-		{
-			removePluginMdc();
-			removeProcessMdc();
-		}
+		withPluginClassLoader(withProcessMdc(delegateExecution, executable));
 	}
 
 	@Override
-	public void executeWithPluginMdc(Runnable runnable)
+	public void executeWithPluginContext(Runnable runnable)
 	{
-		putPluginMdc();
+		withPluginClassLoader(withPluginMdc(runnable));
+	}
+
+	@Override
+	public boolean executeWithPluginContext(Supplier<Boolean> supplier)
+	{
+		return withPluginClassLoader(withPluginMdc(supplier));
+	}
+
+	@FunctionalInterface
+	private interface RunnableWithException
+	{
+		void run() throws Exception;
+	}
+
+	private Supplier<Void> withProcessMdc(DelegateTask delegateTask, Consumer<DelegateTask> executable)
+	{
+		return () ->
+		{
+			putPluginMdc();
+			putProcessMdc(delegateTask.getExecution());
+
+			try
+			{
+				executable.accept(delegateTask);
+			}
+			finally
+			{
+				removeProcessMdc();
+				removePluginMdc();
+			}
+
+			return null;
+		};
+	}
+
+	private RunnableWithException withProcessMdc(DelegateExecution delegateExecution,
+			ConsumerWithException<DelegateExecution> executable) throws Exception
+	{
+		return () ->
+		{
+			putPluginMdc();
+			putProcessMdc(delegateExecution);
+
+			try
+			{
+				executable.accept(delegateExecution);
+			}
+			finally
+			{
+				removeProcessMdc();
+				removePluginMdc();
+			}
+		};
+	}
+
+	private void withPluginClassLoader(RunnableWithException runnable) throws Exception
+	{
+		ClassLoader old = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(pluginClassLoader);
 
 		try
 		{
@@ -160,14 +201,50 @@ public abstract class AbstractPluginMdc implements PluginMdc
 		}
 		finally
 		{
-			removePluginMdc();
+			Thread.currentThread().setContextClassLoader(old);
 		}
 	}
 
-	@Override
-	public boolean executeWithPluginMdc(Supplier<Boolean> supplier)
+	private Supplier<Void> withPluginMdc(Runnable runnable)
 	{
-		putPluginMdc();
+		return () ->
+		{
+			putPluginMdc();
+
+			try
+			{
+				runnable.run();
+
+				return null;
+			}
+			finally
+			{
+				removePluginMdc();
+			}
+		};
+	}
+
+	private <T> Supplier<T> withPluginMdc(Supplier<T> supplier)
+	{
+		return () ->
+		{
+			putPluginMdc();
+
+			try
+			{
+				return supplier.get();
+			}
+			finally
+			{
+				removePluginMdc();
+			}
+		};
+	}
+
+	private <T> T withPluginClassLoader(Supplier<T> supplier)
+	{
+		ClassLoader old = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(pluginClassLoader);
 
 		try
 		{
@@ -175,7 +252,7 @@ public abstract class AbstractPluginMdc implements PluginMdc
 		}
 		finally
 		{
-			removePluginMdc();
+			Thread.currentThread().setContextClassLoader(old);
 		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/context/PluginContext.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/context/PluginContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.dsf.bpe.api.logging;
+package dev.dsf.bpe.api.context;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.DelegateTask;
 
-public interface PluginMdc
+public interface PluginContext
 {
 	@FunctionalInterface
 	public interface ConsumerWithException<T>
@@ -29,12 +29,12 @@ public interface PluginMdc
 		void accept(T t) throws Exception;
 	}
 
-	void executeWithProcessMdc(DelegateTask delegateTask, Consumer<DelegateTask> executable);
+	void executeWithProcessContext(DelegateTask delegateTask, Consumer<DelegateTask> executable);
 
-	void executeWithProcessMdc(DelegateExecution delegateExecution, ConsumerWithException<DelegateExecution> executable)
-			throws Exception;
+	void executeWithProcessContext(DelegateExecution delegateExecution,
+			ConsumerWithException<DelegateExecution> executable) throws Exception;
 
-	void executeWithPluginMdc(Runnable runnable);
+	void executeWithPluginContext(Runnable runnable);
 
-	boolean executeWithPluginMdc(Supplier<Boolean> supplier);
+	boolean executeWithPluginContext(Supplier<Boolean> supplier);
 }

--- a/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/ProcessPlugin.java
+++ b/dsf-bpe/dsf-bpe-process-api/src/main/java/dev/dsf/bpe/api/plugin/ProcessPlugin.java
@@ -29,7 +29,7 @@ import org.operaton.bpm.engine.impl.variable.serializer.TypedValueSerializer;
 import org.operaton.bpm.engine.variable.value.PrimitiveValue;
 import org.springframework.context.ApplicationContext;
 
-import dev.dsf.bpe.api.logging.PluginMdc;
+import dev.dsf.bpe.api.context.PluginContext;
 
 public interface ProcessPlugin
 {
@@ -47,7 +47,7 @@ public interface ProcessPlugin
 
 	ApplicationContext getApplicationContext();
 
-	PluginMdc getPluginMdc();
+	PluginContext getPluginContext();
 
 	@SuppressWarnings("rawtypes")
 	Stream<TypedValueSerializer> getTypedValueSerializers();

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM docker.io/library/debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
+FROM docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS builder
 WORKDIR /opt/bpe
 COPY --chown=root:2202 ./ ./
 RUN chown root:2202 ./ && \
@@ -23,7 +23,7 @@ RUN chown root:2202 ./ && \
     chmod 1775 ./log
 
 
-FROM docker.io/azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
+FROM docker.io/azul/zulu-openjdk:25-jre-headless@sha256:1fa90a584251b66adc28152e25cc496ea63dd787999c86a04c0e2033fa98d39a
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS builder
+FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
 WORKDIR /opt/bpe
 COPY --chown=root:2202 ./ ./
 RUN chown root:2202 ./ && \
@@ -23,7 +23,7 @@ RUN chown root:2202 ./ && \
     chmod 1775 ./log
 
 
-FROM azul/zulu-openjdk:25-jre-headless@sha256:0f843579efd505efb0a0eef1d5a816cc4523ffcad458a54a4e9e52e60c4c030a
+FROM azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
+FROM docker.io/library/debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
 WORKDIR /opt/bpe
 COPY --chown=root:2202 ./ ./
 RUN chown root:2202 ./ && \
@@ -23,7 +23,7 @@ RUN chown root:2202 ./ && \
     chmod 1775 ./log
 
 
-FROM azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
+FROM docker.io/azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -90,6 +90,7 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>${jakarta.ws.rs.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
@@ -124,7 +125,8 @@
 		
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
-			<artifactId>jersey-apache-connector</artifactId>
+			<artifactId>jersey-apache5-connector</artifactId>
+			<version>${jersey.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
@@ -136,22 +138,27 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-jaxb</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 
 		<dependency>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -217,6 +217,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.icegreen</groupId>
 			<artifactId>greenmail-junit4</artifactId>
 			<version>1.6.15</version>

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/dsf/AbstractWebserviceClientJerseyWithRetry.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/dsf/AbstractWebserviceClientJerseyWithRetry.java
@@ -19,8 +19,8 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.function.Supplier;
 
-import org.apache.http.conn.ConnectTimeoutException;
-import org.apache.http.conn.HttpHostConnectException;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.client5.http.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/dsf/WebserviceClientJersey.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/dsf/WebserviceClientJersey.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.glassfish.jersey.SslConfigurator;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.logging.LoggingFeature;
@@ -85,7 +85,7 @@ public class WebserviceClientJersey implements WebserviceClient
 				.connectTimeout(connectTimeout.toMillis(), TimeUnit.MILLISECONDS);
 
 		ClientConfig config = new ClientConfig();
-		config.connectorProvider(new ApacheConnectorProvider());
+		config.connectorProvider(new Apache5ConnectorProvider());
 		config.property(ClientProperties.PROXY_URI, proxySchemeHostPort);
 		config.property(ClientProperties.PROXY_USERNAME, proxyUserName);
 		config.property(ClientProperties.PROXY_PASSWORD, proxyPassword == null ? null : String.valueOf(proxyPassword));

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/fhir/FhirConnectionTestClientJersey.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/fhir/FhirConnectionTestClientJersey.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.glassfish.jersey.SslConfigurator;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
@@ -88,7 +88,7 @@ public class FhirConnectionTestClientJersey implements FhirConnectionTestClient
 				.register((ClientRequestFilter) r -> r.getHeaders().add(HttpHeaders.USER_AGENT, userAgentValue));
 
 		ClientConfig config = new ClientConfig();
-		config.connectorProvider(new ApacheConnectorProvider());
+		config.connectorProvider(new Apache5ConnectorProvider());
 		if (proxyConfig.isEnabled(fhirClientConfig.baseUrl()))
 		{
 			config.property(ClientProperties.PROXY_URI, proxyConfig.getUrl());

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/engine/DelegateProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/engine/DelegateProviderImpl.java
@@ -155,7 +155,7 @@ public class DelegateProviderImpl implements DelegateProvider, InitializingBean
 		return getPlugin(processIdAndVersion).map(plugin ->
 		{
 			JavaDelegate delegate = getDelegate.apply(plugin);
-			return (JavaDelegate) e -> plugin.getPluginMdc().executeWithProcessMdc(e, delegate::execute);
+			return (JavaDelegate) e -> plugin.getPluginContext().executeWithProcessContext(e, delegate::execute);
 
 		}).orElseGet(() -> e -> stopProcess(processIdAndVersion, e));
 	}
@@ -167,7 +167,7 @@ public class DelegateProviderImpl implements DelegateProvider, InitializingBean
 		return getPlugin(processIdAndVersion).map(plugin ->
 		{
 			ExecutionListener delegate = plugin.getExecutionListener(className, fieldDeclarations, variableScope);
-			return (ExecutionListener) e -> plugin.getPluginMdc().executeWithProcessMdc(e, delegate::notify);
+			return (ExecutionListener) e -> plugin.getPluginContext().executeWithProcessContext(e, delegate::notify);
 
 		}).orElseGet(() -> e -> stopProcess(processIdAndVersion, e));
 	}
@@ -179,7 +179,7 @@ public class DelegateProviderImpl implements DelegateProvider, InitializingBean
 		return getPlugin(processIdAndVersion).<TaskListener> map(plugin ->
 		{
 			TaskListener delegate = plugin.getTaskListener(className, fieldDeclarations, variableScope);
-			return (TaskListener) e -> plugin.getPluginMdc().executeWithProcessMdc(e, delegate::notify);
+			return (TaskListener) e -> plugin.getPluginContext().executeWithProcessContext(e, delegate::notify);
 
 		}).orElseGet(() -> e -> stopProcess(processIdAndVersion, e.getExecution()));
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/DefaultBpmnParseListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/listener/DefaultBpmnParseListener.java
@@ -150,7 +150,7 @@ public class DefaultBpmnParseListener implements BpmnParseListener, ProcessPlugi
 			ProcessIdAndVersion processKeyAndVersion = new ProcessIdAndVersion(e.getProcessDefinition().getKey(),
 					e.getProcessDefinition().getVersionTag());
 
-			getPlugin(processKeyAndVersion).getPluginMdc().executeWithProcessMdc(execution, delegate::notify);
+			getPlugin(processKeyAndVersion).getPluginContext().executeWithProcessContext(execution, delegate::notify);
 		};
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginManagerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/plugin/ProcessPluginManagerImpl.java
@@ -118,7 +118,7 @@ public class ProcessPluginManagerImpl implements ProcessPluginManager, Initializ
 				.forEach(name -> Configurator.setLevel(name, Level.DEBUG));
 
 		List<ProcessPlugin> plugins = removeDuplicates(
-				loadedPlugins.stream().filter(p -> p.getPluginMdc().executeWithPluginMdc(
+				loadedPlugins.stream().filter(p -> p.getPluginContext().executeWithPluginContext(
 						() -> p.initializeAndValidateResources(localOrganizationIdentifierValue.orElse(null)))));
 
 		if (plugins.isEmpty())
@@ -224,7 +224,7 @@ public class ProcessPluginManagerImpl implements ProcessPluginManager, Initializ
 				.filter(c -> EnumSet.of(ProcessState.ACTIVE, ProcessState.DRAFT).contains(c.getNewProcessState()))
 				.map(ProcessStateChangeOutcome::getProcessKeyAndVersion).collect(Collectors.toSet());
 
-		plugins.stream().forEach(p -> p.getPluginMdc().executeWithPluginMdc(
+		plugins.stream().forEach(p -> p.getPluginContext().executeWithPluginContext(
 				() -> p.getProcessPluginDeploymentListener().onProcessesDeployed(activeProcesses)));
 	}
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/webservice/ProcessService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/webservice/ProcessService.java
@@ -48,7 +48,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
-import net.sf.saxon.lib.FeatureKeys;
 
 @RolesAllowed("ADMIN")
 @Path(ProcessService.PATH)
@@ -72,7 +71,6 @@ public class ProcessService extends AbstractService implements InitializingBean
 		try
 		{
 			transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			transformerFactory.setFeature(FeatureKeys.ALLOW_EXTERNAL_FUNCTIONS, false);
 		}
 		catch (TransformerConfigurationException e)
 		{

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v1/allowed-bpe-classes.list
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v1/allowed-bpe-classes.list
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-com.fasterxml.jackson.annotation
-com.fasterxml.jackson.core
-com.fasterxml.jackson.databind
+com.fasterxml.jackson
 com.google.common
 dev.dsf.bpe.api
-jakarta.ws.rs
+jakarta.activation
+jakarta.inject
 org.apache.commons.codec
 org.apache.commons.io
 org.apache.commons.lang3
+org.apache.commons.logging
 org.apache.commons.text
 org.apache.http
 org.bouncycastle

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v2/allowed-bpe-classes.list
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/bpe/api/v2/allowed-bpe-classes.list
@@ -14,19 +14,19 @@
 # limitations under the License.
 #
 
-com.fasterxml.jackson.annotation
-com.fasterxml.jackson.core
-com.fasterxml.jackson.databind
-com.fasterxml.jackson.datatype
+com.fasterxml.jackson
 com.google.common
 com.ctc.wstx.stax.WstxInputFactory
 dev.dsf.bpe.api
+jakarta.activation
 jakarta.annotation.Nonnull
 jakarta.annotation.Nullable
+jakarta.inject
 jakarta.ws.rs
 org.apache.commons.codec
 org.apache.commons.io
 org.apache.commons.lang3
+org.apache.commons.logging
 org.apache.commons.text
 org.apache.http
 org.bouncycastle

--- a/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/service/DsfClientTest.java
+++ b/dsf-bpe/dsf-bpe-test-plugin-v2/src/main/java/dev/dsf/bpe/test/service/DsfClientTest.java
@@ -172,7 +172,7 @@ public class DsfClientTest extends AbstractTest implements ServiceTask
 		Optional<DsfClient> client = api.getDsfClientProvider().getById("test-fhir-data-server");
 		expectTrue(client.isPresent());
 
-		CompletableFuture<Bundle> fBundle = client.get().searchAsync(client.get().getBaseUrl() + "/Patient");
+		CompletableFuture<Bundle> fBundle = client.get().searchAsync(client.get().getBaseUrl() + "Patient");
 		expectNotNull(fBundle);
 
 		Bundle bundle = fBundle.get();
@@ -201,7 +201,7 @@ public class DsfClientTest extends AbstractTest implements ServiceTask
 		expectTrue(client.isPresent());
 
 		CompletableFuture<Bundle> fBundle = client.get()
-				.searchAsyncWithStrictHandling(client.get().getBaseUrl() + "/Patient");
+				.searchAsyncWithStrictHandling(client.get().getBaseUrl() + "Patient");
 		expectNotNull(fBundle);
 
 		Bundle bundle = fBundle.get();

--- a/dsf-common/dsf-common-auth/pom.xml
+++ b/dsf-common/dsf-common-auth/pom.xml
@@ -37,6 +37,16 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>

--- a/dsf-common/dsf-common-auth/pom.xml
+++ b/dsf-common/dsf-common-auth/pom.xml
@@ -65,10 +65,12 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>${jakarta.ws.rs.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.annotation</groupId>
 			<artifactId>jakarta.annotation-api</artifactId>
+			<version>${jakarta.annotation.api.version}</version>
 		</dependency>
 
 		<dependency>

--- a/dsf-common/dsf-common-auth/pom.xml
+++ b/dsf-common/dsf-common-auth/pom.xml
@@ -64,6 +64,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>

--- a/dsf-common/dsf-common-config/pom.xml
+++ b/dsf-common/dsf-common-config/pom.xml
@@ -36,6 +36,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>

--- a/dsf-common/dsf-common-docker-secrets-reader/pom.xml
+++ b/dsf-common/dsf-common-docker-secrets-reader/pom.xml
@@ -36,6 +36,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/logging/Log4jConfiguration.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/logging/Log4jConfiguration.java
@@ -60,17 +60,17 @@ public class Log4jConfiguration extends AbstractConfiguration
 		public StringLayout consoleLayout(Configuration configuration)
 		{
 			if (color)
-				return PatternLayout.newBuilder().withPattern(
+				return PatternLayout.newBuilder().setPattern(
 						"%highlight{%p %t - %C{1}.%M(%L) | %m}{FATAL=red, ERROR=red, WARN=yellow, INFO=white, DEBUG=white, TRACE=white}%n")
 						.build();
 			else
-				return PatternLayout.newBuilder().withPattern("%p %t - %C{1}.%M(%L) | %m%n").build();
+				return PatternLayout.newBuilder().setPattern("%p %t - %C{1}.%M(%L) | %m%n").build();
 		}
 
 		@Override
 		public StringLayout fileLayout(Configuration configuration)
 		{
-			return PatternLayout.newBuilder().withPattern("%d [%t] %-5p %c - %m%n").build();
+			return PatternLayout.newBuilder().setPattern("%d [%t] %-5p %c - %m%n").build();
 		}
 	}
 
@@ -87,17 +87,17 @@ public class Log4jConfiguration extends AbstractConfiguration
 		public StringLayout consoleLayout(Configuration configuration)
 		{
 			if (color)
-				return PatternLayout.newBuilder().withPattern(
+				return PatternLayout.newBuilder().setPattern(
 						"%highlight{%p %t - %C{1}.%M(%L)%notEmpty{ - %X} | %m}{FATAL=red, ERROR=red, WARN=yellow, INFO=white, DEBUG=white, TRACE=white}%n")
 						.build();
 			else
-				return PatternLayout.newBuilder().withPattern("%p %t - %C{1}.%M(%L)%notEmpty{ - %X} | %m%n").build();
+				return PatternLayout.newBuilder().setPattern("%p %t - %C{1}.%M(%L)%notEmpty{ - %X} | %m%n").build();
 		}
 
 		@Override
 		public StringLayout fileLayout(Configuration configuration)
 		{
-			return PatternLayout.newBuilder().withPattern("%d [%t] %-5p %c%notEmpty{ - %X} - %m%n").build();
+			return PatternLayout.newBuilder().setPattern("%d [%t] %-5p %c%notEmpty{ - %X} - %m%n").build();
 		}
 	}
 
@@ -180,11 +180,10 @@ public class Log4jConfiguration extends AbstractConfiguration
 
 		if (fileEnabled)
 		{
-			Appender file = RollingFileAppender.newBuilder().setName("FILE")
-					.withFileName("log/" + fileNamePart + ".log")
-					.withFilePattern("log/" + fileNamePart + "_%d{yyyy-MM-dd}_%i.log.gz").setIgnoreExceptions(false)
+			Appender file = RollingFileAppender.newBuilder().setName("FILE").setFileName("log/" + fileNamePart + ".log")
+					.setFilePattern("log/" + fileNamePart + "_%d{yyyy-MM-dd}_%i.log.gz").setIgnoreExceptions(false)
 					.setLayout(fileLayout.fileLayout(this))
-					.withPolicy(CompositeTriggeringPolicy.createPolicy(OnStartupTriggeringPolicy.createPolicy(1),
+					.setPolicy(CompositeTriggeringPolicy.createPolicy(OnStartupTriggeringPolicy.createPolicy(1),
 							TimeBasedTriggeringPolicy.newBuilder().build()))
 					.build();
 			addAppender(file);
@@ -246,10 +245,10 @@ public class Log4jConfiguration extends AbstractConfiguration
 			return null;
 
 		return RollingFileAppender.newBuilder().setName(appenderName + ".FILE")
-				.withFileName("log/" + fileNamePart + ".log")
-				.withFilePattern("log/" + fileNamePart + "_%d{yyyy-MM-dd}_%i.log.gz").setIgnoreExceptions(false)
+				.setFileName("log/" + fileNamePart + ".log")
+				.setFilePattern("log/" + fileNamePart + "_%d{yyyy-MM-dd}_%i.log.gz").setIgnoreExceptions(false)
 				.setLayout(layout)
-				.withPolicy(CompositeTriggeringPolicy.createPolicy(OnStartupTriggeringPolicy.createPolicy(1),
+				.setPolicy(CompositeTriggeringPolicy.createPolicy(OnStartupTriggeringPolicy.createPolicy(1),
 						TimeBasedTriggeringPolicy.newBuilder().build()))
 				.build();
 	}

--- a/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/logging/Log4jInitializer.java
+++ b/dsf-common/dsf-common-jetty/src/main/java/dev/dsf/common/logging/Log4jInitializer.java
@@ -240,9 +240,9 @@ public abstract class Log4jInitializer
 			return configuration -> JsonTemplateLayout.newBuilder().setConfiguration(configuration)
 					.setEventTemplateUri(TemplateUri.LOGSTASH.getUri()).build();
 		else if (STYLE_TEXT.equalsIgnoreCase(value))
-			return _ -> PatternLayout.newBuilder().withPattern("%d %m%n").build();
+			return _ -> PatternLayout.newBuilder().setPattern("%d %m%n").build();
 		else if (STYLE_TEXT_MDC.equalsIgnoreCase(value))
-			return _ -> PatternLayout.newBuilder().withPattern("%d%notEmpty{ %X} %m%n").build();
+			return _ -> PatternLayout.newBuilder().setPattern("%d%notEmpty{ %X} %m%n").build();
 		else
 			throw new IllegalArgumentException(
 					"Value '" + value + "' for " + PREFIX + parameter + POSTFIX_STYLE + " not supported");

--- a/dsf-common/dsf-common-oidc/pom.xml
+++ b/dsf-common/dsf-common-oidc/pom.xml
@@ -43,10 +43,12 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
-			<artifactId>jersey-apache-connector</artifactId>
+			<artifactId>jersey-apache5-connector</artifactId>
+			<version>${jersey.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
@@ -57,6 +59,7 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/dsf-common/dsf-common-oidc/src/main/java/dev/dsf/common/oidc/BaseOidcClientJersey.java
+++ b/dsf-common/dsf-common-oidc/src/main/java/dev/dsf/common/oidc/BaseOidcClientJersey.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import javax.net.ssl.SSLContext;
 
 import org.glassfish.jersey.SslConfigurator;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.logging.LoggingFeature;
@@ -104,7 +104,7 @@ public class BaseOidcClientJersey implements BaseOidcClient
 			builder = builder.sslContext(sslContext);
 
 		ClientConfig config = new ClientConfig();
-		config.connectorProvider(new ApacheConnectorProvider());
+		config.connectorProvider(new Apache5ConnectorProvider());
 		config.property(ClientProperties.PROXY_URI, proxySchemeHostPort);
 		config.property(ClientProperties.PROXY_USERNAME, proxyUserName);
 		config.property(ClientProperties.PROXY_PASSWORD, proxyPassword == null ? null : String.valueOf(proxyPassword));

--- a/dsf-common/dsf-common-status/pom.xml
+++ b/dsf-common/dsf-common-status/pom.xml
@@ -40,10 +40,12 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>${jakarta.ws.rs.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.annotation</groupId>
 			<artifactId>jakarta.annotation-api</artifactId>
+			<version>${jakarta.annotation.api.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/dsf-common/dsf-common-status/pom.xml
+++ b/dsf-common/dsf-common-status/pom.xml
@@ -48,6 +48,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/dsf-common/dsf-common-ui/pom.xml
+++ b/dsf-common/dsf-common-ui/pom.xml
@@ -36,6 +36,7 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>${jakarta.ws.rs.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/dsf-docker-dev-setup-3dic-ttp/docker-compose.yml
+++ b/dsf-docker-dev-setup-3dic-ttp/docker-compose.yml
@@ -16,7 +16,7 @@
 
 services:
   proxy:
-    image: nginx:1.29
+    image: nginx:1.31
     restart: "no"
     ports:
       - 127.0.0.1:443:443
@@ -38,19 +38,19 @@ services:
       dic1-fhir-frontend:
         ipv4_address: 172.20.0.2
       dic2-fhir-frontend:
-        ipv4_address: 172.20.0.10
-      dic3-fhir-frontend:
         ipv4_address: 172.20.0.18
-      ttp-fhir-frontend:
-        ipv4_address: 172.20.0.26
-      dic1-bpe-frontend:
+      dic3-fhir-frontend:
         ipv4_address: 172.20.0.34
-      dic2-bpe-frontend:
-        ipv4_address: 172.20.0.42
-      dic3-bpe-frontend:
+      ttp-fhir-frontend:
         ipv4_address: 172.20.0.50
+      dic1-bpe-frontend:
+        ipv4_address: 172.20.0.66
+      dic2-bpe-frontend:
+        ipv4_address: 172.20.0.82
+      dic3-bpe-frontend:
+        ipv4_address: 172.20.0.98
       ttp-bpe-frontend:
-        ipv4_address: 172.20.0.58
+        ipv4_address: 172.20.0.114
       internet:
         aliases:
           - dic1
@@ -290,7 +290,7 @@ services:
       DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_dic2_fhir.secret
     networks:
       dic2-fhir-frontend:
-        ipv4_address: 172.20.0.11
+        ipv4_address: 172.20.0.19
       dic2-fhir-backend:
       internet:
     depends_on:
@@ -369,7 +369,7 @@ services:
       DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_dic3_fhir.secret
     networks:
       dic3-fhir-frontend:
-        ipv4_address: 172.20.0.19
+        ipv4_address: 172.20.0.35
       dic3-fhir-backend:
       internet:
     depends_on:
@@ -456,7 +456,7 @@ services:
       DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_ttp_fhir.secret
     networks:
       ttp-fhir-frontend:
-        ipv4_address: 172.20.0.27
+        ipv4_address: 172.20.0.51
       ttp-fhir-backend:
       internet:
     depends_on:
@@ -573,7 +573,7 @@ services:
       DEV_DSF_BPE_FHIR_CLIENT_CONNECTIONS_CONFIG_DEFAULT_TRUST_SERVER_CERTIFICATE_CAS: /run/secrets/root_ca.crt
     networks:
       dic1-bpe-frontend:
-        ipv4_address: 172.20.0.35
+        ipv4_address: 172.20.0.67
       dic1-bpe-backend:
       internet:
       forward-proxy:
@@ -664,7 +664,7 @@ services:
       DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_dic2_bpe.secret
     networks:
       dic2-bpe-frontend:
-        ipv4_address: 172.20.0.43
+        ipv4_address: 172.20.0.83
       dic2-bpe-backend:
       internet:
     depends_on:
@@ -753,7 +753,7 @@ services:
       DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_dic3_bpe.secret
     networks:
       dic3-bpe-frontend:
-        ipv4_address: 172.20.0.51
+        ipv4_address: 172.20.0.99
       dic3-bpe-backend:
       internet:
     depends_on:
@@ -843,7 +843,7 @@ services:
       DEV_DSF_SERVER_AUTH_OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_ttp_bpe.secret
     networks:
       ttp-bpe-frontend:
-        ipv4_address: 172.20.0.59
+        ipv4_address: 172.20.0.115
       ttp-bpe-backend:
       internet:
     depends_on:
@@ -964,57 +964,107 @@ networks:
       config:
       - subnet: 172.20.0.0/29
   dic1-fhir-backend:
-  dic2-fhir-frontend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.8/29
-  dic2-fhir-backend:
-  dic3-fhir-frontend:
+  dic2-fhir-frontend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.16/29
-  dic3-fhir-backend:
-  ttp-fhir-frontend:
+  dic2-fhir-backend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.24/29
-  ttp-fhir-backend:
-  dic1-bpe-frontend:
+  dic3-fhir-frontend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.32/29
-  dic1-bpe-backend:
-  dic2-bpe-frontend:
+  dic3-fhir-backend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.40/29
-  dic2-bpe-backend:
-  dic3-bpe-frontend:
+  ttp-fhir-frontend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.48/29
-  dic3-bpe-backend:
-  ttp-bpe-frontend:
+  ttp-fhir-backend:
     driver: bridge
     ipam:
       driver: default
       config:
       - subnet: 172.20.0.56/29
+  dic1-bpe-frontend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.64/29
+  dic1-bpe-backend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.72/29
+  dic2-bpe-frontend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.80/29
+  dic2-bpe-backend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.88/29
+  dic3-bpe-frontend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.96/29
+  dic3-bpe-backend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.104/29
+  ttp-bpe-frontend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.112/29
   ttp-bpe-backend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.120/29
   internet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.128/28
   forward-proxy:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.20.0.144/29
 
 volumes:
   postgresql:

--- a/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/dic1.conf
+++ b/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/dic1.conf
@@ -38,7 +38,7 @@ server {
 	location /bpe {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.35:8080/bpe;
+		proxy_pass http://172.20.0.67:8080/bpe;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;

--- a/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/dic2.conf
+++ b/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/dic2.conf
@@ -22,7 +22,7 @@ server {
 	location /fhir {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.11:8080/fhir;
+		proxy_pass http://172.20.0.19:8080/fhir;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;
@@ -38,7 +38,7 @@ server {
 	location /bpe {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.43:8080/bpe;
+		proxy_pass http://172.20.0.83:8080/bpe;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;

--- a/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/dic3.conf
+++ b/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/dic3.conf
@@ -22,7 +22,7 @@ server {
 	location /fhir {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.19:8080/fhir;
+		proxy_pass http://172.20.0.35:8080/fhir;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;
@@ -38,7 +38,7 @@ server {
 	location /bpe {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.51:8080/bpe;
+		proxy_pass http://172.20.0.99:8080/bpe;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;

--- a/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/ttp.conf
+++ b/dsf-docker-dev-setup-3dic-ttp/proxy/conf.d/ttp.conf
@@ -22,7 +22,7 @@ server {
 	location /fhir {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.27:8080/fhir;
+		proxy_pass http://172.20.0.51:8080/fhir;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;
@@ -38,7 +38,7 @@ server {
 	location /bpe {
 		proxy_set_header X-ClientCert $ssl_client_escaped_cert;
 
-		proxy_pass http://172.20.0.59:8080/bpe;
+		proxy_pass http://172.20.0.115:8080/bpe;
 
 		proxy_http_version 1.1;
 		proxy_set_header Host $http_host;

--- a/dsf-docker-dev-setup-3dic-ttp/proxy/nginx.conf
+++ b/dsf-docker-dev-setup-3dic-ttp/proxy/nginx.conf
@@ -28,9 +28,7 @@ http {
 
 	ssl_certificate /run/secrets/localhost.chain.crt;
 	ssl_certificate_key /run/secrets/localhost.key.plain;
-	ssl_protocols TLSv1.2 TLSv1.3;
-	ssl_ciphers TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
-	ssl_prefer_server_ciphers on;
+	ssl_protocols TLSv1.3;
 	add_header Strict-Transport-Security "max-age=63072000" always;
 
 	ssl_client_certificate /run/secrets/issuing_ca.crt;

--- a/dsf-docker/bpe_proxy/Dockerfile
+++ b/dsf-docker/bpe_proxy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM httpd:2.4-alpine@sha256:968c8b4098fcecb473762b45f6c541a3b2b2cfab2caccb1edbd2cece071ef160
+FROM httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-docker/bpe_proxy/Dockerfile
+++ b/dsf-docker/bpe_proxy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM docker.io/library/httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
+FROM docker.io/library/httpd:2.4-alpine@sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-docker/bpe_proxy/Dockerfile
+++ b/dsf-docker/bpe_proxy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
+FROM docker.io/library/httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF BPE Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-docker/fhir_proxy/Dockerfile
+++ b/dsf-docker/fhir_proxy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM httpd:2.4-alpine@sha256:968c8b4098fcecb473762b45f6c541a3b2b2cfab2caccb1edbd2cece071ef160
+FROM httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-docker/fhir_proxy/Dockerfile
+++ b/dsf-docker/fhir_proxy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
+FROM docker.io/library/httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-docker/fhir_proxy/Dockerfile
+++ b/dsf-docker/fhir_proxy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM docker.io/library/httpd:2.4-alpine@sha256:0136c2d4462f3b8ecc92bea70efdfef4d06523999ae8d7aa533969dea6db4576
+FROM docker.io/library/httpd:2.4-alpine@sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Reverse Proxy"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
+++ b/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
@@ -37,6 +37,16 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>

--- a/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
+++ b/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
@@ -51,6 +51,7 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>${jakarta.ws.rs.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
+FROM docker.io/library/debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
 WORKDIR /opt/fhir
 COPY --chown=root:2101 ./ ./
 RUN chown root:2101 ./ && \
@@ -23,7 +23,7 @@ RUN chown root:2101 ./ && \
     chmod 1775 ./log
 
 
-FROM azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
+FROM docker.io/azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM docker.io/library/debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
+FROM docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS builder
 WORKDIR /opt/fhir
 COPY --chown=root:2101 ./ ./
 RUN chown root:2101 ./ && \
@@ -23,7 +23,7 @@ RUN chown root:2101 ./ && \
     chmod 1775 ./log
 
 
-FROM docker.io/azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
+FROM docker.io/azul/zulu-openjdk:25-jre-headless@sha256:1fa90a584251b66adc28152e25cc496ea63dd787999c86a04c0e2033fa98d39a
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS builder
+FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS builder
 WORKDIR /opt/fhir
 COPY --chown=root:2101 ./ ./
 RUN chown root:2101 ./ && \
@@ -23,7 +23,7 @@ RUN chown root:2101 ./ && \
     chmod 1775 ./log
 
 
-FROM azul/zulu-openjdk:25-jre-headless@sha256:0f843579efd505efb0a0eef1d5a816cc4523ffcad458a54a4e9e52e60c4c030a
+FROM azul/zulu-openjdk:25-jre-headless@sha256:8cec35879adc3694e3cad2a499f9527c7c788278a923363b09b096a1b28f751c
 LABEL org.opencontainers.image.source=https://github.com/datasharingframework/dsf
 LABEL org.opencontainers.image.description="DSF FHIR Server"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -85,6 +85,7 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>${jakarta.ws.rs.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.websocket</groupId>
@@ -125,18 +126,22 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 
 		<dependency>
@@ -154,6 +159,12 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r5</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>net.sourceforge.plantuml</groupId>
+					<artifactId>plantuml-mit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
@@ -174,6 +185,14 @@
 				<exclusion>
 					<groupId>org.xerial</groupId>
 					<artifactId>sqlite-jdbc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.commonmark</groupId>
+					<artifactId>commonmark</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.commonmark</groupId>
+					<artifactId>commonmark-ext-gfm-tables</artifactId>
 				</exclusion>
 			</exclusions>
 			<version>${hapi.fhir.version}</version>

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -143,6 +143,12 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
@@ -156,6 +162,18 @@
 				<exclusion>
 					<artifactId>commons-logging</artifactId>
 					<groupId>commons-logging</groupId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.sf.saxon</groupId>
+					<artifactId>Saxon-HE</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.ogce</groupId>
+					<artifactId>xpp3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.xerial</groupId>
+					<artifactId>sqlite-jdbc</artifactId>
 				</exclusion>
 			</exclusions>
 			<version>${hapi.fhir.version}</version>

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafTemplateServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/adapter/ThymeleafTemplateServiceImpl.java
@@ -65,7 +65,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
-import net.sf.saxon.lib.FeatureKeys;
 
 public class ThymeleafTemplateServiceImpl implements ThymeleafTemplateService, InitializingBean
 {
@@ -154,7 +153,6 @@ public class ThymeleafTemplateServiceImpl implements ThymeleafTemplateService, I
 		try
 		{
 			transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			transformerFactory.setFeature(FeatureKeys.ALLOW_EXTERNAL_FUNCTIONS, false);
 		}
 		catch (TransformerConfigurationException e)
 		{

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
@@ -523,7 +523,7 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 				if (result.next())
 				{
 					if (preparedStatementFactory.getReadByIdDeleted(result) != null)
-						logger.warn("{} with IdPart {} found, but marked as deleted", resourceTypeName, uuid);
+						logger.debug("{} with IdPart {} found, but marked as deleted", resourceTypeName, uuid);
 					else
 						logger.debug("{} with IdPart {} found", resourceTypeName, uuid);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractBooleanParameter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/dev/dsf/fhir/search/parameters/basic/AbstractBooleanParameter.java
@@ -16,12 +16,11 @@
 package dev.dsf.fhir.search.parameters.basic;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.hl7.fhir.r4.model.Resource;
-
-import com.google.common.base.Objects;
 
 import dev.dsf.fhir.search.SearchQueryParameterError;
 import dev.dsf.fhir.search.SearchQueryParameterError.SearchQueryParameterErrorType;
@@ -86,6 +85,6 @@ public abstract class AbstractBooleanParameter<R extends Resource> extends Abstr
 	@Override
 	protected boolean resourceMatches(R resource)
 	{
-		return hasBoolean.test(resource) && Objects.equal(getBoolean.apply(resource), value);
+		return hasBoolean.test(resource) && Objects.equals(getBoolean.apply(resource), value);
 	}
 }

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -37,11 +37,27 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-caffeine</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
@@ -52,12 +68,34 @@
 					<artifactId>commons-logging</artifactId>
 					<groupId>commons-logging</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.sf.saxon</groupId>
+					<artifactId>Saxon-HE</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.ogce</groupId>
+					<artifactId>xpp3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.xerial</groupId>
+					<artifactId>sqlite-jdbc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-r4</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -84,6 +84,18 @@
 					<groupId>io.opentelemetry.instrumentation</groupId>
 					<artifactId>opentelemetry-instrumentation-annotations</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.sourceforge.plantuml</groupId>
+					<artifactId>plantuml-mit</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.commonmark</groupId>
+					<artifactId>commonmark</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.commonmark</groupId>
+					<artifactId>commonmark-ext-gfm-tables</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -133,7 +133,9 @@
 					<licenseSets>
 						<licenseSet>
 							<excludes>
+								<exclude>src/main/resources/fhir/**/*.ignore</exclude>
 								<exclude>src/main/resources/fhir/**/*.post</exclude>
+								<exclude>src/main/resources/fhir/**/*.put</exclude>
 								<exclude>src/main/resources/fhir/bundle.xml</exclude>
 								<exclude>src/main/resources/fhir/resources.delete</exclude>
 							</excludes>

--- a/dsf-fhir/dsf-fhir-webservice-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-webservice-client/pom.xml
@@ -46,22 +46,27 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-jaxb</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
-			<artifactId>jersey-apache-connector</artifactId>
+			<artifactId>jersey-apache5-connector</artifactId>
+			<version>${jersey.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
@@ -19,8 +19,8 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.function.Supplier;
 
-import org.apache.http.conn.ConnectTimeoutException;
-import org.apache.http.conn.HttpHostConnectException;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.client5.http.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractJerseyClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/dev/dsf/fhir/client/AbstractJerseyClient.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import javax.net.ssl.SSLContext;
 
 import org.glassfish.jersey.SslConfigurator;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
@@ -77,7 +77,7 @@ public class AbstractJerseyClient
 			builder = builder.sslContext(sslContext);
 
 		ClientConfig config = new ClientConfig();
-		config.connectorProvider(new ApacheConnectorProvider());
+		config.connectorProvider(new Apache5ConnectorProvider());
 		config.property(ClientProperties.PROXY_URI, proxySchemeHostPort);
 		config.property(ClientProperties.PROXY_USERNAME, proxyUserName);
 		config.property(ClientProperties.PROXY_PASSWORD, proxyPassword == null ? null : String.valueOf(proxyPassword));

--- a/dsf-fhir/dsf-fhir-websocket-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-websocket-client/pom.xml
@@ -42,6 +42,7 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-common</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.tyrus</groupId>

--- a/dsf-maven/dsf-maven-plugin/pom.xml
+++ b/dsf-maven/dsf-maven-plugin/pom.xml
@@ -138,6 +138,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 		<slf4j.version>2.0.18</slf4j.version>
 		<log4j.version>2.26.0</log4j.version>
 		<jetty.version>12.1.10</jetty.version>
-		<jersey.version>3.1.11</jersey.version>
 		<tyrus.version>2.2.2</tyrus.version>
 		<spring.version>7.0.7</spring.version>
 		<jackson.version>2.21.4</jackson.version>
@@ -54,6 +53,15 @@
 		<crypto-utils.version.v1>3.8.0</crypto-utils.version.v1>
 		<crypto-utils.version.v2>5.2.1</crypto-utils.version.v2>
 		<crypto-utils.version>6.0.0</crypto-utils.version>
+		<jersey.version.v1>3.1.11</jersey.version.v1>
+		<jersey.version.v2>4.0.2</jersey.version.v2>
+		<jersey.version>4.0.2</jersey.version>
+		<jakarta.ws.rs.version.v1>3.1.0</jakarta.ws.rs.version.v1>
+		<jakarta.ws.rs.version.v2>4.0.0</jakarta.ws.rs.version.v2>
+		<jakarta.ws.rs.version>4.0.0</jakarta.ws.rs.version>
+		<jakarta.annotation.api.version.v1>2.1.0</jakarta.annotation.api.version.v1>
+		<jakarta.annotation.api.version.v2>3.0.0</jakarta.annotation.api.version.v2>
+		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
 	</properties>
 
 	<name>DSF Parent POM</name>
@@ -244,47 +252,6 @@
 				<version>${jetty.version}</version>
 			</dependency>
 
-			<!-- jersey -->
-			<dependency>
-				<groupId>org.glassfish.jersey.core</groupId>
-				<artifactId>jersey-common</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.core</groupId>
-				<artifactId>jersey-server</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.core</groupId>
-				<artifactId>jersey-client</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.containers</groupId>
-				<artifactId>jersey-container-servlet</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.inject</groupId>
-				<artifactId>jersey-hk2</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.connectors</groupId>
-				<artifactId>jersey-apache-connector</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.media</groupId>
-				<artifactId>jersey-media-jaxb</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.media</groupId>
-				<artifactId>jersey-media-json-jackson</artifactId>
-				<version>${jersey.version}</version>
-			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
@@ -373,16 +340,6 @@
 			</dependency>
 
 			<!-- Jakarta APIs -->
-			<dependency>
-				<groupId>jakarta.ws.rs</groupId>
-				<artifactId>jakarta.ws.rs-api</artifactId>
-				<version>4.0.0</version>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.annotation</groupId>
-				<artifactId>jakarta.annotation-api</artifactId>
-				<version>3.0.0</version>
-			</dependency>
 			<dependency>
 				<groupId>jakarta.servlet</groupId>
 				<artifactId>jakarta.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1095,6 +1095,7 @@
 						<list>SCRIPT_STYLE</list>
 						<conf>SCRIPT_STYLE</conf>
 						<env>SCRIPT_STYLE</env>
+						<trivyignore>SCRIPT_STYLE</trivyignore>
 					</mapping>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,10 @@
 		<log4j.version>2.26.0</log4j.version>
 		<jetty.version>12.1.10</jetty.version>
 		<tyrus.version>2.2.2</tyrus.version>
-		<spring.version>7.0.7</spring.version>
+		<spring.version>7.0.8</spring.version>
+		<!-- operaton 2.1.2 not compatible with jackson 2.22.0 -->
 		<jackson.version>2.21.4</jackson.version>
-		<operaton.version>2.1.1</operaton.version>
+		<operaton.version>2.1.2</operaton.version>
 		<hapi.fhir.version.v1>5.1.0</hapi.fhir.version.v1>
 		<hapi.fhir.version.v2>8.4.2</hapi.fhir.version.v2>
 		<hapi.fhir.org.hl7.version.v2>6.5.27</hapi.fhir.org.hl7.version.v2>
@@ -53,7 +54,7 @@
 		<crypto-utils.version.v1>3.8.0</crypto-utils.version.v1>
 		<crypto-utils.version.v2>5.2.1</crypto-utils.version.v2>
 		<crypto-utils.version>6.1.0</crypto-utils.version>
-		<jersey.version.v1>3.1.11</jersey.version.v1>
+		<jersey.version.v1>3.1.12</jersey.version.v1>
 		<jersey.version.v2>4.0.2</jersey.version.v2>
 		<jersey.version>4.0.2</jersey.version>
 		<jakarta.ws.rs.version.v1>3.1.0</jakarta.ws.rs.version.v1>
@@ -589,7 +590,7 @@
 				<plugin>
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
-					<version>4.9.8.3</version>
+					<version>4.10.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -604,7 +605,7 @@
 				<plugin>
 					<groupId>org.sonatype.central</groupId>
 					<artifactId>central-publishing-maven-plugin</artifactId>
-					<version>0.10.0</version>
+					<version>0.11.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<bouncycastle.version>1.84</bouncycastle.version>
 		<crypto-utils.version.v1>3.8.0</crypto-utils.version.v1>
 		<crypto-utils.version.v2>5.2.1</crypto-utils.version.v2>
-		<crypto-utils.version>5.2.1</crypto-utils.version>
+		<crypto-utils.version>6.0.0</crypto-utils.version>
 	</properties>
 
 	<name>DSF Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
 
 		<main.basedir>${project.basedir}</main.basedir>
 
-		<slf4j.version>2.0.17</slf4j.version>
-		<log4j.version>2.25.4</log4j.version>
-		<jetty.version>12.1.8</jetty.version>
+		<slf4j.version>2.0.18</slf4j.version>
+		<log4j.version>2.26.0</log4j.version>
+		<jetty.version>12.1.10</jetty.version>
 		<jersey.version>3.1.11</jersey.version>
 		<tyrus.version>2.2.2</tyrus.version>
-		<spring.version>6.2.18</spring.version>
-		<jackson.version>2.21.2</jackson.version>
-		<operaton.version>1.1.1</operaton.version>
+		<spring.version>7.0.7</spring.version>
+		<jackson.version>2.21.4</jackson.version>
+		<operaton.version>2.1.1</operaton.version>
 		<hapi.fhir.version.v1>5.1.0</hapi.fhir.version.v1>
 		<hapi.fhir.version.v2>8.4.2</hapi.fhir.version.v2>
 		<hapi.fhir.org.hl7.version.v2>6.5.27</hapi.fhir.org.hl7.version.v2>
@@ -183,7 +183,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.7.10</version>
+				<version>42.7.11</version>
 			</dependency>
 			<dependency>
 				<groupId>org.checkerframework</groupId>
@@ -193,7 +193,7 @@
 			<dependency>
 				<groupId>com.github.ben-manes.caffeine</groupId>
 				<artifactId>caffeine</artifactId>
-				<version>3.2.3</version>
+				<version>3.2.4</version>
 			</dependency>
 
 			<dependency>
@@ -205,7 +205,7 @@
 			<dependency>
 				<groupId>com.auth0</groupId>
 				<artifactId>java-jwt</artifactId>
-				<version>4.5.1</version>
+				<version>4.5.2</version>
 			</dependency>
 
 			<dependency>
@@ -293,8 +293,6 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<!-- TODO change back to ${jackson.version} when
-				jackson-annotations has same version as other jackson libs -->
 				<version>2.21</version>
 			</dependency>
 			<dependency>
@@ -334,7 +332,7 @@
 			<dependency>
 				<groupId>org.glassfish.jaxb</groupId>
 				<artifactId>jaxb-runtime</artifactId>
-				<version>4.0.7</version>
+				<version>4.0.9</version>
 			</dependency>
 
 			<!-- spring -->
@@ -448,17 +446,17 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.13.2</version>
+				<version>2.14.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.thymeleaf</groupId>
 				<artifactId>thymeleaf</artifactId>
-				<version>3.1.4.RELEASE</version>
+				<version>3.1.5.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
-				<version>10.9</version>
+				<version>10.9.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.fhir</groupId>
@@ -469,12 +467,12 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.21.0</version>
+				<version>2.22.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.21.0</version>
+				<version>1.22.0</version>
 			</dependency>
 
 			<dependency>
@@ -508,25 +506,25 @@
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm</artifactId>
-				<version>9.9.1</version>
+				<version>9.10.1</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.tika</groupId>
 				<artifactId>tika-core</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 			</dependency>
 
 			<!-- maven plugin -->
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-core</artifactId>
-				<version>3.9.15</version>
+				<version>3.9.16</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
-				<version>3.9.15</version>
+				<version>3.9.16</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
@@ -574,12 +572,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.5.5</version>
+					<version>3.5.6</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>3.5.5</version>
+					<version>3.5.6</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -609,7 +607,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.10.0</version>
+					<version>3.11.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -624,12 +622,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.6.2</version>
+					<version>3.6.3</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
-					<version>3.21.0</version>
+					<version>3.22.0</version>
 				</plugin>
 				<plugin>
 					<groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Notable dependency upgrades:
- Spring 6.2.18 -> 7.0.8
- Operaton 1.1.1 -> 2.1.2
- Jersey 3.1.11 -> 4.0.2 (FHIR, BPE and API v2)
- Jersey 3.1.11 -> 3.1.12 (API v1)

We upgraded Jetty and EE APIs to EE 11 via the DSF 2 release, but wrongfully kept the implementation at EE 10 levels. This change fixes that. The FHIR and BPE applications as well as API v2 process plugins now use EE 11 APIs and implementations. API v1 process plugins are correctly back to EE 10 and use EE 10 implementations.

closes #480 