### PR TITLE
Issue/520 improve dsf maven plugin

### DIFF
--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/CertificateGenerator.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/CertificateGenerator.java
@@ -247,7 +247,13 @@ public class CertificateGenerator extends AbstractGenerator
 		Optional<PrivateKey> key = readPrivateKey(commonName);
 		if (key.isEmpty())
 		{
-			logger.debug("Private-Key for '{}' not found", commonName);
+			logger.debug("Private-key for '{}' not found", commonName);
+			return Optional.empty();
+		}
+
+		if (key.isPresent() && !KeyPairValidator.isSecp384r1(key.get()))
+		{
+			logger.debug("Private-key type for '{}' not Secp384r1", commonName);
 			return Optional.empty();
 		}
 

--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/CleanDevSetupCertFilesMojo.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/CleanDevSetupCertFilesMojo.java
@@ -15,130 +15,23 @@
  */
 package dev.dsf.maven.dev;
 
-import java.io.File;
-import java.util.List;
-
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import dev.dsf.maven.exception.RuntimeIOException;
-
 /**
- * Cleans up certificate files for a local DSF development setup.
- * <p>
- * This goal deletes all generated certificate files (client, server, CA chain) from the configured target directories.
- * <p>
- * Use <code>-Ddsf.includeCertDir=true</code> and/or <code>-Ddsf.includeKeyDir=true</code> to also delete the plugin
- * cache files.
+ * Deprecated use goal <code>clean-dev-setup-files</code>
  */
 @Mojo(name = "clean-dev-setup-cert-files", defaultPhase = LifecyclePhase.CLEAN, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true, aggregator = true)
-public class CleanDevSetupCertFilesMojo extends AbstractMojo
+public class CleanDevSetupCertFilesMojo extends CleanDevSetupFilesMojo
 {
-	/**
-	 * The base directory of the project.
-	 */
-	@Parameter(defaultValue = "${project.basedir}", readonly = true, required = true)
-	private File projectBasedir;
-
-	/**
-	 * The directory to write the generated certificate files to.
-	 */
-	@Parameter(required = true, property = "dsf.certDir", defaultValue = "cert")
-	private File certDir;
-
-	/**
-	 * The directory to write the generated key files to.
-	 */
-	@Parameter(required = true, property = "dsf.keyDir", defaultValue = "key")
-	private File keyDir;
-
-	/**
-	 * The certificates to generate. See <a href="index.html">usage</a> for details.
-	 */
-	@Parameter
-	private List<Cert> certs;
-
-	/**
-	 * The key-pairs to generate. See <a href="index.html">usage</a> for details.
-	 */
-	@Parameter
-	private List<Key> keys;
-
-	/**
-	 * The root CA configuration.
-	 */
-	@Parameter
-	private RootCa rootCa;
-
-	/**
-	 * The issuing CA configuration.
-	 */
-	@Parameter
-	private IssuingCa issuingCa;
-
-	/**
-	 * The CA chain configuration.
-	 */
-	@Parameter
-	private CaChain caChain;
-
-	/**
-	 * The templates to apply. See <a href="index.html">usage</a> for details.
-	 */
-	@Parameter
-	private List<Template> templates;
-
-	/**
-	 * Whether to delete the cert directory with its contents as well.
-	 */
-	@Parameter(required = true, property = "dsf.includeCertDir", defaultValue = "false")
-	private boolean includeCertDir;
-
-	/**
-	 * Whether to delete the key directory with its contents as well.
-	 */
-	@Parameter(required = true, property = "dsf.includeKeyDir", defaultValue = "false")
-	private boolean includeKeyDir;
-
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException
 	{
-		getLog().debug("projectBasedir: " + projectBasedir);
-		getLog().debug("certDir: " + certDir);
-		getLog().debug("keyDir: " + keyDir);
-		getLog().debug("certs: " + certs);
-		getLog().debug("keys: " + keys);
-		getLog().debug("rootCa: " + rootCa);
-		getLog().debug("issuingCa: " + issuingCa);
-		getLog().debug("caChain: " + caChain);
-		getLog().debug("templates: " + templates);
-		getLog().debug("includeCertDir: " + includeCertDir);
-		getLog().debug("includeKeyDir: " + includeKeyDir);
+		getLog().warn("The goal 'clean-dev-setup-cert-files' is deprecated, use 'clean-dev-setup-files'");
 
-		FileRemover fileRemover = new FileRemover(projectBasedir.toPath(), certDir.toPath(), keyDir.toPath());
-
-		try
-		{
-			fileRemover.deleteCerts(certs);
-			fileRemover.delete(rootCa);
-			fileRemover.delete(issuingCa);
-			fileRemover.delete(caChain);
-			fileRemover.deleteTemplates(templates);
-			fileRemover.deleteKeys(keys);
-
-			if (includeCertDir)
-				fileRemover.deleteFilesInCertDir(certs);
-			if (includeKeyDir)
-				fileRemover.deleteFilesInKeyDir(keys);
-		}
-		catch (RuntimeIOException e)
-		{
-			throw new MojoFailureException(e);
-		}
+		super.execute();
 	}
 }

