### PR TITLE
URL-encode OIDC client id and client secret for Basic authentication to comply to OAuth2.0 spec

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/oidc/OidcClientJersey.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/oidc/OidcClientJersey.java
@@ -152,10 +152,11 @@ public class OidcClientJersey extends BaseOidcClientJersey
 
 		Response response = client.target(tokenEndpoint).request(MediaType.APPLICATION_JSON_TYPE)
 				.header(HttpHeaders.AUTHORIZATION,
-						"Basic " + Base64.getEncoder().encodeToString(new StringBuilder()
-								.append(URLEncoder.encode(clientId, StandardCharsets.US_ASCII)).append(':')
-								.append(URLEncoder.encode(String.valueOf(clientSecret), StandardCharsets.US_ASCII))
-								.toString().getBytes(StandardCharsets.US_ASCII)))
+						"Basic " + Base64.getEncoder()
+								.encodeToString(new StringBuilder()
+										.append(URLEncoder.encode(clientId, StandardCharsets.UTF_8)).append(':')
+										.append(URLEncoder.encode(String.valueOf(clientSecret), StandardCharsets.UTF_8))
+										.toString().getBytes(StandardCharsets.UTF_8)))
 				.post(Entity.form(new Form().param("grant_type", "client_credentials")));
 
 		if (response.getStatus() == Status.OK.getStatusCode())

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/oidc/OidcClientJersey.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/oidc/OidcClientJersey.java
@@ -15,6 +15,7 @@
  */
 package dev.dsf.bpe.client.oidc;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.time.Duration;
@@ -151,9 +152,10 @@ public class OidcClientJersey extends BaseOidcClientJersey
 
 		Response response = client.target(tokenEndpoint).request(MediaType.APPLICATION_JSON_TYPE)
 				.header(HttpHeaders.AUTHORIZATION,
-						"Basic " + Base64.getEncoder()
-								.encodeToString(new StringBuilder().append(clientId).append(':').append(clientSecret)
-										.toString().getBytes(StandardCharsets.US_ASCII)))
+						"Basic " + Base64.getEncoder().encodeToString(new StringBuilder()
+								.append(URLEncoder.encode(clientId, StandardCharsets.US_ASCII)).append(':')
+								.append(URLEncoder.encode(String.valueOf(clientSecret), StandardCharsets.US_ASCII))
+								.toString().getBytes(StandardCharsets.US_ASCII)))
 				.post(Entity.form(new Form().param("grant_type", "client_credentials")));
 
 		if (response.getStatus() == Status.OK.getStatusCode())

--- a/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/oidc/OidcClientJersey.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/dev/dsf/bpe/client/oidc/OidcClientJersey.java
@@ -184,7 +184,7 @@ public class OidcClientJersey extends BaseOidcClientJersey
 				throw new OidcClientException("Access token key with kid '" + keyId + "'  and use 'sig' not in JWKS");
 
 			Optional<Algorithm> algorithm = key.flatMap(JwksKey::toAlgorithm);