--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/CleanDevSetupFilesMojo.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/CleanDevSetupFilesMojo.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018-2025 Heilbronn University of Applied Sciences
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.dsf.maven.dev;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import dev.dsf.maven.exception.RuntimeIOException;
+
+/**
+ * Cleans up certificate files for a local DSF development setup.
+ * <p>
+ * This goal deletes all generated certificate files (client, server, CA chain) from the configured target directories.
+ * <p>
+ * Use <code>-Ddsf.includeCertDir=true</code> and/or <code>-Ddsf.includeKeyDir=true</code> to also delete the plugin
+ * cache files.
+ */
+@Mojo(name = "clean-dev-setup-files", defaultPhase = LifecyclePhase.CLEAN, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true, aggregator = true)
+public class CleanDevSetupFilesMojo extends AbstractMojo
+{
+	/**
+	 * The base directory of the project.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", readonly = true, required = true)
+	private File projectBasedir;
+
+	/**
+	 * The directory to write the generated certificate files to.
+	 */
+	@Parameter(required = true, property = "dsf.certDir", defaultValue = "cert")
+	private File certDir;
+
+	/**
+	 * The directory to write the generated key files to.
+	 */
+	@Parameter(required = true, property = "dsf.keyDir", defaultValue = "key")
+	private File keyDir;
+
+	/**
+	 * The certificates to generate. See <a href="index.html">usage</a> for details.
+	 */
+	@Parameter
+	private List<Cert> certs;
+
+	/**
+	 * The key-pairs to generate. See <a href="index.html">usage</a> for details.
+	 */
+	@Parameter
+	private List<Key> keys;
+
+	/**
+	 * The root CA configuration.
+	 */
+	@Parameter
+	private RootCa rootCa;
+
+	/**
+	 * The issuing CA configuration.
+	 */
+	@Parameter
+	private IssuingCa issuingCa;
+
+	/**
+	 * The CA chain configuration.
+	 */
+	@Parameter
+	private CaChain caChain;
+
+	/**
+	 * The templates to apply. See <a href="index.html">usage</a> for details.
+	 */
+	@Parameter
+	private List<Template> templates;
+
+	/**
+	 * Whether to delete the cert directory with its contents as well.
+	 */
+	@Parameter(required = true, property = "dsf.includeCertDir", defaultValue = "false")
+	private boolean includeCertDir;
+
+	/**
+	 * Whether to delete the key directory with its contents as well.
+	 */
+	@Parameter(required = true, property = "dsf.includeKeyDir", defaultValue = "false")
+	private boolean includeKeyDir;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException
+	{
+		getLog().debug("projectBasedir: " + projectBasedir);
+		getLog().debug("certDir: " + certDir);
+		getLog().debug("keyDir: " + keyDir);
+		getLog().debug("certs: " + certs);
+		getLog().debug("keys: " + keys);
+		getLog().debug("rootCa: " + rootCa);
+		getLog().debug("issuingCa: " + issuingCa);
+		getLog().debug("caChain: " + caChain);
+		getLog().debug("templates: " + templates);
+		getLog().debug("includeCertDir: " + includeCertDir);
+		getLog().debug("includeKeyDir: " + includeKeyDir);
+
+		FileRemover fileRemover = new FileRemover(projectBasedir.toPath(), certDir.toPath(), keyDir.toPath());
+
+		try
+		{
+			fileRemover.deleteCerts(certs);
+			fileRemover.delete(rootCa);
+			fileRemover.delete(issuingCa);
+			fileRemover.delete(caChain);
+			fileRemover.deleteTemplates(templates);
+			fileRemover.deleteKeys(keys);
+
+			if (includeCertDir)
+				fileRemover.deleteFilesInCertDir(certs);
+			if (includeKeyDir)
+				fileRemover.deleteFilesInKeyDir(keys);
+		}
+		catch (RuntimeIOException e)
+		{
+			throw new MojoFailureException(e);
+		}
+	}
+}

--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/GenerateDevSetupCertFilesMojo.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/GenerateDevSetupCertFilesMojo.java
@@ -15,161 +15,23 @@
  */
 package dev.dsf.maven.dev;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.List;
-
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import dev.dsf.maven.exception.RuntimeIOException;
-
 /**
- * Generates certificates and other files for a local DSF development setup.
- * <p>
- * This goal creates all required certificate files (client, server, CA chain) and copies them to the configured target
- * directories.
- * <p>
- * Arbitrary files can be used as templates to fill in certificate thumbprints, private / public key pairs can be
- * generated.
+ * Deprecated use goal <code>generate-dev-setup-files</code>
  */
 @Mojo(name = "generate-dev-setup-cert-files", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true, aggregator = true)
-public class GenerateDevSetupCertFilesMojo extends AbstractMojo
+public class GenerateDevSetupCertFilesMojo extends GenerateDevSetupFilesMojo
 {
-	/**
-	 * The base directory of the project.
-	 */
-	@Parameter(defaultValue = "${project.basedir}", readonly = true, required = true)
-	private File projectBasedir;
-
-	/**
-	 * The text encoding.
-	 */
-	@Parameter(defaultValue = "${project.build.sourceEncoding}", readonly = true, required = true)
-	private String encoding;
-
-	/**
-	 * The directory to write the generated certificate files to.
-	 */
-	@Parameter(required = true, property = "dsf.certDir", defaultValue = "cert")
-	private File certDir;
-
-	/**
-	 * The directory to write the generated key files to.
-	 */
-	@Parameter(required = true, property = "dsf.keyDir", defaultValue = "key")
-	private File keyDir;
-
-	/**
-	 * The password to protect the private keys.
-	 */
-	@Parameter(required = true, property = "dsf.privateKeyPassword", defaultValue = "password")
-	private String privateKeyPassword;
-
-	/**
-	 * The certificates to generate. See <a href="index.html">usage</a> for details.
-	 */
-	@Parameter
-	private List<Cert> certs;
-
-	/**
-	 * The key-pairs to generate. See <a href="index.html">usage</a> for details.
-	 */
-	@Parameter
-	private List<Key> keys;
-
-	/**
-	 * The root CA configuration.
-	 */
-	@Parameter
-	private RootCa rootCa;
-
-	/**
-	 * The issuing CA configuration.
-	 */
-	@Parameter
-	private IssuingCa issuingCa;
-
-	/**
-	 * The CA chain configuration.
-	 */
-	@Parameter
-	private CaChain caChain;
-
-	/**
-	 * The templates to apply. See <a href="index.html">usage</a> for details.
-	 */
-	@Parameter
-	private List<Template> templates;
-
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException
 	{
-		getLog().debug("projectBasedir: " + projectBasedir);
-		getLog().debug("encoding: " + encoding);
-		getLog().debug("certDir: " + certDir);
-		getLog().debug("keyDir: " + keyDir);
-		getLog().debug("privateKeyPassword: "
-				+ (privateKeyPassword == null ? null : !privateKeyPassword.isEmpty() ? "***" : ""));
-		getLog().debug("certs: " + certs);
-		getLog().debug("keys: " + keys);
-		getLog().debug("rootCa: " + rootCa);
-		getLog().debug("issuingCa: " + issuingCa);
-		getLog().debug("caChain: " + caChain);
-		getLog().debug("templates: " + templates);
+		getLog().warn("The goal 'generate-dev-setup-cert-files' is deprecated, use 'generate-dev-setup-files'");
 
-		if (privateKeyPassword == null)
-			throw new MojoExecutionException("privateKeyPassword null");
-
-		try
-		{
-			Files.createDirectories(certDir.toPath());
-		}
-		catch (IOException e)
-		{
-			throw new MojoFailureException(e);
-		}
-
-		CertificateGenerator certificateGenerator = new CertificateGenerator(certDir.toPath(),
-				privateKeyPassword.toCharArray(), certs.stream().map(Cert::toCertificationRequestConfig).toList());
-		CertificateWriter certificateWriter = new CertificateWriter(projectBasedir.toPath(),
-				privateKeyPassword.toCharArray(), certificateGenerator);
-		TemplateHandler templateHandler = new TemplateHandler(projectBasedir.toPath(), certificateGenerator, encoding);
-
-		certificateGenerator.initialize();
-
-		try
-		{
-			certificateWriter.write(certs);
-			certificateWriter.write(rootCa);
-			certificateWriter.write(issuingCa);
-			certificateWriter.write(caChain);
-
-			templateHandler.applyTemplates(templates);
-		}
-		catch (RuntimeIOException e)
-		{
-			throw new MojoFailureException(e);
-		}
-
-		KeyGenerator keyGenerator = new KeyGenerator(keyDir.toPath(), privateKeyPassword.toCharArray(), keys);
-		keyGenerator.initialize();
-
-		KeyWriter keyWriter = new KeyWriter(projectBasedir.toPath(), privateKeyPassword.toCharArray(), keyGenerator);
-
-		try
-		{
-			keyWriter.write(keys);
-		}
-		catch (RuntimeIOException e)
-		{
-			throw new MojoFailureException(e);
-		}
+		super.execute();
 	}
 }