-			if (key.isEmpty())
+			if (algorithm.isEmpty())
 			{
 				throw new OidcClientException("Access token key with kid '" + keyId
 						+ "' has unsupported type (kty) / algorithm (alg) / key-size in JWKS");

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/client/oidc/OidcClientJerseyTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/client/oidc/OidcClientJerseyTest.java
@@ -15,22 +15,51 @@
  */
 package dev.dsf.bpe.client.oidc;
 
-import static org.junit.Assert.assertNotNull;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLEncoder;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExternalResource;
 
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+
+import de.hsheilbronn.mi.utils.crypto.context.SSLContextFactory;
 import de.hsheilbronn.mi.utils.crypto.io.PemReader;
 import de.hsheilbronn.mi.utils.crypto.keystore.KeyStoreCreator;
+import dev.dsf.bpe.api.client.oidc.OidcClientException;
+import dev.dsf.bpe.integration.X509Certificates;
+import dev.dsf.common.oidc.Jwks;
+import dev.dsf.common.oidc.OidcConfiguration;
+import jakarta.ws.rs.core.HttpHeaders;
 
-@Ignore
-// Needs keycloak service from 3dic-ttp dev setup, "Service accounts roles" needs to be activated for dic1-fhir client
 public class OidcClientJerseyTest
 {
+	@Rule
+	public final X509Certificates certificates = new X509Certificates();
+
+	@Rule
+	public final TokenEndpointServerResource tokenEndpointServerResource = new TokenEndpointServerResource();
+
+	// Needs keycloak service from 3dic-ttp dev setup, "Service accounts roles" needs to be activated for dic1-fhir
+	// client
+	@Ignore
 	@Test
 	public void getAccessToken() throws Exception
 	{
@@ -44,5 +73,97 @@ public class OidcClientJerseyTest
 
 		char[] accessToken = client.asOidcClientWithDecodedJwt().getAccessToken();
 		assertNotNull(accessToken);
+	}
+
+	@Test
+	public void basicAuthorizationClientIdAndSecretShouldBeUrlEncoded() throws Exception
+	{
+		var clientId = "client/id:+";
+		var clientSecret = "client/secret:+";
+		var expectedAuthorizationHeaderValue = "Basic ".concat(clientId.transform(id -> URLEncoder.encode(id, US_ASCII))
+				.concat(":").concat(clientSecret.transform(secret -> URLEncoder.encode(secret, US_ASCII)))
+				.transform(s -> Base64.getEncoder().encodeToString(s.getBytes(US_ASCII))));
+		var client = new OidcClientJersey("https://localhost:" + tokenEndpointServerResource.getPort(),
+				"/.well-known/openid-configuration", clientId, clientSecret.toCharArray(),
+				certificates.getFhirServerCertificate().trustStore(), null, null, null, null, null, "Test Client",
+				Duration.ofSeconds(10), Duration.ofSeconds(5), true, Duration.ofSeconds(10), null, false);
+		var config = new OidcConfiguration("https://localhost:" + tokenEndpointServerResource.getPort(),
+				"https://localhost:" + tokenEndpointServerResource.getPort() + "/token", "https://localhost/jwks",
+				Set.of("client_credentials"));
+
+		// token is intentionally invalid as it is not the focus of this test
+		// and to simplify test code
+		assertThrows(OidcClientException.class, () -> client.getAccessTokenDecoded(config, new Jwks(List.of())));
+
+		assertEquals(expectedAuthorizationHeaderValue, tokenEndpointServerResource.getAuthorizationHeaderValue());
+	}
+
+	private class TokenEndpointServerResource extends ExternalResource
+	{
+		private HttpsServer server;
+		private String authorizationHeaderValue;
+
+		@Override
+		protected void before() throws Throwable
+		{
+			// Server will be created lazily when getPort() is first called
+		}
+
+		@Override
+		protected void after()
+		{
+			if (server != null)
+			{
+				server.stop(0);
+			}
+		}
+
+		int getPort() throws Exception
+		{
+			if (server == null)
+			{
+				server = createServer();
+				server.start();
+			}
+			return server.getAddress().getPort();
+		}
+
+		String getAuthorizationHeaderValue()
+		{
+			return authorizationHeaderValue;
+		}
+
+		private HttpsServer createServer() throws Exception
+		{
+			var newServer = HttpsServer.create(new InetSocketAddress("localhost", 0), 0);
+			var serverCertificate = certificates.getFhirServerCertificate();
+
+			var keyStorePassword = "server-password".toCharArray();
+			KeyStore keyStore = KeyStoreCreator.jksForPrivateKeyAndCertificateChain(serverCertificate.privateKey(),
+					keyStorePassword, serverCertificate.certificate(), serverCertificate.caCertificate());
+
+			newServer.setHttpsConfigurator(
+					new HttpsConfigurator(SSLContextFactory.createSSLContext(null, keyStore, keyStorePassword, "TLS")));
+
+			newServer.createContext("/token", exchange ->
+			{
+				authorizationHeaderValue = exchange.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+				byte[] response = "{\"access_token\":\"invalid\",\"expires_in\":300}".getBytes(US_ASCII);
+				exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, "application/json");
+				exchange.sendResponseHeaders(200, response.length);
+				try (OutputStream out = exchange.getResponseBody())
+				{
+					out.write(response);
+				}
+				catch (IOException e)
+				{
+					throw new RuntimeException(e);
+				}
+				exchange.close();
+			});
+
+			return newServer;
+		}
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/client/oidc/OidcClientJerseyTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/dev/dsf/bpe/client/oidc/OidcClientJerseyTest.java
@@ -15,16 +15,13 @@
  */
 package dev.dsf.bpe.client.oidc;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.time.Duration;
@@ -79,10 +76,11 @@ public class OidcClientJerseyTest
 	public void basicAuthorizationClientIdAndSecretShouldBeUrlEncoded() throws Exception
 	{
 		var clientId = "client/id:+";
-		var clientSecret = "client/secret:+";
-		var expectedAuthorizationHeaderValue = "Basic ".concat(clientId.transform(id -> URLEncoder.encode(id, US_ASCII))
-				.concat(":").concat(clientSecret.transform(secret -> URLEncoder.encode(secret, US_ASCII)))
-				.transform(s -> Base64.getEncoder().encodeToString(s.getBytes(US_ASCII))));
+		var clientSecret = "client/s€cr€t:+";
+		var expectedAuthorizationHeaderValue = "Basic "
+				.concat(clientId.transform(id -> URLEncoder.encode(id, StandardCharsets.UTF_8)).concat(":")
+						.concat(clientSecret.transform(secret -> URLEncoder.encode(secret, StandardCharsets.UTF_8)))
+						.transform(s -> Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8))));
 		var client = new OidcClientJersey("https://localhost:" + tokenEndpointServerResource.getPort(),
 				"/.well-known/openid-configuration", clientId, clientSecret.toCharArray(),
 				certificates.getFhirServerCertificate().trustStore(), null, null, null, null, null, "Test Client",
@@ -149,7 +147,7 @@ public class OidcClientJerseyTest
 			{
 				authorizationHeaderValue = exchange.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION);
 
-				byte[] response = "{\"access_token\":\"invalid\",\"expires_in\":300}".getBytes(US_ASCII);
+				byte[] response = "{\"access_token\":\"invalid\",\"expires_in\":300}".getBytes(StandardCharsets.UTF_8);
 				exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, "application/json");
 				exchange.sendResponseHeaders(200, response.length);
 				try (OutputStream out = exchange.getResponseBody())
@@ -165,5 +163,34 @@ public class OidcClientJerseyTest
 
 			return newServer;
 		}