--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/GenerateDevSetupFilesMojo.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/GenerateDevSetupFilesMojo.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018-2025 Heilbronn University of Applied Sciences
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.dsf.maven.dev;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import dev.dsf.maven.exception.RuntimeIOException;
+
+/**
+ * Generates certificates and other files for a local DSF development setup.
+ * <p>
+ * This goal creates all required certificate files (client, server, CA chain) and copies them to the configured target
+ * directories.
+ * <p>
+ * Arbitrary files can be used as templates to fill in certificate thumbprints.
+ * <p>
+ * Private / public key pairs can be generated.
+ */
+@Mojo(name = "generate-dev-setup-files", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true, aggregator = true)
+public class GenerateDevSetupFilesMojo extends AbstractMojo
+{
+	/**
+	 * The base directory of the project.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", readonly = true, required = true)
+	private File projectBasedir;
+
+	/**
+	 * The text encoding.
+	 */
+	@Parameter(defaultValue = "${project.build.sourceEncoding}", readonly = true, required = true)
+	private String encoding;
+
+	/**
+	 * The directory to write the generated certificate files to.
+	 */
+	@Parameter(required = true, property = "dsf.certDir", defaultValue = "cert")
+	private File certDir;
+
+	/**
+	 * The directory to write the generated key files to.
+	 */
+	@Parameter(required = true, property = "dsf.keyDir", defaultValue = "key")
+	private File keyDir;
+
+	/**
+	 * The password to protect the private keys.
+	 */
+	@Parameter(required = true, property = "dsf.privateKeyPassword", defaultValue = "password")
+	private String privateKeyPassword;
+
+	/**
+	 * The certificates to generate. See <a href="index.html">usage</a> for details.
+	 */
+	@Parameter
+	private List<Cert> certs;
+
+	/**
+	 * The key-pairs to generate. See <a href="index.html">usage</a> for details.
+	 */
+	@Parameter
+	private List<Key> keys;
+
+	/**
+	 * The root CA configuration.
+	 */
+	@Parameter
+	private RootCa rootCa;
+
+	/**
+	 * The issuing CA configuration.
+	 */
+	@Parameter
+	private IssuingCa issuingCa;
+
+	/**
+	 * The CA chain configuration.
+	 */
+	@Parameter
+	private CaChain caChain;
+
+	/**
+	 * The templates to apply. See <a href="index.html">usage</a> for details.
+	 */
+	@Parameter
+	private List<Template> templates;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException
+	{
+		getLog().debug("projectBasedir: " + projectBasedir);
+		getLog().debug("encoding: " + encoding);
+		getLog().debug("certDir: " + certDir);
+		getLog().debug("keyDir: " + keyDir);
+		getLog().debug("privateKeyPassword: "
+				+ (privateKeyPassword == null ? null : !privateKeyPassword.isEmpty() ? "***" : ""));
+		getLog().debug("certs: " + certs);
+		getLog().debug("keys: " + keys);
+		getLog().debug("rootCa: " + rootCa);
+		getLog().debug("issuingCa: " + issuingCa);
+		getLog().debug("caChain: " + caChain);
+		getLog().debug("templates: " + templates);
+
+		if (privateKeyPassword == null)
+			throw new MojoExecutionException("privateKeyPassword null");
+
+		try
+		{
+			Files.createDirectories(certDir.toPath());
+		}
+		catch (IOException e)
+		{
+			throw new MojoFailureException(e);
+		}
+
+		CertificateGenerator certificateGenerator = new CertificateGenerator(certDir.toPath(),
+				privateKeyPassword.toCharArray(), certs.stream().map(Cert::toCertificationRequestConfig).toList());
+		CertificateWriter certificateWriter = new CertificateWriter(projectBasedir.toPath(),
+				privateKeyPassword.toCharArray(), certificateGenerator);
+		TemplateHandler templateHandler = new TemplateHandler(projectBasedir.toPath(), certificateGenerator, encoding);
+
+		certificateGenerator.initialize();
+
+		try
+		{
+			certificateWriter.write(certs);
+			certificateWriter.write(rootCa);
+			certificateWriter.write(issuingCa);
+			certificateWriter.write(caChain);
+
+			templateHandler.applyTemplates(templates);
+		}
+		catch (RuntimeIOException e)
+		{
+			throw new MojoFailureException(e);
+		}
+
+		KeyGenerator keyGenerator = new KeyGenerator(keyDir.toPath(), privateKeyPassword.toCharArray(), keys);
+		keyGenerator.initialize();
+
+		KeyWriter keyWriter = new KeyWriter(projectBasedir.toPath(), privateKeyPassword.toCharArray(), keyGenerator);
+
+		try
+		{
+			keyWriter.write(keys);
+		}
+		catch (RuntimeIOException e)
+		{
+			throw new MojoFailureException(e);
+		}
+	}
+}

--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/Key.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/Key.java
@@ -16,43 +16,49 @@
 package dev.dsf.maven.dev;
 
 import java.io.File;
+import java.security.AsymmetricKey;
 import java.util.List;
+import java.util.function.Predicate;
 
 import de.hsheilbronn.mi.utils.crypto.keypair.KeyPairGeneratorFactory;
+import de.hsheilbronn.mi.utils.crypto.keypair.KeyPairValidator;
 
 public class Key
 {
 	public static enum Type
 	{
-		RSA1024(KeyPairGeneratorFactory.rsa1024(), "RSA 1024"),
+		RSA1024(KeyPairGeneratorFactory.rsa1024(), "RSA 1024", KeyPairValidator::isRsa1024),
 
-		RSA2048(KeyPairGeneratorFactory.rsa2048(), "RSA 2048"),
+		RSA2048(KeyPairGeneratorFactory.rsa2048(), "RSA 2048", KeyPairValidator::isRsa2048),
 
-		RSA3072(KeyPairGeneratorFactory.rsa3072(), "RSA 3072"),
+		RSA3072(KeyPairGeneratorFactory.rsa3072(), "RSA 3072", KeyPairValidator::isRsa3072),
 
-		RSA4096(KeyPairGeneratorFactory.rsa4096(), "RSA 4096"),
+		RSA4096(KeyPairGeneratorFactory.rsa4096(), "RSA 4096", KeyPairValidator::isRsa4096),
 
-		SECP256R1(KeyPairGeneratorFactory.secp256r1(), "Secp256r1"),
+		SECP256R1(KeyPairGeneratorFactory.secp256r1(), "Secp256r1", KeyPairValidator::isSecp256r1),
 
-		SECP384R1(KeyPairGeneratorFactory.secp384r1(), "Secp384r1"),
+		SECP384R1(KeyPairGeneratorFactory.secp384r1(), "Secp384r1", KeyPairValidator::isSecp384r1),
 
-		SECP521R1(KeyPairGeneratorFactory.secp521r1(), "Secp521r1"),
+		SECP521R1(KeyPairGeneratorFactory.secp521r1(), "Secp521r1", KeyPairValidator::isSecp521r1),
 
-		ED25519(KeyPairGeneratorFactory.ed25519(), "ED25519"),
+		ED25519(KeyPairGeneratorFactory.ed25519(), "ED25519", KeyPairValidator::isEd25519),
 
-		ED448(KeyPairGeneratorFactory.ed448(), "ED448"),
+		ED448(KeyPairGeneratorFactory.ed448(), "ED448", KeyPairValidator::isEd448),
 
-		X25519(KeyPairGeneratorFactory.x25519(), "X25519"),
+		X25519(KeyPairGeneratorFactory.x25519(), "X25519", KeyPairValidator::isX25519),
 
-		X448(KeyPairGeneratorFactory.x448(), "X448");
+		X448(KeyPairGeneratorFactory.x448(), "X448", KeyPairValidator::isX448);
 
 		private final KeyPairGeneratorFactory keyPairGeneratorFactory;
 		private final String keyType;
+		private final Predicate<AsymmetricKey> isKeyType;
 
-		private Type(KeyPairGeneratorFactory keyPairGeneratorFactory, String keyType)
+		private Type(KeyPairGeneratorFactory keyPairGeneratorFactory, String keyType,
+				Predicate<AsymmetricKey> isKeyType)
 		{
 			this.keyPairGeneratorFactory = keyPairGeneratorFactory;
 			this.keyType = keyType;
+			this.isKeyType = isKeyType;
 		}
 
 		public KeyPairGeneratorFactory getKeyPairGeneratorFactory()
@@ -63,6 +69,11 @@ public class Key
 		public String getKeyType()
 		{
 			return keyType;
+		}
+
+		public boolean isKeyType(AsymmetricKey key)
+		{
+			return isKeyType.test(key);
 		}
 	}
 

--- a/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/KeyGenerator.java
+++ b/dsf-maven/dsf-maven-plugin/src/main/java/dev/dsf/maven/dev/KeyGenerator.java
@@ -54,7 +54,8 @@ public class KeyGenerator extends AbstractGenerator
 
 	public void initialize()
 	{
-		logger.info("Initializing key generator ...");
+		if (!keys.isEmpty())
+			logger.info("Initializing key generator ...");
 
 		keyPairsById = keys.stream().collect(Collectors.toMap(Key::getId, this::initKeyPair));
 	}
@@ -90,11 +91,23 @@ public class KeyGenerator extends AbstractGenerator
 			logger.debug("{} public-key for '{}' not found", key.getType().getKeyType(), key.getId());
 			return Optional.empty();
 		}