+	}
+
+	@Test
+	public void testEncoding() throws Exception
+	{
+		/*
+		 * RFC 6749, Appendix B - https://datatracker.ietf.org/doc/html/rfc6749#appendix-B
+		 *
+		 * [...]
+		 *
+		 * When parsing data from a payload using this media type, the names and values resulting from reversing the
+		 * name/value encoding consequently need to be treated as octet sequences, to be decoded using the UTF-8
+		 * character encoding scheme.
+		 *
+		 * For example, the value consisting of the six Unicode code points (1) U+0020 (SPACE), (2) U+0025 (PERCENT
+		 * SIGN), (3) U+0026 (AMPERSAND), (4) U+002B (PLUS SIGN), (5) U+00A3 (POUND SIGN), and (6) U+20AC (EURO SIGN)
+		 * would be encoded into the octet sequence below (using hexadecimal notation):
+		 *
+		 * 20 25 26 2B C2 A3 E2 82 AC
+		 *
+		 * and then represented in the payload as:
+		 *
+		 * +%25%26%2B%C2%A3%E2%82%AC
+		 */
+
+		String example = "\u0020\u0025\u0026\u002B\u00A3\u20AC";
+		String expected = "+%25%26%2B%C2%A3%E2%82%AC";
+
+		assertEquals(expected, URLEncoder.encode(example, StandardCharsets.UTF_8));
 	}
 }


### PR DESCRIPTION
The main change ensures that the `clientId` and `clientSecret` are properly URL-encoded before being included in the HTTP Basic Authorization header, which is required by [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) . Because client credentials can contain any printable ASCII character—including the colon (`:`) used as the Basic Auth delimiter—an unencoded `clientId` containing a colon caused OIDC server-side authorization failures due to incorrect credential splitting. URL-encoding both values safely escapes these characters and guarantees reliable server-side parsing.

Additionally, a small bug in the access token verification logic has been fixed by checking if the `algorithm` is present instead of just the `key`, providing proper error messages with unsupported key types or algorithms.

Closes #529.

### Changes
The class `OidcClientJersey` now URL-encodes `clientId` and `clientSecret` when used in Basic Authorization header.

### How Was This Patch Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual executed tests