+		else if (!key.getType().isKeyType(publicKey.get()))
+		{
+			logger.debug("{} public-key type for '{}' not {}", key.getType().getKeyType(), key.getId(),
+					key.getType().getKeyType());
+			return Optional.empty();
+		}
 
 		Optional<PrivateKey> privateKey = readPrivateKey(key.getId());
 		if (privateKey.isEmpty())
 		{
 			logger.debug("{} private-key for '{}' not found", key.getType().getKeyType(), key.getId());
+			return Optional.empty();
+		}
+		else if (!key.getType().isKeyType(privateKey.get()))
+		{
+			logger.debug("{} private-key type for '{}' not {}", key.getType().getKeyType(), key.getId(),
+					key.getType().getKeyType());
 			return Optional.empty();
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<bouncycastle.version>1.84</bouncycastle.version>
 		<crypto-utils.version.v1>3.8.0</crypto-utils.version.v1>
 		<crypto-utils.version.v2>5.2.1</crypto-utils.version.v2>
-		<crypto-utils.version>6.1.0</crypto-utils.version>
+		<crypto-utils.version>6.2.0</crypto-utils.version>
 	</properties>
 
 	<name>DSF Parent POM</name>
@@ -673,9 +673,6 @@
 					<executions>
 						<execution>
 							<id>default-cli</id>
-							<goals>
-								<goal>generate-dev-setup-cert-files</goal>
-							</goals>
 							<configuration>
 								<certs>
 									<cert>


### PR DESCRIPTION
- Old goals `generate-dev-setup-cert-files` and `clean-dev-setup-cert-files` now deprecated. Goals do still work but will produce a warning log message.
- New goals `generate-dev-setup-files` and `clean-dev-setup-files`
- Added checks to validate private- and public-key types.
- crypto-utils upgrade to 6.2.0.

closes #520